### PR TITLE
Use as_text to fix syntax error discovered in Python 3.2 (raspberry pi)

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -14,7 +14,7 @@ import logging
 import os
 import sys
 
-from .compat import is_python_version
+from .compat import is_python_version, as_text
 
 
 def gettermsize():
@@ -181,7 +181,7 @@ def utcnow():
 
 
 def utcformat(dt):
-    return dt.strftime(u'%Y-%m-%dT%H:%M:%SZ')
+    return dt.strftime(as_text('%Y-%m-%dT%H:%M:%SZ'))
 
 
 def utcparse(string):


### PR DESCRIPTION
Hi @nvie!  Just a minor tweak I had to do to get rq working on my Raspberry Pi.  They're still using Python 3.2, so unicode literals aren't supported (as far as I know).
