### PR TITLE
Fix usage example of queue.enqueue()

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -83,7 +83,7 @@ to your job and not to RQ's enqueue function, this is what you do:
 
 ```python
 q = Queue('low', connection=redis_conn)
-q.enqueue(f=count_words_at_url,
+q.enqueue(count_words_at_url,
           ttl=30,  # This ttl will be used by RQ
           args=('http://nvie.com',),
           kwargs={

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -83,7 +83,7 @@ to your job and not to RQ's enqueue function, this is what you do:
 
 ```python
 q = Queue('low', connection=redis_conn)
-q.enqueue(func=count_words_at_url,
+q.enqueue(f=count_words_at_url,
           ttl=30,  # This ttl will be used by RQ
           args=('http://nvie.com',),
           kwargs={


### PR DESCRIPTION
queue.enqueue() has arg `f`, not `func` (like enqueue_call).