### PR TITLE
Added new job status "Running"

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -14,7 +14,7 @@ def enum(name, *sequential, **named):
     return type(name, (), values)
 
 Status = enum('Status', QUEUED='queued', FINISHED='finished', FAILED='failed',
-                        RUNNING='running')
+                        STARTED='started')
 
 
 def unpickle(pickled_string):
@@ -107,8 +107,8 @@ class Job(object):
         return self.status == Status.FAILED
 
     @property
-    def is_running(self):
-        return self.status == Status.RUNNING
+    def is_started(self):
+        return self.status == Status.STARTED
 
     @property
     def func(self):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -321,7 +321,7 @@ class Worker(object):
 
                 job, queue = result
                 # Use the public setter here, to immediately update Redis
-                job.status = Status.RUNNING
+                job.status = Status.STARTED
                 self.log.info('%s: %s (%s)' % (green(queue.name),
                     blue(job.description), job.id))
 


### PR DESCRIPTION
We have long running jobs. It's necessary for us to see, if a job is running at the moment and all we have is the job id. With the status "running", it's easy to gather the information.

Sadly, I'm not sure how to test it within the TestWorker.test_worker_sets_job_status test.
