### PR TITLE
Rename argument named `async` to `asynk`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.6-dev"
+  - "3.7-dev" # Unfortunately, as of writing, Travis CI does not support released Python 3.7
   - "pypy"
 install:
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
-sudo: false
+sudo: true
 language: python
 services:
   - redis
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7-dev" # Unfortunately, as of writing, Travis CI does not support released Python 3.7
-  - "pypy"
+matrix:
+  include:
+    - python: "2.7"
+      dist: xenial
+    - python: "3.3"
+      dist: trusty
+    - python: "3.4"
+      dist: trusty
+    - python: "3.5"
+      dist: xenial
+    - python: "3.6"
+      dist: xenial
+    - python: "3.7"
+      dist: xenial
+    - python: "pypy"
+      dist: trusty
 install:
   - pip install -e .
   - pip install pytest-cov

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- `async` is now a reserved keyword in Python 3.7. Because of this, the keyword argument `async` used in the constructor of `Queue` was renamed to `asynk`. Whether you are using Python 3.7 or not, you will need to change calling code to use `asynk` instead of `async`.
+
 ### 0.11.0
 - `Worker` now periodically sends heartbeats and checks whether child process is still alive while performing long running jobs. Thanks @Kriechi!
 - `Job.create` now accepts `timeout` in string format (e.g `1h`). Thanks @theodesp!

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -168,10 +168,10 @@ print job.result
 
 For testing purposes, you can enqueue jobs without delegating the actual
 execution to a worker (available since version 0.3.1). To do this, pass the
-`async=False` argument into the Queue constructor:
+`asynk=False` argument into the Queue constructor:
 
 {% highlight pycon %}
->>> q = Queue('low', async=False, connection=my_redis_conn)
+>>> q = Queue('low', asynk=False, connection=my_redis_conn)
 >>> job = q.enqueue(fib, 8)
 >>> job.result
 21

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -23,7 +23,7 @@ worker.work(burst=True)  # Runs enqueued job
 
 ## Running Jobs in unit tests
 
-Another solution for testing purposes is to use the `async=False` queue
+Another solution for testing purposes is to use the `asynk=False` queue
 parameter, that instructs it to instantly perform the job in the same
 thread instead of dispatching it to the workers. Workers are not required 
 anymore.
@@ -35,7 +35,7 @@ be directly passed as the connection argument to the queue:
 from fakeredis import FakeStrictRedis
 from rq import Queue
 
-queue = Queue(async=False, connection=FakeStrictRedis())
+queue = Queue(asynk=False, connection=FakeStrictRedis())
 job = queue.enqueue(my_long_running_job)
 assert job.is_finished
 {% endhighlight %}

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -58,13 +58,13 @@ class Queue(object):
         return cls(name, connection=connection, job_class=job_class)
 
     def __init__(self, name='default', default_timeout=None, connection=None,
-                 async=True, job_class=None):
+                 asynk=True, job_class=None):
         self.connection = resolve_connection(connection)
         prefix = self.redis_queue_namespace_prefix
         self.name = name
         self._key = '{0}{1}'.format(prefix, name)
         self._default_timeout = parse_timeout(default_timeout)
-        self._async = async
+        self._asynk = asynk
 
         # override class attribute job_class if one was passed
         if job_class is not None:
@@ -303,7 +303,7 @@ class Queue(object):
     def enqueue_job(self, job, pipeline=None, at_front=False):
         """Enqueues a job for delayed execution.
 
-        If Queue is instantiated with async=False, job is executed immediately.
+        If Queue is instantiated with asynk=False, job is executed immediately.
         """
         pipe = pipeline if pipeline is not None else self.connection._pipeline()
 
@@ -319,13 +319,13 @@ class Queue(object):
         job.save(pipeline=pipe)
         job.cleanup(ttl=job.ttl, pipeline=pipe)
 
-        if self._async:
+        if self._asynk:
             self.push_job_id(job.id, pipeline=pipe, at_front=at_front)
 
         if pipeline is None:
             pipe.execute()
 
-        if not self._async:
+        if not self._asynk:
             job = self.run_job(job)
 
         return job

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Internet',
         'Topic :: Scientific/Engineering',

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -389,17 +389,17 @@ class TestJob(RQTestCase):
         assert get_failed_queue(self.testconn).count == 0
 
     def test_job_access_within_synchronous_job_function(self):
-        queue = Queue(async=False)
+        queue = Queue(asynk=False)
         queue.enqueue(fixtures.access_self)
 
     def test_job_async_status_finished(self):
-        queue = Queue(async=False)
+        queue = Queue(asynk=False)
         job = queue.enqueue(fixtures.say_hello)
         self.assertEqual(job.result, 'Hi there, Stranger!')
         self.assertEqual(job.get_status(), JobStatus.FINISHED)
 
     def test_enqueue_job_async_status_finished(self):
-        queue = Queue(async=False)
+        queue = Queue(asynk=False)
         job = Job.create(func=fixtures.say_hello)
         job = queue.enqueue_job(job)
         self.assertEqual(job.result, 'Hi there, Stranger!')

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -646,7 +646,7 @@ class TestFailedQueue(RQTestCase):
 
     def test_async_false(self):
         """Job executes and cleaned up immediately if async=False."""
-        q = Queue(async=False)
+        q = Queue(asynk=False)
         job = q.enqueue(some_calculation, args=(2, 3))
         self.assertEqual(job.return_value, 6)
         self.assertNotEqual(self.testconn.ttl(job.key), -1)


### PR DESCRIPTION
The name `async` is not allowed in Python 3.7.

Fixes https://github.com/rq/rq/issues/921