### PR TITLE
Support querying the worker for the currently executing job.

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -242,8 +242,8 @@ class Worker(object):
 
     job_id = property(get_job_id, set_job_id)
 
-    # most client will want to use the method below to query the current job
     def get_current_job(self):
+        """Returns the job id of the currently executing job."""
         job_id = self.get_job_id()
 
         if job_id is None:


### PR DESCRIPTION
Adds the possibility for pipelining (similar to Job.save and Job.delete) by adding optional pipeline=None parameters. Upon starting a job, right after setting the 'busy' state, saves the id of the job to be executed. A convenience method for the probably most common use case is also available (`Worker.get_current_job()`), which returns a `Job` instance.

I did not implement pipelining at this time, mainly because I am not 100% of the implications. It would also require reordering of the following code:

```
self.state = 'busy'
job, queue = result
```

Someone who knows the codebase better could easily add it though.
