### PR TITLE
Delete dependents of job explicitely

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -582,7 +582,6 @@ class Job(object):
 
     def delete_dependents(self, pipeline=None, remove_from_queue=True):
         """Delete jobs depending on this job."""
-        connection = pipeline if pipeline is not None else self.connection
         for dependent_id in self.dependents_ids:
             try:
                 dependent = Job.fetch(dependent_id, connection=self.connection)

--- a/rq/job.py
+++ b/rq/job.py
@@ -585,8 +585,7 @@ class Job(object):
 
     def delete_dependents(self, pipeline=None, remove_from_queue=True):
         """Delete jobs depending on this job."""
-        # TODO: should we do connection.delete(self.dependents_key) in case
-        # this method is called on its own?
+        connection = pipeline if pipeline is not None else self.connection
         for dependent_id in self.dependent_ids:
             try:
                 job = Job.fetch(dependent_id, connection=self.connection)
@@ -595,6 +594,7 @@ class Job(object):
             except NoSuchJobError:
                 # It could be that the dependent job was never saved to redis
                 pass
+        connection.delete(self.dependents_key)
 
     # Job execution
     def perform(self):  # noqa

--- a/rq/job.py
+++ b/rq/job.py
@@ -579,6 +579,7 @@ class Job(object):
                                    remove_from_queue=remove_from_queue)
 
         connection.delete(self.key)
+        connection.delete(self.dependents_key)
 
     def delete_dependents(self, pipeline=None, remove_from_queue=True):
         """Delete jobs depending on this job."""
@@ -591,8 +592,6 @@ class Job(object):
             except NoSuchJobError:
                 # It could be that the dependent job was never saved to redis
                 pass
-
-        connection.delete(self.dependents_key)
 
     # Job execution
     def perform(self):  # noqa

--- a/rq/job.py
+++ b/rq/job.py
@@ -321,6 +321,7 @@ class Job(object):
         self.ttl = None
         self._status = None
         self._dependency_id = None
+        self._dependents_ids = []
         self.meta = {}
 
     def __repr__(self):  # noqa  # pragma: no cover
@@ -444,6 +445,7 @@ class Job(object):
         self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None  # noqa
         self._status = as_text(obj.get('status') if obj.get('status') else None)
         self._dependency_id = as_text(obj.get('dependency_id', None))
+        self._dependents_ids = self.dependents_ids
         self.ttl = int(obj.get('ttl')) if obj.get('ttl') else None
         self.meta = unpickle(obj.get('meta')) if obj.get('meta') else {}
 
@@ -492,6 +494,8 @@ class Job(object):
             obj['status'] = self._status
         if self._dependency_id is not None:
             obj['dependency_id'] = self._dependency_id
+        if self._dependency_id is not None:
+            obj['dependents_ids'] = self._dependents_ids
         if self.meta and include_meta:
             obj['meta'] = dumps(self.meta)
         if self.ttl:

--- a/rq/job.py
+++ b/rq/job.py
@@ -586,6 +586,8 @@ class Job(object):
 
     def delete_dependents(self, pipeline=None, remove_from_queue=True):
         """Delete jobs depending on this job."""
+        # TODO: should we do connection.delete(self.dependents_key) in case
+        # this method is called on its own?
         for dependent_id in self.dependents_ids:
             try:
                 dependent = Job.fetch(dependent_id, connection=self.connection)

--- a/rq/job.py
+++ b/rq/job.py
@@ -492,9 +492,6 @@ class Job(object):
             obj['status'] = self._status
         if self._dependency_id is not None:
             obj['dependency_id'] = self._dependency_id
-        _dependents_ids = self.dependent_ids
-        if _dependents_ids:
-            obj['dependent_ids'] = _dependents_ids
         if self.meta and include_meta:
             obj['meta'] = dumps(self.meta)
         if self.ttl:

