### PR TITLE
Fixed argument handling in rqinfo

### DIFF
--- a/rq/scripts/__init__.py
+++ b/rq/scripts/__init__.py
@@ -13,6 +13,24 @@ def add_standard_arguments(parser):
             help='The Redis database (default: 0)')
 
 
+def read_config_file(module):
+    """Reads all UPPERCASE variables defined in the given module file."""
+    settings = __import__(module, [], [], [], -1)
+    return {k: v for k, v in settings.__dict__.items() if k.upper() == k}
+
+
+def setup_default_arguments(args, settings):
+    """ Sets up args from settings or defaults """
+    if args.host is None:
+        args.host = settings.get('REDIS_HOST', 'localhost')
+    if args.port is None:
+        args.port = int(settings.get('REDIS_PORT', 6379))
+    else:
+        args.port = int(args.port)
+    if args.db is None:
+        args.db = settings.get('REDIS_DB', 0)
+
+
 def setup_redis(args):
     redis_conn = redis.Redis(host=args.host, port=args.port, db=args.db)
     use_connection(redis_conn)

--- a/rq/scripts/rqinfo.py
+++ b/rq/scripts/rqinfo.py
@@ -9,6 +9,8 @@ from rq import Queue, Worker
 from rq.utils import gettermsize, make_colorizer
 from rq.scripts import add_standard_arguments
 from rq.scripts import setup_redis
+from rq.scripts import read_config_file
+from rq.scripts import setup_default_arguments
 
 red = make_colorizer('darkred')
 green = make_colorizer('darkgreen')
@@ -161,6 +163,12 @@ def main():
 
     if args.path:
         sys.path = args.path.split(':') + sys.path
+
+    settings = {}
+    if args.config:
+        settings = read_config_file(args.config)
+
+    setup_default_arguments(args, settings)
 
     setup_redis(args)
     try:

--- a/rq/scripts/rqworker.py
+++ b/rq/scripts/rqworker.py
@@ -7,6 +7,8 @@ from rq import Queue, Worker
 from redis.exceptions import ConnectionError
 from rq.scripts import add_standard_arguments
 from rq.scripts import setup_redis
+from rq.scripts import read_config_file
+from rq.scripts import setup_default_arguments
 
 
 def format_colors(record, handler):
@@ -53,12 +55,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def read_config_file(module):
-    """Reads all UPPERCASE variables defined in the given module file."""
-    settings = __import__(module, [], [], [], -1)
-    return {k: v for k, v in settings.__dict__.items() if k.upper() == k}
-
-
 def main():
     args = parse_args()
 
@@ -69,13 +65,9 @@ def main():
     if args.config:
         settings = read_config_file(args.config)
 
-    # Default arguments
-    if args.host is None:
-        args.host = settings.get('REDIS_HOST', 'localhost')
-    if args.port is None:
-        args.port = int(settings.get('REDIS_PORT', 6379))
-    if args.db is None:
-        args.db = settings.get('REDIS_DB', 0)
+    setup_default_arguments(args, settings)
+
+    # Other default arguments
     if args.sentry_dsn is None:
         args.sentry_dsn = settings.get('SENTRY_DSN', None)
 


### PR DESCRIPTION
rqinfo was using None for the redis host and port, which was causing
exceptions when trying to connect.  It was possible to supply these on
the commandline, but port was just being passed straight through as a
string, which also caused exceptions.

This commit moves some of the argument & configuration file handling out
of rqworker and into the scripts/**init**.py file, and then calls it
from rqinfo.
