### PR TITLE
Results timeout arg added to rqworker

### DIFF
--- a/rq/scripts/rqworker.py
+++ b/rq/scripts/rqworker.py
@@ -23,7 +23,8 @@ def parse_args():
     parser.add_argument('--name', '-n', default=None, help='Specify a different name')
     parser.add_argument('--worker-class', '-w', action='store', default='rq.Worker', help='RQ Worker class to use')
     parser.add_argument('--path', '-P', default='.', help='Specify the import path.')
-    parser.add_argument('--timeout', '-t', default=None, help='Default results timeout for the worker to use')
+    parser.add_argument('--results-ttl', '-rt', default=None, help='Default results timeout to be used')
+    parser.add_argument('--worker-ttl', '-wt', default=None, help='Default worker timeout to be used')
     parser.add_argument('--verbose', '-v', action='store_true', default=False, help='Show more output')
     parser.add_argument('--quiet', '-q', action='store_true', default=False, help='Show less output')
     parser.add_argument('--sentry-dsn', action='store', default=None, metavar='URL', help='Report exceptions to this Sentry DSN')
@@ -79,7 +80,11 @@ def main():
 
     try:
         queues = list(map(Queue, args.queues))
-        w = worker_class(queues, name=args.name, default_result_ttl=args.timeout)
+        w = worker_class(
+                queues,
+                name=args.name,
+                default_worker_ttl=args.worker_ttl,
+                default_result_ttl=args.results_ttl)
 
         # Should we configure Sentry?
         if args.sentry_dsn:


### PR DESCRIPTION
Added an argument allowing results timeout to be specified for the rqworker script.
Ended up making my own worker for a project just to add a different results timeout for workers.
