### PR TITLE
Update docs to use print function vs print statement

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -38,11 +38,11 @@ q = Queue(connection=redis_conn)  # no args implies the default queue
 
 # Delay execution of count_words_at_url('http://nvie.com')
 job = q.enqueue(count_words_at_url, 'http://nvie.com')
-print job.result   # => None
+print(job.result)   # => None
 
 # Now, wait a while, until the worker is finished
 time.sleep(2)
-print job.result   # => 889
+print(job.result)   # => 889
 {% endhighlight %}
 
 If you want to put the work on a specific queue, simply specify its name:
@@ -107,7 +107,7 @@ redis_conn = Redis()
 q = Queue(connection=redis_conn)
 
 # Getting the number of jobs in the queue
-print len(q)
+print(len(q))
 
 # Retrieving jobs
 queued_job_ids = q.job_ids # Gets a list of job IDs from the queue
@@ -160,7 +160,7 @@ def add(x, y):
 
 job = add.delay(3, 4)
 time.sleep(1)
-print job.result
+print(job.result)
 {% endhighlight %}
 
 

--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -20,7 +20,7 @@ from rq import get_current_job
 
 def add(x, y):
     job = get_current_job()
-    print 'Current job: %s' % (job.id,)
+    print('Current job: %s' % (job.id,))
     return x + y
 {% endhighlight %}
 
@@ -40,7 +40,7 @@ def add(x, y):
     job = get_current_job()
     job.meta['handled_by'] = socket.gethostname()
     job.save_meta()
-    
+
     # do more work
     time.sleep(1)
     return x + y
@@ -65,8 +65,8 @@ job = q.enqueue(count_words_at_url, 'http://nvie.com', ttl=43)
 
 ## Failed Jobs
 
-If a job fails and raises an exception, the worker will put the job in a failed job queue. 
-On the Job instance, the `is_failed` property will be true. To fetch all failed jobs, scan 
+If a job fails and raises an exception, the worker will put the job in a failed job queue.
+On the Job instance, the `is_failed` property will be true. To fetch all failed jobs, scan
 through the `get_failed_queue()` queue.
 
 {% highlight python %}


### PR DESCRIPTION
I was working my way through the documentation and had to change a few print statements to print functions for the examples to run in Python 3.

As most new projects begin with Python 3, I thought it would be a good idea to update the examples in the documentation.

Please let me know if I missed anything. Thanks!