### PR TITLE
Fix dependent jobs enqueueing

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -398,7 +398,7 @@ class Queue(object):
                     if dependent.origin == self.name:
                         self.enqueue_job(dependent, pipeline=pipe)
                     else:
-                        queue = Queue(name=dependent.origin, connection=self.connection)
+                        queue = self.__class__(name=dependent.origin, connection=self.connection)
                         queue.enqueue_job(dependent, pipeline=pipe)
 
                 pipe.delete(dependents_key)


### PR DESCRIPTION
If Queue was subclassed and enqueue_job changed, these changes should affect on dependent jobs' enqueueing too.

```
class MyQueue(Queue):
    def enqueue_job(self, *args, **kwargs):
        logger.info('Job was enqueued')
        return super().enqueue_job(*args, **kwargs)
```