### PR TITLE
Persist jobs with "None" results

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -115,7 +115,8 @@ class Queue(object):
         contain options for RQ itself.
         """
         timeout = timeout or self._default_timeout
-        job = Job.create(func, args, kwargs, connection=self.connection, result_ttl=result_ttl)
+        job = Job.create(func, args, kwargs, connection=self.connection,
+                         result_ttl=result_ttl, status=Job.STATUS.queued)
         return self.enqueue_job(job, timeout=timeout)
 
     def enqueue(self, f, *args, **kwargs):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -205,6 +205,12 @@ class TestQueue(RQTestCase):
                 None)
         self.assertEquals(q.count, 0)
 
+    def test_enqueue_sets_status(self):
+        """Enqueueing a job sets its status to "queued"."""
+        q = Queue()
+        job = q.enqueue(say_hello)
+        self.assertEqual(job.status, Job.STATUS.queued)
+
 
 class TestFailedQueue(RQTestCase):
     def test_requeue_job(self):


### PR DESCRIPTION
Job returning None as result are now persisted correctly.

Additionally, as we discussed in issue #115, job status can now be checked via `status` property which should return either "queued", "finished" or "failed".
