### PR TITLE
fix reading of version in py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ from setuptools import setup, find_packages
 def get_version():
     basedir = os.path.dirname(__file__)
     with open(os.path.join(basedir, 'rq/version.py')) as f:
-        VERSION = None
-        exec(f.read())
-        return VERSION
+        locals = {}
+        exec(f.read(), locals)
+        return locals['VERSION']
     raise RuntimeError('No version info found.')
 
 


### PR DESCRIPTION
The version is not being loaded correctly under python3 because `exec` works differently now.
