### PR TITLE
Remove dependency on 'times' library (issue #286).

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ### 0.4.0
 (not released yet)
 
+- Removed dependency on the `times` library. Thanks, Malthe!
+
 - Job dependencies!  Thanks, Selwin.
 
 - `Queue.all()` and `rqinfo` now report empty queues, too.  Thanks, Rob!

--- a/rq/job.py
+++ b/rq/job.py
@@ -1,5 +1,4 @@
 import inspect
-import times
 from uuid import uuid4
 try:
     from cPickle import loads, dumps, UnpicklingError
@@ -8,7 +7,7 @@ except ImportError:  # noqa
 from .local import LocalStack
 from .connections import resolve_connection
 from .exceptions import UnpickleError, NoSuchJobError
-from .utils import import_attribute
+from .utils import import_attribute, utcnow, utcformat, utcparse
 from rq.compat import text_type, decode_redis_hash, as_text
 
 
@@ -192,7 +191,7 @@ class Job(object):
     def __init__(self, id=None, connection=None):
         self.connection = resolve_connection(connection)
         self._id = id
-        self.created_at = times.now()
+        self.created_at = utcnow()
         self._func_name = None
         self._instance = None
         self._args = None
@@ -293,9 +292,9 @@ class Job(object):
 
         def to_date(date_str):
             if date_str is None:
-                return None
+                return
             else:
-                return times.to_universal(as_text(date_str))
+                return utcparse(as_text(date_str))
 
         try:
             self.data = obj['data']
@@ -323,7 +322,7 @@ class Job(object):
     def dump(self):
         """Returns a serialization of the current job instance"""
         obj = {}
-        obj['created_at'] = times.format(self.created_at or times.now(), 'UTC')
+        obj['created_at'] = utcformat(self.created_at or utcnow())
 
         if self.func_name is not None:
             obj['data'] = dumps(self.job_tuple)
@@ -332,9 +331,9 @@ class Job(object):
         if self.description is not None:
             obj['description'] = self.description
         if self.enqueued_at is not None:
-            obj['enqueued_at'] = times.format(self.enqueued_at, 'UTC')
+            obj['enqueued_at'] = utcformat(self.enqueued_at)
         if self.ended_at is not None:
-            obj['ended_at'] = times.format(self.ended_at, 'UTC')
+            obj['ended_at'] = utcformat(self.ended_at)
         if self._result is not None:
             obj['result'] = dumps(self._result)
         if self.exc_info is not None:

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1,8 +1,8 @@
-import times
 import uuid
 
 from .connections import resolve_connection
 from .job import Job, Status
+from .utils import utcnow
 
 from .exceptions import (DequeueTimeout, InvalidJobOperationError,
                          NoSuchJobError, UnpickleError)
@@ -225,7 +225,7 @@ class Queue(object):
 
         if set_meta_data:
             job.origin = self.name
-            job.enqueued_at = times.now()
+            job.enqueued_at = utcnow()
 
         if job.timeout is None:
             job.timeout = self.DEFAULT_TIMEOUT
@@ -371,7 +371,7 @@ class FailedQueue(Queue):
         must not be overridden (e.g. `origin` or `enqueued_at`) and other meta
         data must be inserted (`ended_at` and `exc_info`).
         """
-        job.ended_at = times.now()
+        job.ended_at = utcnow()
         job.exc_info = exc_info
         return self.enqueue_job(job, set_meta_data=False)
 

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -6,6 +6,7 @@ The formatter for ANSI colored console output is heavily based on Pygments
 terminal colorizing code, originally by Georg Brandl.
 """
 import importlib
+import datetime
 import logging
 import os
 import sys
@@ -168,3 +169,15 @@ def import_attribute(name):
     module_name, attribute = name.rsplit('.', 1)
     module = importlib.import_module(module_name)
     return getattr(module, attribute)
+
+
+def utcnow():
+    return datetime.datetime.utcnow()
+
+
+def utcformat(dt):
+    return dt.strftime(u"%Y-%m-%dT%H:%M:%SZ")
+
+
+def utcparse(string):
+    return datetime.datetime.strptime(string, "%Y-%m-%dT%H:%M:%SZ")

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def get_version():
 
 
 def get_dependencies():
-    deps = ['redis >= 2.4.13', 'times']
+    deps = ['redis >= 2.4.13']
     if sys.version_info < (2, 7) or \
             (sys.version_info >= (3, 0) and sys.version_info < (3, 1)):
         deps += ['importlib']

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,6 @@
-import times
+from datetime import timedelta
 
 
-def strip_milliseconds(date):
-    return times.to_universal(times.format(date, 'UTC'))
+def strip_microseconds(date):
+    return date - timedelta(microseconds=date.microsecond)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,7 +3,7 @@ from time import sleep
 from tests import RQTestCase, slow
 from tests.fixtures import say_hello, div_by_zero, do_nothing, create_file, \
         create_file_after_timeout
-from tests.helpers import strip_milliseconds
+from tests.helpers import strip_microseconds
 from rq import Queue, Worker, get_failed_queue
 from rq.job import Job, Status
 
@@ -87,7 +87,7 @@ class TestWorker(RQTestCase):
         self.assertEquals(q.count, 1)
 
         # keep for later
-        enqueued_at_date = strip_milliseconds(job.enqueued_at)
+        enqueued_at_date = strip_microseconds(job.enqueued_at)
 
         w = Worker([q])
         w.work(burst=True)  # should silently pass


### PR DESCRIPTION
Basically, for the functionality needed, a dependency on 'times' (which
in turn depends on 'python-dateutil') seem unnecessary.

This closes https://github.com/nvie/rq/issues/286.