--- a/rq/job.py
+++ b/rq/job.py
@@ -531,8 +531,8 @@ class Job(object):
         cancellation.
         """
         # TODO: Dependent jobs are by default in a DEFERRED state. Should we
-        # introduce a CANCELLED state to make the difference clearer for those
-        # what has happened? Would we then also need a canceled registry?
+        # introduce a CANCELLED state to make the difference clearer?
+        # Would we then also need a canceled registry?
         from .queue import Queue
         pipeline = pipeline or self.connection._pipeline()
         if self.origin:

--- a/rq/job.py
+++ b/rq/job.py
@@ -198,7 +198,7 @@ class Job(object):
     def dependent_ids(self):
         """Returns a list of ids of jobs whose execution depends on this
         job's successful execution."""
-        return map(as_text, self.connection.smembers(self.dependents_key))
+        return list(map(as_text, self.connection.smembers(self.dependents_key)))
 
     @property
     def func(self):
@@ -492,8 +492,8 @@ class Job(object):
             obj['status'] = self._status
         if self._dependency_id is not None:
             obj['dependency_id'] = self._dependency_id
-        _dependents_ids = list(self.dependent_ids)
-        if len(_dependents_ids) > 0:
+        _dependents_ids = self.dependent_ids
+        if _dependents_ids:
             obj['dependent_ids'] = _dependents_ids
         if self.meta and include_meta:
             obj['meta'] = dumps(self.meta)

--- a/rq/job.py
+++ b/rq/job.py
@@ -32,8 +32,7 @@ JobStatus = enum(
     FINISHED='finished',
     FAILED='failed',
     STARTED='started',
-    DEFERRED='deferred',
-    CANCELED='canceled'
+    DEFERRED='deferred'
 )
 
 # Sentinel value to mark that some of our lazily evaluated properties have not
@@ -532,7 +531,7 @@ class Job(object):
         # introduce a CANCELLED state to make the difference clearer for those
         # what has happened? Would we then also need a canceled registry?
         from .queue import Queue
-        pipeline = self.connection._pipeline()
+        pipeline = pipeline or self.connection._pipeline()
         if self.origin:
             q = Queue(name=self.origin, connection=self.connection)
             q.remove(self, pipeline=pipeline)
@@ -544,7 +543,7 @@ class Job(object):
         on this job can optionally be deleted as well."""
 
         if remove_from_queue:
-            self.cancel(pipeline)
+            self.cancel(pipeline=pipeline)
         connection = pipeline if pipeline is not None else self.connection
 
         if self.get_status() == JobStatus.FINISHED:

--- a/rq/job.py
+++ b/rq/job.py
@@ -571,20 +571,19 @@ class Job(object):
             failed_queue.remove(self, pipeline=pipeline)
 
         if delete_dependents:
-            self.delete_dependents(pipeline=pipeline,
-                                   remove_from_queue=remove_from_queue)
+            self.delete_dependents(pipeline=pipeline)
 
         connection.delete(self.key)
         connection.delete(self.dependents_key)
 
-    def delete_dependents(self, pipeline=None, remove_from_queue=True):
+    def delete_dependents(self, pipeline=None):
         """Delete jobs depending on this job."""
         connection = pipeline if pipeline is not None else self.connection
         for dependent_id in self.dependent_ids:
             try:
                 job = Job.fetch(dependent_id, connection=self.connection)
                 job.delete(pipeline=pipeline,
-                           remove_from_queue=remove_from_queue)
+                           remove_from_queue=False)
             except NoSuchJobError:
                 # It could be that the dependent job was never saved to redis
                 pass

--- a/rq/job.py
+++ b/rq/job.py
@@ -530,9 +530,6 @@ class Job(object):
         without worrying about the internals required to implement job
         cancellation.
         """
-        # TODO: Dependent jobs are by default in a DEFERRED state. Should we
-        # introduce a CANCELLED state to make the difference clearer?
-        # Would we then also need a canceled registry?
         from .queue import Queue
         pipeline = pipeline or self.connection._pipeline()
         if self.origin:


### PR DESCRIPTION
Linked to PRs https://github.com/rq/rq/pull/427 and https://github.com/rq/rq/pull/856
As discussed in both of the above PRs I am introducing a method to explicitly delete dependents of a job.
In this implementation deleting a job by default does not touch the dependents (should we introduce a CANCELED or ORPHANED state?).
In case a user uses `delete_dependents=True`, all dependent jobs are deleted.
Since canceling a job only removes it form the queue and dependents are not in a queue yet anyway that method is not involved.