### PR TITLE
Renamed Worker.fork_and_perform_job to Worker.run.

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -318,7 +318,7 @@ class Worker(object):
                               blue(job.description), job.id))
 
                 self.heartbeat((job.timeout or 180) + 60)
-                self.fork_and_perform_job(job)
+                self.run(job)
                 self.heartbeat()
                 if job.status == Status.FINISHED:
                     queue.enqueue_dependents(job)
@@ -359,7 +359,7 @@ class Worker(object):
         self.log.debug('Sent heartbeat to prevent worker timeout. '
                        'Next one should arrive within {0} seconds.'.format(timeout))
 
-    def fork_and_perform_job(self, job):
+    def run(self, job):
         """Spawns a work horse to perform the actual work and passes it a job.
         The worker will wait for the work horse and make sure it executes
         within the given timeout bounds, or will end the work horse with


### PR DESCRIPTION
There have been interests to use workers with different concurrency models which may not involve `os.fork()`.

This PR renames `Worker.fork_and_perform_job(self, job)` to `Worker.run(self, job)`.
