### PR TITLE
fix #373 , setup_loghandlers will override already exists logging settings

### DIFF
--- a/rq/logutils.py
+++ b/rq/logutils.py
@@ -12,31 +12,30 @@ except ImportError:
     from rq.compat.dictconfig import dictConfig  # noqa
 
 
-def setup_loghandlers(level=None):
-    if not logging._handlerList:
-        dictConfig({
-            'version': 1,
-            'disable_existing_loggers': False,
+def setup_loghandlers(level='INFO'):
+    dictConfig({
+        'version': 1,
+        'disable_existing_loggers': False,
 
-            'formatters': {
-                'console': {
-                    'format': '%(asctime)s %(message)s',
-                    'datefmt': '%H:%M:%S',
-                },
+        'formatters': {
+            'console': {
+                'format': '%(asctime)s %(message)s',
+                'datefmt': '%H:%M:%S',
             },
+        },
 
-            'handlers': {
-                'console': {
-                    'level': 'DEBUG',
-                    # 'class': 'logging.StreamHandler',
-                    'class': 'rq.utils.ColorizingStreamHandler',
-                    'formatter': 'console',
-                    'exclude': ['%(asctime)s'],
-                },
+        'handlers': {
+            'console': {
+                'level': 'DEBUG',
+                # 'class': 'logging.StreamHandler',
+                'class': 'rq.utils.ColorizingStreamHandler',
+                'formatter': 'console',
+                'exclude': ['%(asctime)s'],
             },
+        },
 
-            'root': {
-                'handlers': ['console'],
-                'level': level or 'INFO',
-            }
-        })
+        'root': {
+            'handlers': ['console'],
+            'level': level,
+        }
+    })

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -338,7 +338,6 @@ class Worker(object):
 
         The return value indicates whether any jobs were processed.
         """
-        setup_loghandlers()
         self._install_signal_handlers()
 
         did_perform_work = False


### PR DESCRIPTION
`logging._handlers` always is a empty WeakValueDictionary. so [setup_loghandlers](https://github.com/nvie/rq/blob/master/rq/logutils.py#L16)
will override already exists logging settings. we can use
`logging._handlerList` instead of `logging._handlers` will works fine.
