### PR TITLE
Add a standard --url argument to all scripts.

### DIFF
--- a/rq/scripts/__init__.py
+++ b/rq/scripts/__init__.py
@@ -47,7 +47,7 @@ def setup_default_arguments(args, settings):
 
 def setup_redis(args):
     if args.url is not None:
-        redis_conn = redis.Redis.from_url(args.url, db=args.db)
+        redis_conn = redis.from_url(args.url, db=args.db)
     else:
         redis_conn = redis.Redis(host=args.host, port=args.port, db=args.db,
             password=args.password)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def get_version():
 
 
 def get_dependencies():
-    deps = ['redis >= 2.6.2', 'times']
+    deps = ['redis >= 2.4.13', 'times']
     deps += ['logbook']  # should be soft dependency?
     if sys.version_info < (2, 7) or \
             (sys.version_info >= (3, 0) and sys.version_info < (3, 1)):


### PR DESCRIPTION
redis-py now supports URL-based connection configuration.  When `--url` is specified, we use it to construct the Redis client object.  Otherwise, we use the existing argument-based construction method.

`Redis.from_url()` is new in redis-py 2.6.2, so that prerequisite has been adjusted accordingly.  If this is undesirable, we could instead use the older `redis.from_url()` method (introduced in redis-py 2.4.13), which would still require a prerequisite bump.  As a third option, we could inspect `redis.__version__` at runtime and make this feature available conditionally.

See: https://github.com/andymccurdy/redis-py/blob/master/CHANGES
