### PR TITLE
Added support for multi-job dependency

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -326,7 +326,7 @@ class Worker(object):
                 self.fork_and_perform_job(job)
                 self.connection.expire(self.key, self.default_worker_ttl)
                 if job.status == Status.FINISHED:
-                    queue.enqueue_dependents(job)
+                    queue.bump_dependents(job)
 
                 did_perform_work = True
         finally:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -142,14 +142,14 @@ class TestJob(RQTestCase):
         job = Job.create(func=some_calculation, depends_on=parent_job)
         job.save()
         stored_job = Job.fetch(job.id)
-        self.assertEqual(stored_job._dependency_id, parent_job.id)
-        self.assertEqual(stored_job.dependency, parent_job)
+        self.assertEqual(stored_job._prerequisite_ids, [parent_job.id])
+        self.assertEqual(stored_job.prerequisites, [parent_job])
 
         job = Job.create(func=some_calculation, depends_on=parent_job.id)
         job.save()
         stored_job = Job.fetch(job.id)
-        self.assertEqual(stored_job._dependency_id, parent_job.id)
-        self.assertEqual(stored_job.dependency, parent_job)
+        self.assertEqual(stored_job._prerequisite_ids, [parent_job.id])
+        self.assertEqual(stored_job.prerequisites, [parent_job])
 
     def test_store_then_fetch(self):
         """Store, then fetch."""
@@ -283,19 +283,20 @@ class TestJob(RQTestCase):
         job.cleanup(ttl=0)
         self.assertRaises(NoSuchJobError, Job.fetch, job.id, self.testconn)
 
-    def test_register_dependency(self):
+    def test_register_prerequisites(self):
         """Test that jobs updates the correct job dependents."""
         job = Job.create(func=say_hello)
-        job._dependency_id = 'id'
+        job._prerequisite_ids = ['id1', 'id2']
         job.save()
-        job.register_dependency()
-        self.assertEqual(as_text(self.testconn.spop('rq:job:id:dependents')), job.id)
+        job.register_prerequisites(['id1'])
+        self.assertEqual(map(as_text, self.testconn.smembers('rq:job:id1:dependents')), [job.id])
+        self.assertEqual(map(as_text, self.testconn.smembers('rq:job:id2:dependents')), [])
 
     def test_cancel(self):
         """job.cancel() deletes itself & dependents mapping from Redis."""
         job = Job.create(func=say_hello)
         job2 = Job.create(func=say_hello, depends_on=job)
-        job2.register_dependency()
+        job2.register_prerequisites([job.id])
         job.cancel()
         self.assertFalse(self.testconn.exists(job.key))
         self.assertFalse(self.testconn.exists(job.dependents_key))


### PR DESCRIPTION
Outstanding items:
1. Pipeline Redis operations.
2. Should depends_on accept both an enumerable (e.g. list of Jobs) and a scalar (e.g. Job), or an enumerable only?
3. Should depends_on accept Job only or job id in addition to Job? If former, then maybe we should make some functions less accepting of different types of inputs.
