### PR TITLE
fixes the `enqueue_call` example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ counterpart.  A typical use case for this is to pass in a `timeout` argument:
 {% highlight python %}
 q = Queue('low', connection=redis_conn)
 q.enqueue_call(func=count_words_at_url,
-               args=('http://nvie.com'),
+               args=('http://nvie.com',),
                timeout=30)
 {% endhighlight %}
 


### PR DESCRIPTION
The `args` param of `enqueue_call` requires a tuple.
It's documented correctly in the "results" section but missing a comma here.
