### PR TITLE
Replace 'async' keyword with 'is_async' for Queue objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.6-dev"
+  - "3.7-dev"
   - "pypy"
 install:
   - pip install -e .

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -65,7 +65,7 @@ job function.
     and marked as `failed`. Its default unit is second and it can be an integer or a string representing an integer(e.g.  `2`, `'2'`). Furthermore, it can be a string with specify unit including hour, minute, second(e.g. `'1h'`, `'3m'`, `'5s'`).
 * `result_ttl` specifies the expiry time of the key where the job result will
   be stored
-* `ttl` specifies the maximum queued time of the job before it'll be cancelled. 
+* `ttl` specifies the maximum queued time of the job before it'll be cancelled.
   If you specify a value of `-1` you indicate an infinite job ttl and it will run indefinitely
 * `depends_on` specifies another job (or job id) that must complete before this
   job will be queued
@@ -104,7 +104,7 @@ from rq import Queue
 from redis import Redis
 
 redis_conn = Redis()
-q = Queue(connection=redis_conn) 
+q = Queue(connection=redis_conn)
 
 # Getting the number of jobs in the queue
 print len(q)
@@ -168,10 +168,10 @@ print job.result
 
 For testing purposes, you can enqueue jobs without delegating the actual
 execution to a worker (available since version 0.3.1). To do this, pass the
-`async=False` argument into the Queue constructor:
+`is_async=False` argument into the Queue constructor:
 
 {% highlight pycon %}
->>> q = Queue('low', async=False, connection=my_redis_conn)
+>>> q = Queue('low', is_async=False, connection=my_redis_conn)
 >>> job = q.enqueue(fib, 8)
 >>> job.result
 21

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Workers inside unit tests
 
-You may wish to include your RQ tasks inside unit tests. However many frameworks (such as Django) use in-memory databases which do not play nicely with the default `fork()` behaviour of RQ. 
+You may wish to include your RQ tasks inside unit tests. However many frameworks (such as Django) use in-memory databases which do not play nicely with the default `fork()` behaviour of RQ.
 
 Therefore, you must use the SimpleWorker class to avoid fork();
 
@@ -23,19 +23,19 @@ worker.work(burst=True)  # Runs enqueued job
 
 ## Running Jobs in unit tests
 
-Another solution for testing purposes is to use the `async=False` queue
+Another solution for testing purposes is to use the `is_async=False` queue
 parameter, that instructs it to instantly perform the job in the same
-thread instead of dispatching it to the workers. Workers are not required 
+thread instead of dispatching it to the workers. Workers are not required
 anymore.
 Additionally, we can use fakeredis to mock a redis instance, so we don't have to
-run a redis server separately. The instance of the fake redis server can 
+run a redis server separately. The instance of the fake redis server can
 be directly passed as the connection argument to the queue:
 
 {% highlight python %}
 from fakeredis import FakeStrictRedis
 from rq import Queue
 
-queue = Queue(async=False, connection=FakeStrictRedis())
+queue = Queue(is_async=False, connection=FakeStrictRedis())
 job = queue.enqueue(my_long_running_job)
 assert job.is_finished
 {% endhighlight %}

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Internet',
         'Topic :: Scientific/Engineering',

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -389,17 +389,17 @@ class TestJob(RQTestCase):
         assert get_failed_queue(self.testconn).count == 0
 
     def test_job_access_within_synchronous_job_function(self):
-        queue = Queue(async=False)
+        queue = Queue(is_async=False)
         queue.enqueue(fixtures.access_self)
 
     def test_job_async_status_finished(self):
-        queue = Queue(async=False)
+        queue = Queue(is_async=False)
         job = queue.enqueue(fixtures.say_hello)
         self.assertEqual(job.result, 'Hi there, Stranger!')
         self.assertEqual(job.get_status(), JobStatus.FINISHED)
 
     def test_enqueue_job_async_status_finished(self):
-        queue = Queue(async=False)
+        queue = Queue(is_async=False)
         job = Job.create(func=fixtures.say_hello)
         job = queue.enqueue_job(job)
         self.assertEqual(job.result, 'Hi there, Stranger!')

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -645,8 +645,8 @@ class TestFailedQueue(RQTestCase):
         self.assertEqual(int(job_from_queue.result_ttl), 10)
 
     def test_async_false(self):
-        """Job executes and cleaned up immediately if async=False."""
-        q = Queue(async=False)
+        """Job executes and cleaned up immediately if is_async=False."""
+        q = Queue(is_async=False)
         job = q.enqueue(some_calculation, args=(2, 3))
         self.assertEqual(job.return_value, 6)
         self.assertNotEqual(self.testconn.ttl(job.key), -1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,py34,py35,pypy,flake8
+envlist=py26,py27,py33,py34,py35,py36,py37,pypy,flake8
 
 [testenv]
 commands=py.test --cov rq --durations=5 {posargs}


### PR DESCRIPTION
This PR provides Python 3.7 compatibility by changing the Queue object's `async` keyword to `is_async`. For backwards compatibility, `**kwargs` is checked for the `async` keyword and will continue to work, but will raise a warning.

All tests and documentation references are updated to use `is_async` instead of `async`.

Some other PR's are suggesting reversing the keyword (i.e. `sync`) which will break any code that uses ordered keywords rather than named keywords, so this PR is intended to provide a safer alternative.