### PR TITLE
Replaced limit by length and start by offset to remove a possible ambiguity

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -78,7 +78,7 @@ class Queue(object):
         """Returns a slice of job IDs in the queue."""
         start = offset
         if length >= 0:
-            end = offset + length
+            end = offset + (length - 1)
         else:
             end = length
         return self.connection.lrange(self.key, start, end)


### PR DESCRIPTION
When using these methods (Although I was really using just get_jobs):

```
def get_job_ids(self, start=0, limit=-1):
    """Returns a slice of job IDs in the queue."""

def get_jobs(self, start=0, limit=-1):
    """Returns a slice of jobs in the queue."""
```

I stumbled a cross a bug in my application and then I found that my mistake happened when I wrongly interpreted the limit argument of the functions.

Then I notice there's some ambiguity in this case. get_jobs functions `start` parameter can make method seems like it works like works redis `LRANGE` command, so limit is like STOP

http://redis.io/commands/lrange

But is not.

Then I though it can work like python slice notation:

http://stackoverflow.com/questions/509211/the-python-slice-notation
http://docs.python.org/2/tutorial/introduction.html

So limit is like `:end`
But it not also.

Then I noticed it somehow resembles php's `array_slice` notation. 

http://php.net/manual/pt_BR/function.array-slice.php

In my humble opinion, `limit` is a little bit ambiguous, it could easily be mistaken with STOP of redis command or "end" of python slice notation. 

Maybe `length` is a better parameter name.

I also changed `start` paramater to `offset` for the same reasons.

PS: I know get_jobs is no exactly the `array_slice` of PHP since the method would have to be like 

   def get_job_ids(self, offset=0, length=None):

And that would add a lot of problems that doesn't worth mentioning here. If you want, we can discuss this in a another pull request.
