### PR TITLE
fix --worker-ttl command line arg

### DIFF
--- a/rq/scripts/rqworker.py
+++ b/rq/scripts/rqworker.py
@@ -30,7 +30,7 @@ def parse_args():
     parser.add_argument('--job-class', '-j', action='store', default='rq.job.Job', help='RQ Job class to use')
     parser.add_argument('--path', '-P', default='.', help='Specify the import path.')
     parser.add_argument('--results-ttl', default=None, help='Default results timeout to be used')
-    parser.add_argument('--worker-ttl', default=None, help='Default worker timeout to be used')
+    parser.add_argument('--worker-ttl', type=int, default=None, help='Default worker timeout to be used')
     parser.add_argument('--verbose', '-v', action='store_true', default=False, help='Show more output')
     parser.add_argument('--quiet', '-q', action='store_true', default=False, help='Show less output')
     parser.add_argument('--sentry-dsn', action='store', default=None, metavar='URL', help='Report exceptions to this Sentry DSN')  # noqa


### PR DESCRIPTION
Make sure it's converted to an int, since the rest of the code expects it to be.  Without this patch, trying to use that argument gets you something like this:

``` bash
(cogo)[dbonner@bonnervm18 syseng]$ rqworker --worker-ttl 86400
21:52:07 RQ worker started, version 0.4.6
Traceback (most recent call last):
  File "/opt/cogo/bin/rqworker", line 9, in <module>
    load_entry_point('rq==0.4.6', 'console_scripts', 'rqworker')()
  File "/home/dbonner/src/github/rq/rq/scripts/rqworker.py", line 102, in main
    w.work(burst=args.burst)
  File "/home/dbonner/src/github/rq/rq/worker.py", line 354, in work
    timeout = None if burst else max(1, self.default_worker_ttl - 60)
TypeError: unsupported operand type(s) for -: 'str' and 'int'
```
