### PR TITLE
rq: Configurable serializer support

### DIFF
--- a/rq/__init__.py
+++ b/rq/__init__.py
@@ -7,6 +7,7 @@ from .connections import (Connection, get_current_connection, pop_connection,
                           push_connection, use_connection)
 from .job import cancel_job, get_current_job, requeue_job
 from .queue import Queue
+from .utils import configure_serializer
 from .version import VERSION
 from .worker import SimpleWorker, Worker
 

--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -19,10 +19,13 @@ class InvalidJobOperation(Exception):
     pass
 
 
-class UnpickleError(Exception):
+class DeserializationError(Exception):
     def __init__(self, message, raw_data, inner_exception=None):
-        super(UnpickleError, self).__init__(message, inner_exception)
+        super(DeserializationError, self).__init__(message, inner_exception)
         self.raw_data = raw_data
+
+
+UnpickleError = DeserializationError
 
 
 class DequeueTimeout(Exception):

--- a/rq/job.py
+++ b/rq/job.py
@@ -395,7 +395,7 @@ class Job(object):
             rv = self.connection.hget(self.key, 'result')
             if rv is not None:
                 # cache the result
-                self._result = loads(rv)
+                self._result = serializer.loads(rv)
         return self._result
 
     """Backwards-compatibility accessor property `return_value`."""

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -10,8 +10,8 @@ from redis import WatchError
 from .compat import as_text, string_types, total_ordering
 from .connections import resolve_connection
 from .defaults import DEFAULT_RESULT_TTL
-from .exceptions import (DequeueTimeout, InvalidJobDependency, NoSuchJobError,
-                         UnpickleError)
+from .exceptions import (DequeueTimeout, DeserializatonError, InvalidJobDependency,
+                         NoSuchJobError)
 from .job import Job, JobStatus
 from .utils import backend_class, import_attribute, utcnow, parse_timeout
 
@@ -479,7 +479,7 @@ class Queue(object):
                 # Silently pass on jobs that don't exist (anymore),
                 # and continue in the look
                 continue
-            except UnpickleError as e:
+            except DeserializatonError as e:
                 # Attach queue information on the exception for improved error
                 # reporting
                 e.job_id = job_id

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -10,7 +10,7 @@ from redis import WatchError
 from .compat import as_text, string_types, total_ordering
 from .connections import resolve_connection
 from .defaults import DEFAULT_RESULT_TTL
-from .exceptions import (DequeueTimeout, DeserializatonError, InvalidJobDependency,
+from .exceptions import (DequeueTimeout, DeserializationError, InvalidJobDependency,
                          NoSuchJobError)
 from .job import Job, JobStatus
 from .utils import backend_class, import_attribute, utcnow, parse_timeout
@@ -479,7 +479,7 @@ class Queue(object):
                 # Silently pass on jobs that don't exist (anymore),
                 # and continue in the look
                 continue
-            except DeserializatonError as e:
+            except DeserializationError as e:
                 # Attach queue information on the exception for improved error
                 # reporting
                 e.job_id = job_id

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -10,6 +10,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import calendar
 import datetime
+from functools import partial
 import importlib
 import logging
 import numbers
@@ -18,6 +19,10 @@ try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
+try:
+    import cPickle as pickle
+except ImportError:  # noqa  # pragma: no cover
+    import pickle
 
 from .compat import as_text, is_python_version, string_types
 from .exceptions import TimeoutFormatError
@@ -147,6 +152,22 @@ class ColorizingStreamHandler(logging.StreamHandler):
             message = '\n'.join(parts)
 
         return message
+
+
+class _DefaultSerializer(object):
+    def __init__(self):
+        # Serialize pickle dumps using the highest pickle protocol (binary, default
+        # uses ascii)
+        self.dumps = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)
+        self.loads = pickle.loads
+
+
+serializer = _DefaultSerializer()
+
+
+def configure_serializer(mod):
+    global serializer
+    serializer = mod
 
 
 def import_attribute(name):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -823,7 +823,7 @@ class Worker(object):
 
             job.ended_at = utcnow()
 
-            # Pickle the result in the same try-except block since we need
+            # Serialize the result in the same try-except block since we need
             # to use the same exc handling when pickling fails
             job._result = rv
             self.handle_job_success(job=job,

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -365,7 +365,7 @@ class TestJob(RQTestCase):
         job = Job.create(func=fixtures.say_hello, args=('Lionel',))
         job._result = queue.Queue()
         data = job.to_dict()
-        self.assertEqual(data['result'], 'Unpickleable return value')
+        self.assertEqual(data['result'], 'Unserializable return value')
 
     def test_result_ttl_is_persisted(self):
         """Ensure that job's result_ttl is set properly"""


### PR DESCRIPTION
This is a WIP approach to configurable serializer support.

Instead of making the serializer an attribute of every class/instance that might potentially need to use it, this introduces `utils.serializer` and `utils.configure_serializer`. During early initialization, applications can do something like this:

```python
import rq
import dill

rq.configure_serializer(dill)
```

A "serializer" is any object that has at least `dumps` and `loads`.

This also introduces a more generic exception, `DeserializationError`, and aliases the old `UnpickleError` to it for backwards compatibility.

I'd appreciate any and all feedback on this approach!

Closes #973.