### PR TITLE
register_sentry breaks failed queue

### DIFF
--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,29 @@
+from tests import RQTestCase
+from rq import Queue, Worker, get_failed_queue
+from rq.contrib.sentry import register_sentry
+
+
+class FakeSentry(object):
+    def captureException(self, *args, **kwds):
+        pass  # we cannot check this, because worker forks
+
+
+class TestSentry(RQTestCase):
+
+    def test_work_fails(self):
+        """Non importable jobs should be put on the failed queue event with sentry"""
+        q = Queue()
+        failed_q = get_failed_queue()
+
+        # Action
+        q.enqueue('_non.importable.job')
+        self.assertEquals(q.count, 1)
+
+        w = Worker([q])
+        register_sentry(FakeSentry(), w)
+
+        w.work(burst=True)
+
+        # Postconditions
+        self.assertEquals(failed_q.count, 1)
+        self.assertEquals(q.count, 0)


### PR DESCRIPTION
When you enable Sentry `rqworker default --sentry-dsn [URL]` and enqueue a task that cannot be imported in Job.func (think: `q.enqueue('os.path.abpathsz', '.')` or `q.enqueue(oh_noes.function.not.available.in.worker)`) the worker fails **as expected**. 

What's rather unfortunate is that:
a) error is **not** logged in Sentry
b) job is **not** placed on the _failed_ queue

I've attached a test case checking for this issue. My current fix looks something like this:

``` python
def register_sentry(client, worker):
    """Given a Raven client and an RQ worker, registers exception handlers
    with the worker so exceptions are logged to Sentry.
    """
    def send_to_sentry(job, *exc_info):
        try:
            # .func imports code, and can fail with any exception
            func = job.func
        except:
            func = None

        client.captureException(
                exc_info=exc_info,
                extra={
                    'job_id': job.id,
                    'func': func,
                    'func_name': job.func_name,
                    'args': job.args,
                    'kwargs': job.kwargs,
                    'description': job.description,
                    })

    worker.push_exc_handler(send_to_sentry)
```

When the module is missing, job is correctly placed on _failed_ queue and  traceback in Sentry says exactly what happened:

```
ImportError: No module named __nonoos.path

Stacktrace (most recent call last):

  File "rq/worker.py", line 410, in perform_job
    rv = job.perform()
  File "rq/job.py", line 344, in perform
    self._result = self.func(*self.args, **self.kwargs)
  File "rq/job.py", line 132, in func
    module = importlib.import_module(module_name)
  File "importlib/__init__.py", line 37, in import_module
    __import__(name)
```

However,  when the module exists, but the callable inside it doesn't, the traceback is a bit confusing. 

```
AttributeError: 'super' object has no attribute 'func'

Stacktrace (most recent call last):

  File "rq/worker.py", line 410, in perform_job
    rv = job.perform()
  File "rq/job.py", line 344, in perform
    self._result = self.func(*self.args, **self.kwargs)
  File "rq/job.py", line 412, in __getattr__
    return getattr(super(Job, self), name)
```

Any idea how to fix this _correctly_?
