### PR TITLE
Define redis key prefix as class variable

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -366,7 +366,7 @@ class Job(object):
     @classmethod
     def dependents_key_for(cls, job_id):
         """The Redis key that is used to store job dependents hash under."""
-        return '{0}{0}:dependents'.format(cls.redis_job_namespace_prefix, job_id)
+        return '{0}{1}:dependents'.format(cls.redis_job_namespace_prefix, job_id)
 
     @property
     def key(self):

--- a/rq/job.py
+++ b/rq/job.py
@@ -85,6 +85,7 @@ def get_current_job(connection=None, job_class=None):
 class Job(object):
     """A Job is just a convenient datastructure to pass around job (meta) data.
     """
+    redis_job_namespace_prefix = 'rq:job:'
 
     # Job construction
     @classmethod
@@ -360,12 +361,12 @@ class Job(object):
     @classmethod
     def key_for(cls, job_id):
         """The Redis key that is used to store job hash under."""
-        return b'rq:job:' + job_id.encode('utf-8')
+        return (cls.redis_job_namespace_prefix + job_id).encode('utf-8')
 
     @classmethod
     def dependents_key_for(cls, job_id):
         """The Redis key that is used to store job dependents hash under."""
-        return 'rq:job:{0}:dependents'.format(job_id)
+        return '{0}{0}:dependents'.format(cls.redis_job_namespace_prefix, job_id)
 
     @property
     def key(self):

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -179,7 +179,7 @@ class Queue(object):
         """Removes all "dead" jobs from the queue by cycling through it, while
         guaranteeing FIFO semantics.
         """
-        COMPACT_QUEUE = '{0}_compact:{0}'.format(
+        COMPACT_QUEUE = '{0}_compact:{1}'.format(
             self.redis_queue_namespace_prefix, uuid.uuid4())  # noqa
 
         self.connection.rename(self.key, COMPACT_QUEUE)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -91,8 +91,8 @@ class Queue(object):
 
     def empty(self):
         """Removes all messages on the queue."""
-        script = b"""
-            local prefix = "rq:job:"
+        script = """
+            local prefix = "{0}"
             local q = KEYS[1]
             local count = 0
             while true do
@@ -107,7 +107,7 @@ class Queue(object):
                 count = count + 1
             end
             return count
-        """
+        """.format(self.job_class.redis_job_namespace_prefix).encode("utf-8")
         script = self.connection.register_script(script)
         return script(keys=[self.key])
 
@@ -179,7 +179,8 @@ class Queue(object):
         """Removes all "dead" jobs from the queue by cycling through it, while
         guaranteeing FIFO semantics.
         """
-        COMPACT_QUEUE = 'rq:queue:_compact:{0}'.format(uuid.uuid4())  # noqa
+        COMPACT_QUEUE = '{0}_compact:{0}'.format(
+            self.redis_queue_namespace_prefix, uuid.uuid4())  # noqa
 
         self.connection.rename(self.key, COMPACT_QUEUE)
         while True:

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -597,3 +597,17 @@ class TestJob(RQTestCase):
         self.assertEqual(get_failed_queue().count, 0)
         self.assertEqual(Queue('fake').count, 1)
         self.assertEqual(requeued_job.origin, job.origin)
+
+    def test_dependents_key_for_should_return_prefixed_job_id(self):
+        """test redis key to store job dependents hash under"""
+        job_id = 'random'
+        key = Job.dependents_key_for(job_id=job_id)
+
+        assert key == Job.redis_job_namespace_prefix + job_id + ':dependents'
+
+    def test_key_for_should_return_prefixed_job_id(self):
+        """test redis key to store job hash under"""
+        job_id = 'random'
+        key = Job.key_for(job_id=job_id)
+
+        assert key == (Job.redis_job_namespace_prefix + job_id).encode('utf-8')


### PR DESCRIPTION
Some prefixes were hardcoded in several places. This made it hard to
use custom prefixes via subclasses.

Resolves #920