### PR TITLE
Add failure_ttl on job decorator

### DIFF
--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -17,7 +17,7 @@ class job(object):  # noqa
     def __init__(self, queue, connection=None, timeout=None,
                  result_ttl=DEFAULT_RESULT_TTL, ttl=None,
                  queue_class=None, depends_on=None, at_front=None, meta=None,
-                 description=None):
+                 description=None, failure_ttl=None):
         """A decorator that adds a ``delay`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required
         ``queue`` argument that can be either a ``Queue`` instance or a string
@@ -39,6 +39,7 @@ class job(object):  # noqa
         self.depends_on = depends_on
         self.at_front = at_front
         self.description = description
+        self.failure_ttl = failure_ttl
 
     def __call__(self, f):
         @wraps(f)
@@ -61,6 +62,6 @@ class job(object):  # noqa
             return queue.enqueue_call(f, args=args, kwargs=kwargs,
                                       timeout=self.timeout, result_ttl=self.result_ttl,
                                       ttl=self.ttl, depends_on=depends_on, at_front=at_front,
-                                      meta=self.meta, description=self.description)
+                                      meta=self.meta, description=self.description, failure_ttl=self.failure_ttl)
         f.delay = delay
         return f

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -203,3 +203,17 @@ class TestDecorator(RQTestCase):
 
         custom_queue_job.delay(1, 2)
         self.assertEqual(queue.enqueue_call.call_count, 1)
+
+    def test_decorator_custom_failure_ttl(self):
+        """Ensure that passing in failure_ttl to the decorator sets the
+        failure_ttl on the job
+        """
+        # Ensure default
+        result = decorated_job.delay(1, 2)
+        self.assertEqual(result.failure_ttl, None)
+
+        @job('default', failure_ttl=10)
+        def hello():
+            return 'Why hello'
+        result = hello.delay()
+        self.assertEqual(result.failure_ttl, 10)


### PR DESCRIPTION
Without it you cannot specify custom timeout for failed jobs created using decorator