### PR TITLE
Don't pass "args" into logging call

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -528,7 +528,7 @@ class Worker(object):
                              traceback.format_exception(*exc_info))
         self.log.error(exc_string, exc_info=True, extra={
             'func': job.func_name,
-            'args': job.args,
+            'arguments': job.args,
             'kwargs': job.kwargs,
             'queue': job.origin,
         })


### PR DESCRIPTION
@gsakkis do you mind trying out this patch and see if this fixes #409 for you? I'm not entirely sure why this error is not caught by [this test](https://github.com/nvie/rq/blob/master/tests/test_worker.py#L118).

I also tried writing a new test but this doesn't catch the error either:

``` python
def test_exception_handlers(self):
        """Ensure exception handling does not crash"""
        q = Queue()
        job = q.enqueue_call(div_by_zero)
        w = Worker([q])
        setup_loghandlers()
        w.handle_exception(job, *sys.exc_info())
```
