### PR TITLE
Fix timeout adding job to StartedJobRegistry

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -699,7 +699,10 @@ class Worker(object):
         """Performs misc bookkeeping like updating states prior to
         job execution.
         """
-        timeout = (job.timeout or 180) + 60
+        if job.timeout < 0:
+          timeout = job.timeout
+        else:
+          timeout = (job.timeout or 180) + 60
 
         if heartbeat_ttl is None:
             heartbeat_ttl = self.job_monitoring_interval + 5

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -699,8 +699,10 @@ class Worker(object):
         """Performs misc bookkeeping like updating states prior to
         job execution.
         """
-        base_timeout = job.timeout or 180
-        timeout = base_timeout + 60 if base_timeout > 0 else base_timeout
+        if job.timeout == -1:
+            timeout = -1
+        else:
+            timeout = job.timeout or 180
 
         if heartbeat_ttl is None:
             heartbeat_ttl = self.job_monitoring_interval + 5

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -699,10 +699,8 @@ class Worker(object):
         """Performs misc bookkeeping like updating states prior to
         job execution.
         """
-        if job.timeout < 0:
-          timeout = job.timeout
-        else:
-          timeout = (job.timeout or 180) + 60
+        base_timeout = job.timeout or 180
+        timeout = base_timeout + 60 if base_timeout > 0 else base_timeout
 
         if heartbeat_ttl is None:
             heartbeat_ttl = self.job_monitoring_interval + 5


### PR DESCRIPTION
See issue #1085 

Fixed by adding a check for negative `job.timeout` value before adding the job to the `StartedJobRegistry`.