### PR TITLE
Remove log handler configuration from Worker.work method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@
 /.tox
 /dist
 /build
+/venv
 .tox
+.coverage
 .vagrant
 Vagrantfile
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -18,7 +18,6 @@ from rq.compat import as_text, string_types, text_type
 from .connections import get_current_connection
 from .exceptions import DequeueTimeout, NoQueueError
 from .job import Job, Status
-from .logutils import setup_loghandlers
 from .queue import get_failed_queue, Queue
 from .timeouts import UnixSignalDeathPenalty
 from .utils import import_attribute, make_colorizer, utcformat, utcnow
@@ -342,7 +341,6 @@ class Worker(object):
 
         The return value indicates whether any jobs were processed.
         """
-        setup_loghandlers()
         self._install_signal_handlers()
 
         did_perform_work = False


### PR DESCRIPTION
Log handlers do not need to be installed by the `work` method. The two entry points for starting a worker are:
- The built-in rq worker. It calls `setup_loghandlers` already.
- Custom worker. Applications that call `work()` are probably doing it so they can do configuration before starting the worker. This would normally include configuring logging.

In the case where an application has created its own worker and not configured logging, then the default root log handler is used. If they are not happy with that, then `setup_loghandlers` can always be called anyway.
