### PR TITLE
Split Job.dump() and Job.save()

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -291,11 +291,8 @@ class Job(object):
         self._status = as_text(obj.get('status') if obj.get('status') else None)
         self.meta = unpickle(obj.get('meta')) if obj.get('meta') else {}
 
-    def save(self, pipeline=None):
-        """Persists the current job instance to its corresponding Redis key."""
-        key = self.key
-        connection = pipeline if pipeline is not None else self.connection
-
+    def dump(self):
+        """Returns a serialization of the current job instance"""
         obj = {}
         obj['created_at'] = times.format(self.created_at or times.now(), 'UTC')
 
@@ -322,7 +319,14 @@ class Job(object):
         if self.meta:
             obj['meta'] = dumps(self.meta)
 
-        connection.hmset(key, obj)
+        return obj
+
+    def save(self, pipeline=None):
+        """Persists the current job instance to its corresponding Redis key."""
+        key = self.key
+        connection = pipeline if pipeline is not None else self.connection
+
+        connection.hmset(key, self.dump())
 
     def cancel(self):
         """Cancels the given job, which will prevent the job from ever being
@@ -379,13 +383,13 @@ class Job(object):
         - If it's a positive number, set the job to expire in X seconds.
         - If result_ttl is negative, don't set an expiry to it (persist
           forever)
-        """        
+        """
         if ttl == 0:
             self.cancel()
         elif ttl > 0:
             connection = pipeline if pipeline is not None else self.connection
             connection.expire(self.key, ttl)
-        
+
 
     def __str__(self):
         return '<Job %s: %s>' % (self.id, self.description)


### PR DESCRIPTION
In our app we sometimes want to save serialized jobs somewhere else in addition to Redis and need to get the serialized version of the job without saving it right away.

Regardless, I think it is also good design to split dump() and save().

Comments welcome!
