### PR TITLE
Ability to get SENTRY_DSN from the environment variables

### DIFF
--- a/rq/scripts/rqworker.py
+++ b/rq/scripts/rqworker.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 import sys
 import argparse
 import logging
@@ -45,7 +46,8 @@ def main():
 
     # Other default arguments
     if args.sentry_dsn is None:
-        args.sentry_dsn = settings.get('SENTRY_DSN', None)
+        args.sentry_dsn = settings.get('SENTRY_DSN',
+                                       os.environ.get('SENTRY_DSN', None))
 
     if args.verbose and args.quiet:
         raise RuntimeError("Flags --verbose and --quiet are mutually exclusive.")


### PR DESCRIPTION
`SENTRY_DSN` is often exposed as an environment variable. This makes it easier to share configuration between different components (workers, web processes, cron jobs) without creating a config file for each component.
