### PR TITLE
rqworker default arguments of socket, worker_ttl, results_ttl bugfix

### DIFF
--- a/rq/scripts/__init__.py
+++ b/rq/scripts/__init__.py
@@ -48,7 +48,7 @@ def setup_default_arguments(args, settings):
 
     args.host = strict_first([args.host, settings.get('REDIS_HOST'), os.environ.get('RQ_REDIS_HOST'), 'localhost'])
     args.port = int(strict_first([args.port, settings.get('REDIS_PORT'), os.environ.get('RQ_REDIS_PORT'), 6379]))
-    args.socket = strict_first([args.socket, settings.get('REDIS_SOCKET'), os.environ.get('RQ_REDIS_SOCKET'), False])
+    args.socket = strict_first([args.socket, settings.get('REDIS_SOCKET'), os.environ.get('RQ_REDIS_SOCKET'), None])
     args.db = strict_first([args.db, settings.get('REDIS_DB'), os.environ.get('RQ_REDIS_DB'), 0])
     args.password = strict_first([args.password, settings.get('REDIS_PASSWORD'), os.environ.get('RQ_REDIS_PASSWORD')])
 


### PR DESCRIPTION
socket default argument exception

```
Traceback (most recent call last):
  File "/var/www/salesapp.beappart.com/venv/bin/rqworker", line 8, in <module>
    load_entry_point('rq==0.3.13', 'console_scripts', 'rqworker')()
  File "/var/www/salesapp.beappart.com/venv/src/rq/rq/scripts/rqworker.py", line 78, in main
    cleanup_ghosts()
  File "/var/www/salesapp.beappart.com/venv/src/rq/rq/contrib/legacy.py", line 20, in cleanup_ghosts
    for worker in Worker.all():
  File "/var/www/salesapp.beappart.com/venv/src/rq/rq/worker.py", line 71, in all
    reported_working = connection.smembers(cls.redis_workers_keys)
  File "/var/www/salesapp.beappart.com/venv/local/lib/python2.7/site-packages/redis/client.py", line 1286, in smembers
    return self.execute_command('SMEMBERS', name)
  File "/var/www/salesapp.beappart.com/venv/local/lib/python2.7/site-packages/redis/client.py", line 460, in execute_command
    connection.send_command(*args)
  File "/var/www/salesapp.beappart.com/venv/local/lib/python2.7/site-packages/redis/connection.py", line 334, in send_command
    self.send_packed_command(self.pack_command(*args))
  File "/var/www/salesapp.beappart.com/venv/local/lib/python2.7/site-packages/redis/connection.py", line 316, in send_packed_command
    self.connect()
  File "/var/www/salesapp.beappart.com/venv/local/lib/python2.7/site-packages/redis/connection.py", line 250, in connect
    sock = self._connect()
  File "/var/www/salesapp.beappart.com/venv/local/lib/python2.7/site-packages/redis/connection.py", line 395, in _connect
    sock.connect(self.path)
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
TypeError: argument must be string or read-only character buffer, not bool
```

worker_ttl default argument exception

```
Traceback (most recent call last):
  File "/var/www/salesapp.beappart.com/venv/bin/rqworker", line 8, in <module>
    load_entry_point('rq==0.3.13', 'console_scripts', 'rqworker')()
  File "/var/www/salesapp.beappart.com/venv/src/rq/rq/scripts/rqworker.py", line 95, in main
    w.work(burst=args.burst)
  File "/var/www/salesapp.beappart.com/venv/src/rq/rq/worker.py", line 329, in work
    self.register_birth()
  File "/var/www/salesapp.beappart.com/venv/src/rq/rq/worker.py", line 206, in register_birth
    p.execute()
  File "/var/www/salesapp.beappart.com/venv/local/lib/python2.7/site-packages/redis/client.py", line 2155, in execute
    return execute(conn, stack, raise_on_error)
  File "/var/www/salesapp.beappart.com/venv/local/lib/python2.7/site-packages/redis/client.py", line 2070, in _execute_transaction
    self.raise_first_error(commands, response)
  File "/var/www/salesapp.beappart.com/venv/local/lib/python2.7/site-packages/redis/client.py", line 2106, in raise_first_error
    raise r
redis.exceptions.ResponseError: Command # 5 (EXPIRE rq:worker:vps.2662 None) of pipeline caused error: value is not an integer or out of range
```
