### PR TITLE
Use a non-zero exit code on errors in scripts

### DIFF
--- a/rq/scripts/rqinfo.py
+++ b/rq/scripts/rqinfo.py
@@ -174,3 +174,4 @@ def main():
         interval(args.interval, func, args)
     except ConnectionError as e:
         print(e)
+        sys.exit(1)

--- a/rq/scripts/rqworker.py
+++ b/rq/scripts/rqworker.py
@@ -66,3 +66,4 @@ def main():
         w.work(burst=args.burst)
     except ConnectionError as e:
         print(e)
+        sys.exit(1)


### PR DESCRIPTION
We use supervisor (http://supervisord.org) to start our worker processes and need to be able to differentiate a "clean" exit from an error, so supervisor can react accordingly. This commit makes rqworker (and rqinfo) return 1 if Redis is unreachable.
