### PR TITLE
Added a MANIFEST excluding tests from distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-exclude tests *


### PR DESCRIPTION
Otherwise `find_packages()` sees `tests/` as something that must be installed.
Currently installing `rq` creates a `tests` directory in `site-packages`,
conflicting with projects having a local `tests` directory like rq does :)

Maybe shipping the tests with the distribution is intended, in which case tests should lie under the `rq` namespace.
