### PR TITLE
Safe fetching a deleted job removes the deleted job from queue.

### DIFF
--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -50,6 +50,32 @@ class TestQueue(RQTestCase):
         self.testconn.rpush('rq:queue:example', 'sentinel message')
         self.assertEquals(q.is_empty(), False)
 
+    def test_remove(self):
+        """Ensure queue.remove properly removes Job from queue."""
+        q = Queue('example')
+        job = q.enqueue(say_hello)
+        self.assertIn(job.id, q.job_ids)
+        q.remove(job)
+        self.assertNotIn(job.id, q.job_ids)
+
+        job = q.enqueue(say_hello)
+        self.assertIn(job.id, q.job_ids)
+        q.remove(job.id)
+        self.assertNotIn(job.id, q.job_ids)
+
+    def test_jobs(self):
+        """Getting jobs out of a queue."""
+        q = Queue('example')
+        self.assertEqual(q.jobs, [])
+        job = q.enqueue(say_hello)
+        self.assertEqual(q.jobs, [job])
+
+        # Fetching a deleted removes it from queue
+        job.delete()
+        self.assertEqual(q.job_ids, [job.id])
+        q.jobs
+        self.assertEqual(q.job_ids, [])
+
     def test_compact(self):
         """Compacting queueus."""
         q = Queue()


### PR DESCRIPTION
Hi Vincent,

Currently, `queue.jobs` silently drops "dead" jobs. This patch removes "dead" jobs from queue whenever it sees one.

The motivation behind this patch is that queues start showing wrong job counts whenever I delete something on `django-rq`.

Related to this, I also modified `job.cancel` to remove itself from related queue on https://github.com/selwin/rq/commit/f316f35793430d85ca8fd981e37d76f030253150 so the probability of this happening should be much lower.
