### PR TITLE
add the ability to have the worker stop executing after a max amount of jobs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- Added `max_jobs` to `Worker.work` and `--max-jobs` to `rq worker` CLI.
+
 ### 1.0 (2019-04-06)
 Backward incompatible changes:
 

--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -68,6 +68,7 @@ In addition to `--burst`, `rq worker` also accepts these arguments:
 * `--log-format`: Format for the worker logs, defaults to `'%(asctime)s %(message)s'`
 * `--date-format`: Datetime format for the worker logs, defaults to `'%H:%M:%S'`
 * `--disable-job-desc-logging`: Turn off job description logging.
+* `--max-jobs`: Maximum number of jobs to execute.
 
 ## Inside the worker
 

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -188,12 +188,13 @@ def info(cli_config, interval, raw, only_queues, only_workers, by_queue, queues,
 @click.option('--exception-handler', help='Exception handler(s) to use', multiple=True)
 @click.option('--pid', help='Write the process ID number to a file at the specified path')
 @click.option('--disable-default-exception-handler', '-d', is_flag=True, help='Disable RQ\'s default exception handler')
+@click.option('--job-limit', type=int, default=None, help='Maximum number of jobs to execute')
 @click.argument('queues', nargs=-1)
 @pass_cli_config
 def worker(cli_config, burst, logging_level, name, results_ttl,
            worker_ttl, job_monitoring_interval, verbose, quiet, sentry_dsn,
-           exception_handler, pid, disable_default_exception_handler, queues,
-           log_format, date_format, **options):
+           exception_handler, pid, disable_default_exception_handler,
+           job_limit, queues, log_format, date_format, **options):
     """Starts an RQ worker."""
     settings = read_config_file(cli_config.config) if cli_config.config else {}
     # Worker specific default arguments
@@ -236,7 +237,7 @@ def worker(cli_config, burst, logging_level, name, results_ttl,
             from rq.contrib.sentry import register_sentry
             register_sentry(sentry_dsn)
 
-        worker.work(burst=burst, logging_level=logging_level, date_format=date_format, log_format=log_format)
+        worker.work(burst=burst, logging_level=logging_level, date_format=date_format, log_format=log_format, job_limit=job_limit)
     except ConnectionError as e:
         print(e)
         sys.exit(1)

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -188,12 +188,12 @@ def info(cli_config, interval, raw, only_queues, only_workers, by_queue, queues,
 @click.option('--exception-handler', help='Exception handler(s) to use', multiple=True)
 @click.option('--pid', help='Write the process ID number to a file at the specified path')
 @click.option('--disable-default-exception-handler', '-d', is_flag=True, help='Disable RQ\'s default exception handler')
-@click.option('--job-limit', type=int, default=None, help='Maximum number of jobs to execute')
+@click.option('--max-jobs', type=int, default=None, help='Maximum number of jobs to execute')
 @click.argument('queues', nargs=-1)
 @pass_cli_config
 def worker(cli_config, burst, logging_level, name, results_ttl,
            worker_ttl, job_monitoring_interval, disable_job_desc_logging, verbose, quiet, sentry_dsn,
-           exception_handler, pid, disable_default_exception_handler, job_limit, queues,
+           exception_handler, pid, disable_default_exception_handler, max_jobs, queues,
            log_format, date_format, **options):
     """Starts an RQ worker."""
     settings = read_config_file(cli_config.config) if cli_config.config else {}
@@ -238,7 +238,7 @@ def worker(cli_config, burst, logging_level, name, results_ttl,
             from rq.contrib.sentry import register_sentry
             register_sentry(sentry_dsn)
 
-        worker.work(burst=burst, logging_level=logging_level, date_format=date_format, log_format=log_format, job_limit=job_limit)
+        worker.work(burst=burst, logging_level=logging_level, date_format=date_format, log_format=log_format, max_jobs=max_jobs)
     except ConnectionError as e:
         print(e)
         sys.exit(1)

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -435,7 +435,7 @@ class Worker(object):
             self.set_state(before_state)
 
     def work(self, burst=False, logging_level="INFO", date_format=DEFAULT_LOGGING_DATE_FORMAT,
-             log_format=DEFAULT_LOGGING_FORMAT, job_limit=None):
+             log_format=DEFAULT_LOGGING_FORMAT, max_jobs=None):
         """Starts the work loop.
 
         Pops and performs all jobs on the current list of queues.  When all
@@ -478,8 +478,8 @@ class Worker(object):
                     self.heartbeat()
 
                     completed_jobs += 1
-                    if job_limit is not None:
-                        if completed_jobs >= job_limit:
+                    if max_jobs is not None:
+                        if completed_jobs >= max_jobs:
                             self.log.info("RQ worker %r done, quitting", self.key)
                             break
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -480,7 +480,10 @@ class Worker(object):
                     completed_jobs += 1
                     if max_jobs is not None:
                         if completed_jobs >= max_jobs:
-                            self.log.info("RQ worker %r done, quitting", self.key)
+                            self.log.info(
+                                "RQ Worker %r finished executing %d jobs, quitting",
+                                self.key, completed_jobs
+                            )
                             break
 
                 except StopRequested:
@@ -492,8 +495,8 @@ class Worker(object):
 
                 except:  # noqa
                     self.log.error(
-                        'Worker %s: found an unhandled exception, quitting...',
-                        self.name, exc_info=True
+                        'RQ Worker %r: found an unhandled exception, quitting...',
+                        self.key, exc_info=True
                     )
                     break
         finally:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -340,13 +340,13 @@ class TestWorker(RQTestCase):
         # total_working_time should be around 0.05 seconds
         self.assertTrue(0.05 <= worker.total_working_time < 0.06)
 
-    def test_job_limit(self):
+    def test_max_jobs(self):
         """Worker exits after number of jobs complete."""
         queue = Queue()
         job1 = queue.enqueue(do_nothing)
         job2 = queue.enqueue(do_nothing)
         worker = Worker([queue])
-        worker.work(job_limit=1)
+        worker.work(max_jobs=1)
 
         self.assertEqual(JobStatus.FINISHED, job1.get_status())
         self.assertEqual(JobStatus.QUEUED, job2.get_status())


### PR DESCRIPTION
This adds the ability to the worker to gracefully exit after a maximum number of jobs have been processed. The behaviour is similar to `--burst` except instead of processing until all queues are empty, it will exit after the limit is reached.

This will be useful in situations where the queue is known to be busy for a long time and you want to stop part way through, push our a deploy of your application, and then have the worker start up again with the updated job code.

Let me know if you would prefer different naming or coding conventions.