### PR TITLE
Writes an optional specified PID file on startup

### DIFF
--- a/rq/scripts/rqworker.py
+++ b/rq/scripts/rqworker.py
@@ -28,7 +28,7 @@ def parse_args():
     parser.add_argument('--quiet', '-q', action='store_true', default=False, help='Show less output')
     parser.add_argument('--sentry-dsn', action='store', default=None, metavar='URL', help='Report exceptions to this Sentry DSN')
     parser.add_argument('--pid', action='store', default=None,
-                        help='Write PID to this file')
+                        help='Write the process ID number to a file at the specified path')
     parser.add_argument('queues', nargs='*', help='The queues to listen on (default: \'default\')')
 
     return parser.parse_args()


### PR DESCRIPTION
Hello,

In my setup I'd benefit from being able to write a PID file on startup. I've made this rather minimalistic implementation but I guess it could be a little bit more complete if it cleaned up it's PID file in `worker.py`, at least when a warm shutdown is requested. I can't see any obvious place where the startup configuration is kept, though so I couldn't didn't know the path of the PID file in `worker.Worker.request_stop` yet.

If you're interested in merging, I see too immediate possibilities:
1. Let the `--pid` / `PID_FILE` configuration option have the caveat of not deleting old PID files (I'd use it anyway).
2. Find a way to let `worker.Worker.request_stop` access configuration from `rq.script.rqworker` et. al. (which might complicate things unnecessarily).

What do you think?
