### PR TITLE
Ensure the FinishedJobRegistry honors an 'infinite' result_ttl of -1

### DIFF
--- a/rq/registry.py
+++ b/rq/registry.py
@@ -28,8 +28,8 @@ class BaseRegistry(object):
         return self.connection.zcard(self.key)
 
     def add(self, job, timeout, pipeline=None):
-        """Adds a job to StartedJobRegistry with expiry time of now + timeout."""
-        score = current_timestamp() + timeout
+        """Adds a job to a registry with expiry time of now + timeout."""
+        score = timeout if timeout == -1 else current_timestamp() + timeout
         if pipeline is not None:
             return pipeline.zadd(self.key, score, job.id)
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -27,6 +27,10 @@ class TestRegistry(RQTestCase):
         self.assertLess(self.testconn.zscore(self.registry.key, job.id),
                         timestamp + 1002)
 
+        # Ensure that a timeout of -1 results in a score of -1
+        self.registry.add(job, -1)
+        self.assertEqual(self.testconn.zscore(self.registry.key, job.id), -1)
+
         # Ensure that job is properly removed from sorted set
         self.registry.remove(job)
         self.assertIsNone(self.testconn.zscore(self.registry.key, job.id))


### PR DESCRIPTION
@selwin 

The `FinishedJobRegistry`'s `cleanup()` method purges jobs older than `add()` time (i.e. job finish time) + `result_ttl`. However per the RQ documentation jobs with a `result_ttl` of `-1` never expire - they should be cleaned up manually. Currently jobs with a `result_ttl` of `-1` are guaranteed to be purged any time the `cleanup()` (and thus `get_job_ids()`) method of the `FinishedJobRegistry` is called, because their score (i.e. expiry time) is set to one second before the job finished.

This pull request ensures such jobs will instead remain in the `FinishedJobRegistry` forever.
