### PR TITLE
Pass the default worker connection into the started and finished registries

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -496,7 +496,7 @@ class Worker(object):
         self.prepare_job_execution(job)
 
         with self.connection._pipeline() as pipeline:
-            started_job_registry = StartedJobRegistry(job.origin)
+            started_job_registry = StartedJobRegistry(job.origin, self.connection)
 
             try:
                 with self.death_penalty_class(job.timeout or self.queue_class.DEFAULT_TIMEOUT):
@@ -514,7 +514,7 @@ class Worker(object):
                     job._status = Status.FINISHED
                     job.save(pipeline=pipeline)
 
-                    finished_job_registry = FinishedJobRegistry(job.origin)
+                    finished_job_registry = FinishedJobRegistry(job.origin, self.connection)
                     finished_job_registry.add(job, result_ttl, pipeline)
 
                 job.cleanup(result_ttl, pipeline=pipeline)


### PR DESCRIPTION
@selwin 

In practice all the registry methods are called with pipelines, but if no connection is passed in when instantiating the registry and the connection stack is empty resolve_connection will raise `NoRedisConnectionException`.

Given that you don't really need an instance level connection when using pipelines perhaps a better solution would be to replace the `connection = pipeline if pipeline is not None else self.connection` pattern with a utility function that raises `NoRedisConnectionException` if neither exist?
