### PR TITLE
Made rqworker and rqinfo respect db parameters from --url

### DIFF
--- a/rq/scripts/__init__.py
+++ b/rq/scripts/__init__.py
@@ -7,7 +7,8 @@ def add_standard_arguments(parser):
     parser.add_argument('--config', '-c', default=None,
             help='Module containing RQ settings.')
     parser.add_argument('--url', '-u', default=None,
-            help='URL describing Redis connection details')
+            help='URL describing Redis connection details. '
+                 'Overrides other connection arguments if supplied.')
     parser.add_argument('--host', '-H', default=None,
             help='The Redis hostname (default: localhost)')
     parser.add_argument('--port', '-p', default=None,
@@ -42,13 +43,10 @@ def setup_default_arguments(args, settings):
     if args.password is None:
         args.password = settings.get('REDIS_PASSWORD', None)
 
-    if not args.queues:
-        args.queues = settings.get('QUEUES', ['default'])
-
 
 def setup_redis(args):
     if args.url is not None:
-        redis_conn = redis.StrictRedis.from_url(args.url, db=args.db)
+        redis_conn = redis.StrictRedis.from_url(args.url)
     else:
         redis_conn = redis.StrictRedis(host=args.host, port=args.port, db=args.db,
             password=args.password)

--- a/rq/scripts/rqinfo.py
+++ b/rq/scripts/rqinfo.py
@@ -21,6 +21,7 @@ def pad(s, pad_to_length):
     """Pads the given string to the given length."""
     return ('%-' + '%ds' % pad_to_length) % (s,)
 
+
 def get_scale(x):
     """Finds the lowest scale where x <= scale."""
     scales = [20, 50, 100, 200, 400, 600, 800, 1000]
@@ -28,6 +29,7 @@ def get_scale(x):
         if x <= scale:
             return scale
     return x
+
 
 def state_symbol(state):
     symbols = {
@@ -186,4 +188,3 @@ def main():
     except KeyboardInterrupt:
         print
         sys.exit(0)
-

--- a/rq/scripts/rqworker.py
+++ b/rq/scripts/rqworker.py
@@ -31,6 +31,19 @@ def parse_args():
     return parser.parse_args()
 
 
+def setup_loghandlers_from_args(args):
+    if args.verbose and args.quiet:
+        raise RuntimeError("Flags --verbose and --quiet are mutually exclusive.")
+
+    if args.verbose:
+        level = 'DEBUG'
+    elif args.quiet:
+        level = 'WARNING'
+    else:
+        level = 'INFO'
+    setup_loghandlers(level)
+
+
 def main():
     args = parse_args()
 
@@ -43,20 +56,14 @@ def main():
 
     setup_default_arguments(args, settings)
 
-    # Other default arguments
+    # Worker specific default arguments
+    if not args.queues:
+        args.queues = settings.get('QUEUES', ['default'])
+
     if args.sentry_dsn is None:
         args.sentry_dsn = settings.get('SENTRY_DSN', None)
 
-    if args.verbose and args.quiet:
-        raise RuntimeError("Flags --verbose and --quiet are mutually exclusive.")
-
-    if args.verbose:
-        level = 'DEBUG'
-    elif args.quiet:
-        level = 'WARNING'
-    else:
-        level = 'INFO'
-    setup_loghandlers(level)
+    setup_loghandlers_from_args(args)
     setup_redis(args)
 
     cleanup_ghosts()


### PR DESCRIPTION
When starting the rqworker and rqinfo scripts with an `--url` parameter containing a non default database, e.g. `redis://localhost:6379/2`, both scripts connected to db 0 instead of the desired database. Fixed this behavior by ignoring the `--host`, `--port` and `--db` arguments if `--url` is present.

Also fixed another issue with the rqinfo script, in which it defaulted to only the 'default' queue instead of finding all available queues using `Queue.all()`.
