### PR TITLE
Raise a StopException when Control+C is pressed.

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -56,3 +56,7 @@ with Connection():
     @job(queue='default')
     def decorated_job(x, y):
         return x + y
+
+
+def long_running_job():
+    time.sleep(10)


### PR DESCRIPTION
I've implemented the warm shutdown as per our discussion in https://github.com/nvie/rq/pull/102 and the warm Shutdown signal is now properly caught.

However, in my testing I found out that workers will _always_ terminate right away if Control+C is pressed, instead of waiting for its horses to finish before quitting.

In tests.fixtures you will find a `long_running_job` which is just a function that blocks for 10 seconds before it returns. To test this, simply run a worker and enqueue `long_running_job`, if Control+C is pressed while the worker is still performing the job, the worker will quit.

I rolled this back to the previous commit, but still found the same behavior (worker quitting right away if Control+C is pressed when performing a job). I have always assumed that the worker needs to wait for the current job to finish before quitting. Am I missing something or is this a bug?
