### PR TITLE
Optional job description

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -68,7 +68,7 @@ class Job(object):
     # Job construction
     @classmethod
     def create(cls, func, args=None, kwargs=None, connection=None,
-               result_ttl=None, status=None):
+               result_ttl=None, status=None, description=None):
         """Creates a new Job instance for the given function, arguments, and
         keyword arguments.
         """
@@ -88,7 +88,7 @@ class Job(object):
             job._func_name = func
         job._args = args
         job._kwargs = kwargs
-        job.description = job.get_call_string()
+        job.description = description or job.get_call_string()
         job.result_ttl = result_ttl
         job._status = status
         return job

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -203,6 +203,20 @@ class TestJob(RQTestCase):
         job_from_queue = Job.fetch(job.id, connection=self.testconn)
         self.assertEqual(job.result_ttl, None)
 
+    def test_description_is_persisted(self):
+        """Ensure that job's custom description is set properly"""
+        description = 'Say hello!'
+        job = Job.create(func=say_hello, args=('Lionel',), description=description)
+        job.save()
+        job_from_queue = Job.fetch(job.id, connection=self.testconn)
+        self.assertEqual(job.description, description)
+
+        # Ensure job description is constructed from function call string
+        job = Job.create(func=say_hello, args=('Lionel',))
+        job.save()
+        job_from_queue = Job.fetch(job.id, connection=self.testconn)
+        self.assertEqual(job.description, job.get_call_string())
+
     def test_job_access_within_job_function(self):
         """The current job is accessible within the job function."""
         # Executing the job function from outside of RQ throws an exception


### PR DESCRIPTION
Is there a way to add custom description to jobs? Since RQ uses the func_name for its jobs, instance methods from different instances have the same description right now. E.g.:

``` python
class Base(object):
    def ping(self):
        pass

class Foo(Base):
    def ping(self):
        # Foo related ping logic
        pass

class Bar(Base):
    def ping(self):
        # Bar related ping logic
        pass
```

If I enqueue both Foo().ping and Bar().ping, I see them as [ping(), ping()] in jobs list and it's hard to tell which one is which.

It would be nice if I could pass a description to a job, like:

``` python
q.enqueue_call(Foo().ping, description='Foo.ping() whatever') 
```
