### PR TITLE
docs/jobs: Fix minor typo

### DIFF
--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -19,7 +19,7 @@ from rq.job import Job
 
 redis = Redis()
 job = Job.fetch('my_job_id', connection=redis)
-print('Status: %s' $ job.get_status())
+print('Status: %s' % job.get_status())
 ```
 
 Some interesting job attributes include:


### PR DESCRIPTION
Fixes a minor typo in the documentation for jobs.

Thanks for creating and maintaining `rq`!