### PR TITLE
job: save the real exception when unpickling fails

### DIFF
--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -11,6 +11,6 @@ class NoQueueError(Exception):
 
 
 class UnpickleError(Exception):
-    def __init__(self, message, raw_data):
-        super(UnpickleError, self).__init__(message)
+    def __init__(self, message, raw_data, inner_exception):
+        super(UnpickleError, self).__init__(message, inner_exception)
         self.raw_data = raw_data

--- a/rq/job.py
+++ b/rq/job.py
@@ -27,8 +27,8 @@ def unpickle(pickled_string):
     """
     try:
         obj = loads(pickled_string)
-    except (StandardError, UnpicklingError):
-        raise UnpickleError('Could not unpickle.', pickled_string)
+    except (StandardError, UnpicklingError), e:
+        raise UnpickleError('Could not unpickle.', pickled_string, e)
     return obj
 
 


### PR DESCRIPTION
We raise our own exception which hides the real error (often an ImportError),
making it difficult to see what happend. Instead, save the original exception
too.
