### PR TITLE
Allow enqueue_job to override the synchronous setting on a queue. Add option to the @job decorator.

### DIFF
--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -7,7 +7,7 @@ from rq.compat import string_types
 
 class job(object):
     def __init__(self, queue, connection=None, timeout=None,
-                 result_ttl=DEFAULT_RESULT_TTL):
+                 result_ttl=DEFAULT_RESULT_TTL, async=True):
         """A decorator that adds a ``delay`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required
         ``queue`` argument that can be either a ``Queue`` instance or a string
@@ -23,6 +23,7 @@ class job(object):
         self.connection = resolve_connection(connection)
         self.timeout = timeout
         self.result_ttl = result_ttl
+        self.async = async
 
     def __call__(self, f):
         @wraps(f)
@@ -32,6 +33,6 @@ class job(object):
             else:
                 queue = self.queue
             return queue.enqueue_call(f, args=args, kwargs=kwargs,
-                                      timeout=self.timeout, result_ttl=self.result_ttl)
+                                      timeout=self.timeout, result_ttl=self.result_ttl, async=self.async)
         f.delay = delay
         return f

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -207,7 +207,7 @@ class Queue(object):
                                  timeout=timeout, result_ttl=result_ttl,
                                  description=description, depends_on=depends_on)
 
-    def enqueue_job(self, job, set_meta_data=True):
+    def enqueue_job(self, job, set_meta_data=True, async=True):
         """Enqueues a job for delayed execution.
 
         If the `set_meta_data` argument is `True` (default), it will update
@@ -226,11 +226,14 @@ class Queue(object):
             job.timeout = self.DEFAULT_TIMEOUT
         job.save()
 
-        if self._async:
-            self.push_job_id(job.id)
-        else:
+        # Execute synchronously if either the
+        # queue or enqueue_job call asks for it
+        if not async or not self._async:
             job.perform()
             job.save()
+        else:
+            self.push_job_id(job.id)
+
         return job
 
     def enqueue_dependents(self, job):


### PR DESCRIPTION
Makes enqueueing a single job synchronously easier than creating a second queue object, and allows for the `@job` decorator to use a setting for asynchronicity. This only allows overriding in the sync > async direction.

Ex: 

```

from settings import JOB_ASYNC

@job('low', async=JOB_ASYNC)
def do_something(...):
    ....
```

_(Edited for example code formatting)_
