### PR TITLE
Update/add flag for description logging

### DIFF
--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -63,7 +63,7 @@ In addition to `--burst`, `rq worker` also accepts these arguments:
 * `--connection-class`: Redis connection class to use, defaults to `redis.StrictRedis`.
 * `--log-format`: Format for the worker logs, defaults to `'%(asctime)s %(message)s'`
 * `--date-format`: Datetime format for the worker logs, defaults to `'%H:%M:%S'`
-* `--log_job_description`: Toggle logging of a job description, defaults to True.
+* `--disable-job-desc-logging`: Toggle logging of a job description, defaults to True.
 
 ## Inside the worker
 

--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -63,7 +63,7 @@ In addition to `--burst`, `rq worker` also accepts these arguments:
 * `--connection-class`: Redis connection class to use, defaults to `redis.StrictRedis`.
 * `--log-format`: Format for the worker logs, defaults to `'%(asctime)s %(message)s'`
 * `--date-format`: Datetime format for the worker logs, defaults to `'%H:%M:%S'`
-
+* `--log_job_description`: Toggle logging of a job description, defaults to True.
 
 ## Inside the worker
 

--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -63,7 +63,7 @@ In addition to `--burst`, `rq worker` also accepts these arguments:
 * `--connection-class`: Redis connection class to use, defaults to `redis.StrictRedis`.
 * `--log-format`: Format for the worker logs, defaults to `'%(asctime)s %(message)s'`
 * `--date-format`: Datetime format for the worker logs, defaults to `'%H:%M:%S'`
-* `--disable-job-desc-logging`: Toggle logging of a job description, defaults to True.
+* `--disable-job-desc-logging`: Turn off job description logging.
 
 ## Inside the worker
 

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -180,7 +180,7 @@ def info(cli_config, interval, raw, only_queues, only_workers, by_queue, queues,
 @click.option('--results-ttl', type=int, default=DEFAULT_RESULT_TTL , help='Default results timeout to be used')
 @click.option('--worker-ttl', type=int, default=DEFAULT_WORKER_TTL , help='Default worker timeout to be used')
 @click.option('--job-monitoring-interval', type=int, default=DEFAULT_JOB_MONITORING_INTERVAL , help='Default job monitoring interval to be used')
-@click.option('--log_job_description', is_flag=True, help='Toggle description logging in worker.')
+@click.option('--disable-job-desc-logging', is_flag=True, help='Toggle description logging in worker.')
 @click.option('--verbose', '-v', is_flag=True, help='Show more output')
 @click.option('--quiet', '-q', is_flag=True, help='Show less output')
 @click.option('--sentry-dsn', envvar='SENTRY_DSN', help='Report exceptions to this Sentry DSN')

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -180,7 +180,7 @@ def info(cli_config, interval, raw, only_queues, only_workers, by_queue, queues,
 @click.option('--results-ttl', type=int, default=DEFAULT_RESULT_TTL , help='Default results timeout to be used')
 @click.option('--worker-ttl', type=int, default=DEFAULT_WORKER_TTL , help='Default worker timeout to be used')
 @click.option('--job-monitoring-interval', type=int, default=DEFAULT_JOB_MONITORING_INTERVAL , help='Default job monitoring interval to be used')
-@click.option('--disable-job-desc-logging', is_flag=True, help='Toggle description logging in worker.')
+@click.option('--disable-job-desc-logging', is_flag=True, help='Turn off description logging.')
 @click.option('--verbose', '-v', is_flag=True, help='Show more output')
 @click.option('--quiet', '-q', is_flag=True, help='Show less output')
 @click.option('--sentry-dsn', envvar='SENTRY_DSN', help='Report exceptions to this Sentry DSN')

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -180,6 +180,7 @@ def info(cli_config, interval, raw, only_queues, only_workers, by_queue, queues,
 @click.option('--results-ttl', type=int, default=DEFAULT_RESULT_TTL , help='Default results timeout to be used')
 @click.option('--worker-ttl', type=int, default=DEFAULT_WORKER_TTL , help='Default worker timeout to be used')
 @click.option('--job-monitoring-interval', type=int, default=DEFAULT_JOB_MONITORING_INTERVAL , help='Default job monitoring interval to be used')
+@click.option('--log_job_description', is_flag=True, help='Toggle description logging in worker.')
 @click.option('--verbose', '-v', is_flag=True, help='Show more output')
 @click.option('--quiet', '-q', is_flag=True, help='Show less output')
 @click.option('--sentry-dsn', envvar='SENTRY_DSN', help='Report exceptions to this Sentry DSN')

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -526,7 +526,8 @@ class Worker(object):
                     job, queue = result
                     if self.log_job_description:
                         self.log.info('{0}: {1} ({2})'.format(green(queue.name),
-                                                              blue(job.description), job.id))
+                                                              blue(job.description),
+                                                              job.id))
                     else:
                         self.log.info('{0}:{1}'.format(green(queue.name),
                                                        job.id))

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -162,7 +162,8 @@ class Worker(object):
                  connection=None, exc_handler=None, exception_handlers=None,
                  default_worker_ttl=DEFAULT_WORKER_TTL, job_class=None,
                  queue_class=None,
-                 job_monitoring_interval=DEFAULT_JOB_MONITORING_INTERVAL):  # noqa
+                 job_monitoring_interval=DEFAULT_JOB_MONITORING_INTERVAL,
+                 log_job_description=True):  # noqa
         if connection is None:
             connection = get_current_connection()
         self.connection = connection
@@ -189,6 +190,7 @@ class Worker(object):
         self._horse_pid = 0
         self._stop_requested = False
         self.log = logger
+        self.log_job_description = log_job_description
         self.failed_queue = get_failed_queue(connection=self.connection,
                                              job_class=self.job_class)
         self.last_cleaned_at = None

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -100,6 +100,8 @@ class Worker(object):
     # `log_result_lifespan` controls whether "Result is kept for XXX seconds"
     # messages are logged after every job, by default they are.
     log_result_lifespan = True
+    # `log_job_description` is used to toggle logging an entire jobs description.
+    log_job_description = True
 
     @classmethod
     def all(cls, connection=None, job_class=None, queue_class=None, queue=None):
@@ -520,9 +522,14 @@ class Worker(object):
                                                       connection=self.connection,
                                                       job_class=self.job_class)
                 if result is not None:
+
                     job, queue = result
-                    self.log.info('{0}: {1} ({2})'.format(green(queue.name),
-                                                          blue(job.description), job.id))
+                    if self.log_job_description:
+                        self.log.info('{0}: {1} ({2})'.format(green(queue.name),
+                                                              blue(job.description), job.id))
+                    else:
+                        self.log.info('{0}:{1}'.format(green(queue.name),
+                                                       job.id))
 
                 break
             except DequeueTimeout:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -816,11 +816,7 @@ class TestWorker(RQTestCase):
     def test_log_job_description_false(self, mock_logger_info):
         """Check that log_job_description False causes job lifespan to not be logged."""
         q = Queue()
-
-        class TestWorker(Worker):
-            log_job_description = False
-
-        w = TestWorker([q])
+        w = Worker([q], log_job_description=False)
         job = q.enqueue(say_hello, args=('Frank',), result_ttl=10)
         w.dequeue_job_and_maintain_ttl(10)
         self.assertNotIn("Frank", mock_logger_info.call_args[0][0])


### PR DESCRIPTION
Add ability to disable logging of all job descriptions.

I've often found that job descriptions in this case contain sensitive information, or simply are verbose and not something we want to be filling up our logs with.

This is a pretty simple solution to that, with some tests.