### PR TITLE
Worker now sends a "shutdown job" on warm shutdown

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -49,6 +49,11 @@ def signal_name(signum):
         return 'SIG_UNKNOWN'
 
 
+def stop_worker():
+    # A job that does nothing, only for triggering Worker's warm shutdown
+    pass
+
+
 class Worker(object):
     redis_worker_namespace_prefix = 'rq:worker:'
     redis_workers_keys = 'rq:workers'
@@ -104,6 +109,7 @@ class Worker(object):
         self._stopped = False
         self.log = Logger('worker')
         self.failed_queue = get_failed_queue(connection=self.connection)
+        self._shutdown_job = None
 
 
     def validate_queues(self):  # noqa
@@ -195,6 +201,8 @@ class Worker(object):
             p.hset(self.key, 'death', time.time())
             p.expire(self.key, 60)
             p.execute()
+            if self._shutdown_job:
+                self._shutdown_job.cancel()
 
     def set_state(self, new_state):
         self._state = new_state
@@ -248,6 +256,11 @@ class Worker(object):
             msg = 'Warm shut down. Press Ctrl+C again for a cold shutdown.'
             self.log.warning(msg)
             self._stopped = True
+            """Workers use Redis' blpop blocking call to listen for new jobs, so
+            we need to create an empty job that gets cleaned up on on exit to
+            trigger shutdown.
+            """
+            self._shutdown_job = self.queues[0].enqueue(stop_worker)
             self.log.debug('Stopping after current horse is finished.')
 
         signal.signal(signal.SIGINT, request_stop)


### PR DESCRIPTION
Hi @nvie,

This is a quick and dirty patch attempting to solve the warm shutdown issue as discussed on https://github.com/nvie/rq/issues/48 .

I'm not sure how write a test to verify shutdowns due to how the code is structured, but this is the output from my test:

```
    >>> w.work()
    [2012-07-25 02:49] DEBUG: worker: Registering birth of worker selwin
    [2012-07-25 02:49] INFO: worker: 
    [2012-07-25 02:49] INFO: worker: *** Listening on default...
    ^C[2012-07-25 02:49] DEBUG: worker: Got SIGINT signal.
    [2012-07-25 02:49] WARNING: worker: Warm shut down. Press Ctrl+C again for a cold shutdown.
    [2012-07-25 02:49] DEBUG: worker: Stopping after current horse is finished.
    [2012-07-25 02:49] INFO: worker: default: rq.worker.stop_worker() (f5e087b1-edcf-4827-9371-960e7a604e96)
    [2012-07-25 02:49] INFO: horse: Job OK
    [2012-07-25 02:49] INFO: worker: Stopping on request.
    [2012-07-25 02:49] DEBUG: worker: Registering death
```
