### PR TITLE
Make Python 3.7 compatibility and keep backward compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.6-dev"
+  - "3.7-dev"
   - "pypy"
 install:
   - pip install -e .

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -168,10 +168,10 @@ print job.result
 
 For testing purposes, you can enqueue jobs without delegating the actual
 execution to a worker (available since version 0.3.1). To do this, pass the
-`async=False` argument into the Queue constructor:
+`sync=True` argument into the Queue constructor:
 
 {% highlight pycon %}
->>> q = Queue('low', async=False, connection=my_redis_conn)
+>>> q = Queue('low', sync=True, connection=my_redis_conn)
 >>> job = q.enqueue(fib, 8)
 >>> job.result
 21

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -168,10 +168,10 @@ print job.result
 
 For testing purposes, you can enqueue jobs without delegating the actual
 execution to a worker (available since version 0.3.1). To do this, pass the
-`sync=True` argument into the Queue constructor:
+`asynchronous=False` argument into the Queue constructor:
 
 {% highlight pycon %}
->>> q = Queue('low', sync=True, connection=my_redis_conn)
+>>> q = Queue('low', asynchronous=False, connection=my_redis_conn)
 >>> job = q.enqueue(fib, 8)
 >>> job.result
 21

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -23,7 +23,7 @@ worker.work(burst=True)  # Runs enqueued job
 
 ## Running Jobs in unit tests
 
-Another solution for testing purposes is to use the `sync=True` queue
+Another solution for testing purposes is to use the `asynchronous=False` queue
 parameter, that instructs it to instantly perform the job in the same
 thread instead of dispatching it to the workers. Workers are not required 
 anymore.
@@ -35,7 +35,7 @@ be directly passed as the connection argument to the queue:
 from fakeredis import FakeStrictRedis
 from rq import Queue
 
-queue = Queue(sync=True, connection=FakeStrictRedis())
+queue = Queue(asynchronous=False, connection=FakeStrictRedis())
 job = queue.enqueue(my_long_running_job)
 assert job.is_finished
 {% endhighlight %}

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -23,7 +23,7 @@ worker.work(burst=True)  # Runs enqueued job
 
 ## Running Jobs in unit tests
 
-Another solution for testing purposes is to use the `async=False` queue
+Another solution for testing purposes is to use the `sync=True` queue
 parameter, that instructs it to instantly perform the job in the same
 thread instead of dispatching it to the workers. Workers are not required 
 anymore.
@@ -35,7 +35,7 @@ be directly passed as the connection argument to the queue:
 from fakeredis import FakeStrictRedis
 from rq import Queue
 
-queue = Queue(async=False, connection=FakeStrictRedis())
+queue = Queue(sync=True, connection=FakeStrictRedis())
 job = queue.enqueue(my_long_running_job)
 assert job.is_finished
 {% endhighlight %}

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import uuid
+import warnings
 
 from redis import WatchError
 
@@ -66,6 +67,7 @@ class Queue(object):
         self._default_timeout = parse_timeout(default_timeout)
         if 'async' in kwargs:
             self._async = kwargs['async']
+            warnings.warn('`async` keyword is deprecated. Use sync', DeprecationWarning)
         else:
             self._async = not sync
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -58,13 +58,16 @@ class Queue(object):
         return cls(name, connection=connection, job_class=job_class)
 
     def __init__(self, name='default', default_timeout=None, connection=None,
-                 async=True, job_class=None):
+                 sync=False, job_class=None, **kwargs):
         self.connection = resolve_connection(connection)
         prefix = self.redis_queue_namespace_prefix
         self.name = name
         self._key = '{0}{1}'.format(prefix, name)
         self._default_timeout = parse_timeout(default_timeout)
-        self._async = async
+        if 'async' in kwargs:
+            self._async = kwargs['async']
+        else:
+            self._async = not sync
 
         # override class attribute job_class if one was passed
         if job_class is not None:

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Internet',
         'Topic :: Scientific/Engineering',

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -389,17 +389,17 @@ class TestJob(RQTestCase):
         assert get_failed_queue(self.testconn).count == 0
 
     def test_job_access_within_synchronous_job_function(self):
