### PR TITLE
Exclude tests package from setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     description='RQ is a simple, lightweight, library for creating background '
                 'jobs, and processing them.',
     long_description=__doc__,
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     zip_safe=False,
     platforms='any',


### PR DESCRIPTION
Pull request nvie/rq#192 solved the issue for `pip install rq` but not when
directly installing from a git repository as in
`pip install git+git://github.com/nvie/rq@master` that still creates a
possibly conflicting `tests` folder.
