### PR TITLE
Fix collections abc import deprecation warning.

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -14,7 +14,7 @@ import importlib
 import logging
 import numbers
 import sys
-from collections import Iterable
+from collections.abc import Iterable
 
 from .compat import as_text, is_python_version, string_types
 from .exceptions import TimeoutFormatError

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -14,7 +14,10 @@ import importlib
 import logging
 import numbers
 import sys
-from collections.abc import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from .compat import as_text, is_python_version, string_types
 from .exceptions import TimeoutFormatError


### PR DESCRIPTION
Prepare for 3.8 when it is deprecated.