-        queue = Queue(**{'async': False})
+        queue = Queue(sync=True)
         queue.enqueue(fixtures.access_self)
 
     def test_job_async_status_finished(self):
-        queue = Queue(**{'async': False})
+        queue = Queue(sync=True)
         job = queue.enqueue(fixtures.say_hello)
         self.assertEqual(job.result, 'Hi there, Stranger!')
         self.assertEqual(job.get_status(), JobStatus.FINISHED)
 
     def test_enqueue_job_async_status_finished(self):
-        queue = Queue(**{'async': False})
+        queue = Queue(sync=True)
         job = Job.create(func=fixtures.say_hello)
         job = queue.enqueue_job(job)
         self.assertEqual(job.result, 'Hi there, Stranger!')

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -389,17 +389,17 @@ class TestJob(RQTestCase):
         assert get_failed_queue(self.testconn).count == 0
 
     def test_job_access_within_synchronous_job_function(self):
-        queue = Queue(async=False)
+        queue = Queue(**{'async': False})
         queue.enqueue(fixtures.access_self)
 
     def test_job_async_status_finished(self):
-        queue = Queue(async=False)
+        queue = Queue(**{'async': False})
         job = queue.enqueue(fixtures.say_hello)
         self.assertEqual(job.result, 'Hi there, Stranger!')
         self.assertEqual(job.get_status(), JobStatus.FINISHED)
 
     def test_enqueue_job_async_status_finished(self):
-        queue = Queue(async=False)
+        queue = Queue(**{'async': False})
         job = Job.create(func=fixtures.say_hello)
         job = queue.enqueue_job(job)
         self.assertEqual(job.result, 'Hi there, Stranger!')

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -389,17 +389,17 @@ class TestJob(RQTestCase):
         assert get_failed_queue(self.testconn).count == 0
 
     def test_job_access_within_synchronous_job_function(self):
-        queue = Queue(sync=True)
+        queue = Queue(asynchronous=False)
         queue.enqueue(fixtures.access_self)
 
     def test_job_async_status_finished(self):
-        queue = Queue(sync=True)
+        queue = Queue(asynchronous=False)
         job = queue.enqueue(fixtures.say_hello)
         self.assertEqual(job.result, 'Hi there, Stranger!')
         self.assertEqual(job.get_status(), JobStatus.FINISHED)
 
     def test_enqueue_job_async_status_finished(self):
-        queue = Queue(sync=True)
+        queue = Queue(asynchronous=False)
         job = Job.create(func=fixtures.say_hello)
         job = queue.enqueue_job(job)
         self.assertEqual(job.result, 'Hi there, Stranger!')

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -646,7 +646,7 @@ class TestFailedQueue(RQTestCase):
 
     def test_async_false(self):
         """Job executes and cleaned up immediately if async=False."""
-        q = Queue(async=False)
+        q = Queue(**{'async': False})
         job = q.enqueue(some_calculation, args=(2, 3))
         self.assertEqual(job.return_value, 6)
         self.assertNotEqual(self.testconn.ttl(job.key), -1)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -645,8 +645,8 @@ class TestFailedQueue(RQTestCase):
         self.assertEqual(int(job_from_queue.result_ttl), 10)
 
     def test_async_false(self):
-        """Job executes and cleaned up immediately if async=False."""
-        q = Queue(**{'async': False})
+        """Job executes and cleaned up immediately if sync=True."""
+        q = Queue(sync=True)
         job = q.enqueue(some_calculation, args=(2, 3))
         self.assertEqual(job.return_value, 6)
         self.assertNotEqual(self.testconn.ttl(job.key), -1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,py35,pypy,flake8
+envlist=py26,py27,py33,py34,py35,py36,py37,pypy,flake8
 
 [testenv]
 commands=py.test --cov rq --durations=5 {posargs}


### PR DESCRIPTION
- Close: https://github.com/rq/rq/issues/972
- Keep async keyword for older Python by using ** keyword arguments.
  - Thanks to https://github.com/rq/rq/issues/921#issuecomment-358096956
- Add sync keyword argument that means the inverse of async.