### PR TITLE
Fix docs on job attributes

### DIFF
--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -23,7 +23,7 @@ print('Status: %s' $ job.get_status())
 ```
 
 Some interesting job attributes include:
-* `job.status`
+* `job.get_status()`
 * `job.func_name`
 * `job.args`
 * `job.kwargs`


### PR DESCRIPTION
Job objects no longer have `.status` attribute - correct docs to use the `.get_status()` function.