### PR TITLE
registry.get_job_ids should add timestamp

### DIFF
--- a/rq/registry.py
+++ b/rq/registry.py
@@ -50,9 +50,9 @@ class BaseRegistry(object):
         return [as_text(job_id) for job_id in
                 self.connection.zrangebyscore(self.key, 0, score)]
 
-    def get_job_ids(self, start=0, end=-1):
+    def get_job_ids(self, start=0, end=-1, timestamp=None):
         """Returns list of all job ids."""
-        self.cleanup()
+        self.cleanup(timestamp=timestamp)
         return [as_text(job_id) for job_id in
                 self.connection.zrange(self.key, start, end)]
 

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -130,16 +130,16 @@ class DeferredJobRegistry(BaseRegistry):
         super(DeferredJobRegistry, self).__init__(name, connection)
         self.key = 'rq:deferred:{0}'.format(name)
 
-    def cleanup(self):
+    def cleanup(self, timestamp=None):
         """This method is only here to prevent errors because this method is
         automatically called by `count()` and `get_job_ids()` methods
         implemented in BaseRegistry."""
         pass
 
 
-def clean_registries(queue):
+def clean_registries(queue, timestamp=None):
     """Cleans StartedJobRegistry and FinishedJobRegistry of a queue."""
     registry = FinishedJobRegistry(name=queue.name, connection=queue.connection)
-    registry.cleanup()
+    registry.cleanup(timestamp=timestamp)
     registry = StartedJobRegistry(name=queue.name, connection=queue.connection)
-    registry.cleanup()
+    registry.cleanup(timestamp=timestamp)


### PR DESCRIPTION
registry.get_job_ids can not custom cleanup time if no timestamp.
