### PR TITLE
use warnings.warn() instead of raise for DeprecationWarning

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import inspect
 from uuid import uuid4
+import warnings
 
 from rq.compat import as_text, decode_redis_hash, string_types, text_type
 
@@ -131,8 +132,9 @@ class Job(object):
         return self._status
 
     def _get_status(self):
-        raise DeprecationWarning(
-            "job.status is deprecated. Use job.get_status() instead"
+        warnings.warn(
+            "job.status is deprecated. Use job.get_status() instead",
+            DeprecationWarning
         )
         return self.get_status()
 
@@ -141,8 +143,9 @@ class Job(object):
         self.connection.hset(self.key, 'status', self._status)
 
     def _set_status(self, status):
-        raise DeprecationWarning(
-            "job.status is deprecated. Use job.set_status() instead"
+        warnings.warn(
+            "job.status is deprecated. Use job.set_status() instead",
+            DeprecationWarning
         )
         self.set_status(status)
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -11,6 +11,7 @@ import socket
 import sys
 import time
 import traceback
+import warnings
 
 from rq.compat import as_text, text_type
 
@@ -235,8 +236,9 @@ class Worker(object):
 
     def _set_state(self, state):
         """Raise a DeprecationWarning if ``worker.state = X`` is used"""
-        raise DeprecationWarning(
-            "worker.state is deprecated, use worker.set_state() instead."
+        warnings.warn(
+            "worker.state is deprecated, use worker.set_state() instead.",
+            DeprecationWarning
         )
         self.set_state(state)
 
@@ -245,8 +247,9 @@ class Worker(object):
 
     def _get_state(self):
         """Raise a DeprecationWarning if ``worker.state == X`` is used"""
-        raise DeprecationWarning(
-            "worker.state is deprecated, use worker.get_state() instead."
+        warnings.warn(
+            "worker.state is deprecated, use worker.get_state() instead.",
+            DeprecationWarning
         )
         return self.get_state()
 


### PR DESCRIPTION
`raise DeprecationWarning` syntax treats the warning as an error and causes a crash instead of a warning on legacy code.  This change converts the `raise DeprecationWarning` occurrences into `warnings.warn()`.  It includes regression tests for the change to the Job objects, though I wasn't familiar enough with manipulating Worker objects manually to provide a regression test for the that class.
