### PR TITLE
Allow instance methods to be enqueued

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -39,3 +39,12 @@ def create_file(path):
 def create_file_after_timeout(path, timeout):
     time.sleep(timeout)
     create_file(path)
+
+
+class Calculator(object):
+    """Test instance methods."""
+    def __init__(self, denominator):
+        self.denominator = denominator
+
+    def calculate(x, y):
+        return x * y / self.denominator

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,5 +1,5 @@
 from tests import RQTestCase
-from tests.fixtures import say_hello, div_by_zero
+from tests.fixtures import Calculator, say_hello, div_by_zero
 from rq import Queue, get_failed_queue
 from rq.job import Job
 from rq.exceptions import InvalidJobOperationError
@@ -131,6 +131,19 @@ class TestQueue(RQTestCase):
 
         # ...and assert the queue count when down
         self.assertEquals(q.count, 0)
+
+    def test_dequeue_instance_method(self):
+        """Dequeueing instance method jobs from queues."""
+        q = Queue()
+        c = Calculator(2)
+        result = q.enqueue(c.calculate, 3, 4)
+
+        job = q.dequeue()
+        # The instance has been pickled and unpickled, so it is now a separate
+        # object. Test for equality using each object's __dict__ instead.
+        self.assertEquals(job.instance.__dict__, c.__dict__)
+        self.assertEquals(job.func.__name__, 'calculate')
+        self.assertEquals(job.args, (3, 4))
 
     def test_dequeue_ignores_nonexisting_jobs(self):
         """Dequeuing silently ignores non-existing jobs."""


### PR DESCRIPTION
I have made a minor modification to the `Job` class to allow instance methods to be enqueued. This works by pickling the instance itself alongside the method name and adding it to the job's `job_tuple`. This now works:

``` python
import time

class PingPong(object):
    def __init__(self, delay):
        self.delay = delay

    def ping(self):
        time.sleep(self.delay)
        return 'PONG'

obj = PingPong(5)
q.enqueue(obj.ping)
```

Naturally the instance must be picklable for this to work. Tests included.
