### PR TITLE
Convert `_dependency_id` to `_dependency_ids`

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -137,7 +137,7 @@ class Job(object):
 
         # dependency could be job instance or id
         if depends_on is not None:
-            job._dependency_id = depends_on.id if isinstance(depends_on, Job) else depends_on
+            job._dependency_ids = [depends_on.id if isinstance(depends_on, Job) else depends_on]
         return job
 
     def get_status(self):
@@ -174,11 +174,11 @@ class Job(object):
         """Returns a job's dependency. To avoid repeated Redis fetches, we cache
         job.dependency as job._dependency.
         """
-        if self._dependency_id is None:
+        if not self._dependency_ids:
             return None
         if hasattr(self, '_dependency'):
             return self._dependency
-        job = self.fetch(self._dependency_id, connection=self.connection)
+        job = self.fetch(self._dependency_ids[0], connection=self.connection)
         self._dependency = job
         return job
 
@@ -328,7 +328,7 @@ class Job(object):
         self.failure_ttl = None
         self.ttl = None
         self._status = None
-        self._dependency_id = None
+        self._dependency_ids = None
         self.meta = {}
 
     def __repr__(self):  # noqa  # pragma: no cover
@@ -437,7 +437,10 @@ class Job(object):
         self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None  # noqa
         self.failure_ttl = int(obj.get('failure_ttl')) if obj.get('failure_ttl') else None  # noqa
         self._status = obj.get('status') if obj.get('status') else None
-        self._dependency_id = as_text(obj.get('dependency_id', None))
+
+        dependency_id = obj.get('dependency_id', None)
+        self._dependency_ids = [as_text(dependency_id)] if dependency_id else []
+
         self.ttl = int(obj.get('ttl')) if obj.get('ttl') else None
         self.meta = unpickle(obj.get('meta')) if obj.get('meta') else {}
 
@@ -497,8 +500,8 @@ class Job(object):
             obj['failure_ttl'] = self.failure_ttl
         if self._status is not None:
             obj['status'] = self._status
-        if self._dependency_id is not None:
-            obj['dependency_id'] = self._dependency_id
+        if self._dependency_ids:
+            obj['dependency_id'] = self._dependency_ids[0]
         if self.meta and include_meta:
             obj['meta'] = dumps(self.meta)
         if self.ttl:
@@ -683,7 +686,8 @@ class Job(object):
         registry.add(self, pipeline=pipeline)
 
         connection = pipeline if pipeline is not None else self.connection
-        connection.sadd(self.dependents_key_for(self._dependency_id), self.id)
 
+        dependents_key = self.dependents_key_for(self._dependency_ids[0])
+        connection.sadd(dependents_key, self.id)
 
 _job_stack = LocalStack()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -6,9 +6,8 @@ import mock
 from redis import Redis
 from rq.decorators import job
 from rq.job import Job
-from rq.worker import DEFAULT_RESULT_TTL
 from rq.queue import Queue
-
+from rq.worker import DEFAULT_RESULT_TTL
 from tests import RQTestCase
 from tests.fixtures import decorated_job
 
@@ -95,7 +94,7 @@ class TestDecorator(RQTestCase):
         # Ensure default
         result = decorated_job.delay(1, 2)
         self.assertEqual(result.dependency, None)
-        self.assertEqual(result._dependency_id, None)
+        self.assertEqual(result.dependency.id, None)
 
         @job(queue='queue_name')
         def foo():
@@ -109,11 +108,11 @@ class TestDecorator(RQTestCase):
 
         bar_job = bar.delay()
 
-        self.assertIsNone(foo_job._dependency_id)
+        self.assertIsNone(foo_job.dependency.id)
 
         self.assertEqual(bar_job.dependency, foo_job)
 
-        self.assertEqual(bar_job._dependency_id, foo_job.id)
+        self.assertEqual(bar_job.dependency.id, foo_job.id)
 
     def test_decorator_delay_accepts_depends_on_as_argument(self):
         """Ensure that passing in depends_on to the delay method of
@@ -123,7 +122,7 @@ class TestDecorator(RQTestCase):
         # Ensure default
         result = decorated_job.delay(1, 2)
         self.assertEqual(result.dependency, None)
-        self.assertEqual(result._dependency_id, None)
+        self.assertEqual(result.dependency.id, None)
 
         @job(queue='queue_name')
         def foo():

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -2,11 +2,20 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import sys
+import time
+import zlib
 from datetime import datetime
 
-import time
-import sys
-import zlib
+from rq.compat import PY2, as_text
+from rq.exceptions import NoSuchJobError, UnpickleError
+from rq.job import Job, JobStatus, cancel_job, get_current_job
+from rq.queue import Queue
+from rq.registry import (DeferredJobRegistry, FailedJobRegistry,
+                         FinishedJobRegistry, StartedJobRegistry)
+from rq.utils import utcformat
+from rq.worker import Worker
+from tests import RQTestCase, fixtures
 
 is_py2 = sys.version[0] == '2'
 if is_py2:
@@ -14,16 +23,7 @@ if is_py2:
 else:
     import queue as queue
 
-from tests import fixtures, RQTestCase
 
-from rq.compat import PY2, as_text
-from rq.exceptions import NoSuchJobError, UnpickleError
-from rq.job import Job, get_current_job, JobStatus, cancel_job
-from rq.queue import Queue
-from rq.registry import (DeferredJobRegistry, FailedJobRegistry,
-                         FinishedJobRegistry, StartedJobRegistry)
-from rq.utils import utcformat
-from rq.worker import Worker
 
 try:
     from cPickle import loads, dumps
@@ -226,13 +226,13 @@ class TestJob(RQTestCase):
         job = Job.create(func=fixtures.some_calculation, depends_on=parent_job)
         job.save()
         stored_job = Job.fetch(job.id)
-        self.assertEqual(stored_job._dependency_id, parent_job.id)
+        self.assertEqual(stored_job.dependency.id, parent_job.id)
         self.assertEqual(stored_job.dependency, parent_job)
 
         job = Job.create(func=fixtures.some_calculation, depends_on=parent_job.id)
         job.save()
         stored_job = Job.fetch(job.id)
-        self.assertEqual(stored_job._dependency_id, parent_job.id)
+        self.assertEqual(stored_job.dependency.id, parent_job.id)
         self.assertEqual(stored_job.dependency, parent_job)
 
     def test_store_then_fetch(self):


### PR DESCRIPTION
Change `Job`s tracking of it's dependen[y|cies] from a single _id_ to a list of _id_ s. This change should be private to `Job` - especially leaving `Job#to_dict` and `Job#restore`s treatment of a single 'dependency_id' intact.