### PR TITLE
add is_async property to queue

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -130,6 +130,11 @@ class Queue(object):
         """Returns whether the current queue is empty."""
         return self.count == 0
 
+    @property
+    def is_async(self):
+        """Returns whether the current queue is async."""
+        return bool(self._is_async)
+
     def fetch_job(self, job_id):
         try:
             job = self.job_class.fetch(job_id, connection=self.connection)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -651,6 +651,13 @@ class TestFailedQueue(RQTestCase):
         self.assertEqual(job.return_value, 6)
         self.assertNotEqual(self.testconn.ttl(job.key), -1)
 
+    def test_is_async(self):
+        """Queue exposes is_async as a property."""
+        inline_queue = Queue(is_async=False)
+        self.assertFalse(inline_queue.is_async)
+        async_queue = Queue(is_async=True)
+        self.assertTrue(async_queue.is_async)
+
     def test_custom_job_class(self):
         """Ensure custom job class assignment works as expected."""
         q = Queue(job_class=CustomJob)


### PR DESCRIPTION
When creating a queue we are allowed to specify if its async or not, but there is no way to know if a current queue instance is async or not without knowing the internals of the code.

This just exposes that setting as a property on the queue.