### PR TITLE
Workaround getting isatty from a poorly implemented stdout object

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -70,9 +70,9 @@ class _Colorizer(object):
         self.codes["fuscia"] = self.codes["fuchsia"]
         self.codes["white"] = self.codes["bold"]
 
-        try:
+        if hasattr(sys.stdout, "isatty"):
             self.notty = not sys.stdout.isatty()
-        except:
+        else:
             self.notty = True
 
     def reset_color(self):


### PR DESCRIPTION
When faced with badly overloaded stdout you should probably not assume proper implementation of the object

e.g. in Pyramid

``` python
class LazyWriter(object):

    """
    File-like object that opens a file lazily when it is first written
    to.
    """

    def __init__(self, filename, mode='w'):
        self.filename = filename
        self.fileobj = None
        self.lock = threading.Lock()
        self.mode = mode

    def open(self):
        if self.fileobj is None:
            with self.lock:
                self.fileobj = open(self.filename, self.mode)
        return self.fileobj

    def close(self):
        fileobj = self.fileobj
        if fileobj is not None:
            fileobj.close()

    def __del__(self):
        self.close()

    def write(self, text):
        fileobj = self.open()
        fileobj.write(text)
        fileobj.flush()

    def writelines(self, text):
        fileobj = self.open()
        fileobj.writelines(text)
        fileobj.flush()

    def flush(self):
        self.open().flush()
```

you are missing a isatty method which causes

```
File "/var/www/someproject/env/local/lib/python2.7/site-packages/pyramid/path.py", line 318, in maybe_resolve
    return self._resolve(dotted, package)
  File "/var/www/someproject/env/local/lib/python2.7/site-packages/pyramid/path.py", line 325, in _resolve
    return self._zope_dottedname_style(dotted, package)
  File "/var/www/someproject/env/local/lib/python2.7/site-packages/pyramid/path.py", line 368, in _zope_dottedname_style
    found = __import__(used)
  File "/var/www/someproject/env/local/lib/python2.7/site-packages/pyramid_rq-1.0dev-py2.7.egg/pyramid_rq/__init__.py", line 2, in <module>
    import rq
  File "/var/www/someproject/env/src/rq/rq/__init__.py", line 7, in <module>
    from .worker import Worker
  File "/var/www/someproject/env/src/rq/rq/worker.py", line 19, in <module>
    from .utils import make_colorizer
  File "/var/www/someproject/env/src/rq/rq/utils.py", line 109, in <module>
    colorizer = _Colorizer()
  File "/var/www/someproject/env/src/rq/rq/utils.py", line 72, in __init__
    self.notty = not sys.stdout.isatty()
AttributeError: 'LazyWriter' object has no attribute 'isatty' 
```
