### PR TITLE
Move job timeout handling to Worker class for better customizability.

### DIFF
--- a/rq/timeouts.py
+++ b/rq/timeouts.py
@@ -8,44 +8,5 @@ class JobTimeoutException(Exception):
     pass
 
 
-class death_penalty_after(object):
-    def __init__(self, timeout):
-        self._timeout = timeout
-
-    def __enter__(self):
-        self.setup_death_penalty()
-
-    def __exit__(self, type, value, traceback):
-        # Always cancel immediately, since we're done
-        try:
-            self.cancel_death_penalty()
-        except JobTimeoutException:
-            # Weird case: we're done with the with body, but now the alarm is
-            # fired.  We may safely ignore this situation and consider the
-            # body done.
-            pass
-
-        # __exit__ may return True to supress further exception handling.  We
-        # don't want to suppress any exceptions here, since all errors should
-        # just pass through, JobTimeoutException being handled normally to the
-        # invoking context.
-        return False
-
-    def handle_death_penalty(self, signum, frame):
-        raise JobTimeoutException('Job exceeded maximum timeout '
-                                  'value (%d seconds).' % self._timeout)
-
-    def setup_death_penalty(self):
-        """Sets up an alarm signal and a signal handler that raises
-        a JobTimeoutException after the timeout amount (expressed in
-        seconds).
-        """
-        signal.signal(signal.SIGALRM, self.handle_death_penalty)
-        signal.alarm(self._timeout)
-
-    def cancel_death_penalty(self):
-        """Removes the death penalty alarm and puts back the system into
-        default signal handling.
-        """
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, signal.SIG_DFL)
+def interrupt_job_execution(signum, frame):
+    raise JobTimeoutException('Job exceeded maximum timeout.')


### PR DESCRIPTION
This PR moves job timeout handling to worker class so it can be easily changed. See discussion on #303 for more details.
