### PR TITLE
Pass job_id to death penalty class

### DIFF
--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -290,6 +290,16 @@ queue.enqueue(some_func)
 {% endhighlight %}
 
 
+## Custom DeathPenalty classes
+
+When a Job times-out, the worker will try to kill it using the supplied
+`death_penalty_class` (default: `UnixSignalDeathPenalty`). This can be overridden
+if you wish to attempt to kill jobs in an application specific or 'cleaner' manner. 
+
+DeathPenalty classes are constructed with the following arguments
+`BaseDeathPenalty(timeout, JobTimeoutException, job_id=job.id)`
+
+
 ## Custom exception handlers
 
 _New in version 0.5.5._

--- a/rq/timeouts.py
+++ b/rq/timeouts.py
@@ -27,7 +27,7 @@ class HorseMonitorTimeoutException(BaseTimeoutException):
 class BaseDeathPenalty(object):
     """Base class to setup job timeouts."""
 
-    def __init__(self, timeout, exception=JobTimeoutException):
+    def __init__(self, timeout, exception=JobTimeoutException, **kwargs):
         self._timeout = timeout
         self._exception = exception
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -795,7 +795,7 @@ class Worker(object):
         try:
             job.started_at = utcnow()
             timeout = job.timeout or self.queue_class.DEFAULT_TIMEOUT
-            with self.death_penalty_class(timeout, JobTimeoutException):
+            with self.death_penalty_class(timeout, JobTimeoutException, job_id=job.id):
                 rv = job.perform()
 
             job.ended_at = utcnow()


### PR DESCRIPTION
This allows custom workers to use associated custom `DeathPenalty` classes and apply custom timeouts or less messy death methods.

Implemented with **kwargs so future changes to `BaseDeathPenalty` wont break API.
