### PR TITLE
Fix #469 - shutdown worker if it has become orphaned

### DIFF
--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -18,6 +18,8 @@ class InvalidJobOperationError(Exception):
 class InvalidJobOperation(Exception):
     pass
 
+class OrphanedWorkerError(Exception):
+    pass
 
 class UnpickleError(Exception):
     def __init__(self, message, raw_data, inner_exception=None):


### PR DESCRIPTION
This forces a worker to quit if the corresponding worker key has been removed or expired. Otherwise the worker continues to execute jobs but in a broken state (e.g. worker key is empty save for `last_heartbeat`).

Tests do not pass at this stage. Haven't looked closely.