### PR TITLE
Added vagrant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ If you want the cutting edge version (that may well be broken), use this:
     pip install -e git+git@github.com:nvie/rq.git@master#egg=rq
 
 
+## Testing
+
+To run tests, simply use;
+
+```
+./run_tests
+```
+
+This requires several libraries, and you can keep these self contained by using [Vagrant](https://www.vagrantup.com/). To create a working vagrant environment, use the following;
+
+```
+vagrant init ubuntu/trusty64
+vagrant up
+vagrant ssh -- "sudo apt-get -y install redis-server python-dev python-pip"
+vagrant ssh -- "sudo pip install --no-input redis hiredis mock"
+vagrant ssh -- "(cd /vagrant; ./run_tests)"
+```
+
+
 ## Project history
 
 This project has been inspired by the good parts of [Celery][1], [Resque][2]


### PR DESCRIPTION
This should make contributions and testing a bit easier.

It handles creating a vagrant guest with all the necessary dev libraries, then testing is built into a single Makefile command. There's also some basic status tests to reduce overheads on Vagrant commands (e.g. vagrant up, which can take several seconds alone).

This could be improved at a later date to also include some automatic service repair (e.g. if Redis dies), but for now this will get the job done nicely. I've been using this for the PRs I sent today, and it worked beautifully.
