### PR TITLE
Remove duplicate function call.

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -79,7 +79,6 @@ class Worker(object):
         by their Redis keys.
         """
         prefix = cls.redis_worker_namespace_prefix
-        name = worker_key[len(prefix):]
         if not worker_key.startswith(prefix):
             raise ValueError('Not a valid RQ worker key: %s' % (worker_key,))
 


### PR DESCRIPTION
There are two lines doing the same thing in `find_by_key` function which is retrieve worker's name.
The first one doesn't seem useful in this case.
