### PR TITLE
Multi Dependency Support - Registration & Enqueue Call

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -411,11 +411,10 @@ class Job(object):
 
         Returned jobs will use self's connection, not the pipeline supplied.
         """
-        if pipeline is None:
-            pipeline = pipeline or self.connection
+        connection = pipeline if pipeline is not None else self.connection
 
         if watch and self._dependency_ids:
-            pipeline.watch(*self._dependency_ids)
+            connection.watch(*self._dependency_ids)
 
         jobs = self.fetch_many(self._dependency_ids, connection=self.connection)
 
@@ -700,6 +699,8 @@ class Job(object):
         elif ttl > 0:
             connection = pipeline if pipeline is not None else self.connection
             connection.expire(self.key, ttl)
+            connection.expire(self.dependents_key, ttl)
+            connection.expire(self.dependencies_key, ttl)
 
     @property
     def failed_job_registry(self):

--- a/rq/job.py
+++ b/rq/job.py
@@ -400,7 +400,7 @@ class Job(object):
 
     @property
     def dependencies_key(self):
-        return '{0}{1}:dependencies'.format(self.redis_job_namespace_prefix, self.id)
+        return '{0}:{1}:dependencies'.format(self.redis_job_namespace_prefix, self.id)
 
     def fetch_dependencies(self, watch=False, pipeline=None):
         """
@@ -415,10 +415,7 @@ class Job(object):
         if watch and self._dependency_ids:
             pipeline.watch(*self._dependency_ids)
 
-        jobs = self.fetch_many(
-            self._dependency_ids,
-            connection=self.connection
-        )
+        jobs = self.fetch_many(self._dependency_ids, connection=self.connection)
 
         for i, job in enumerate(jobs):
             if not job:
@@ -625,9 +622,7 @@ class Job(object):
         if delete_dependents:
             self.delete_dependents(pipeline=pipeline)
 
-        connection.delete(self.key)
-        connection.delete(self.dependents_key)
-        connection.delete(self.dependencies_key)
+        connection.delete(self.key, self.dependents_key, self.dependencies_key)
 
     def delete_dependents(self, pipeline=None):
         """Delete jobs depending on this job."""

--- a/rq/job.py
+++ b/rq/job.py
@@ -140,8 +140,10 @@ class Job(object):
             job._dependency_ids = [depends_on.id if isinstance(depends_on, Job) else depends_on]
         return job
 
-    def get_status(self):
-        self._status = as_text(self.connection.hget(self.key, 'status'))
+    def get_status(self, refresh=True):
+        if refresh:
+            self._status = as_text(self.connection.hget(self.key, 'status'))
+
         return self._status
 
     def set_status(self, status, pipeline=None):

--- a/rq/job.py
+++ b/rq/job.py
@@ -297,7 +297,7 @@ class Job(object):
         return job
 
     @classmethod
-    def fetch_many(cls, job_ids, connection=None):
+    def fetch_many(cls, job_ids, connection):
         """
         Bulk version of Job.fetch
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -419,7 +419,7 @@ class Job(object):
 
         for i, job in enumerate(jobs):
             if not job:
-                raise InvalidJobDependency('Job {0} does not exist'.format(self._dependency_ids[i]))
+                raise NoSuchJobError('Dependency {0} does not exist'.format(self._dependency_ids[i]))
 
         return jobs
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -475,7 +475,7 @@ class Job(object):
         self.timeout = parse_timeout(obj.get('timeout')) if obj.get('timeout') else None
         self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None  # noqa
         self.failure_ttl = int(obj.get('failure_ttl')) if obj.get('failure_ttl') else None  # noqa
-        self._status = obj.get('status') if obj.get('status') else None
+        self._status = as_text(obj.get('status')) if obj.get('status') else None
 
         dependency_id = obj.get('dependency_id', None)
         self._dependency_ids = [as_text(dependency_id)] if dependency_id else []

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -263,12 +263,13 @@ class Queue(object):
             with self.connection.pipeline() as pipe:
                 while True:
                     try:
+
+                        pipe.watch(job.dependencies_key)
+
                         dependencies = job.fetch_dependencies(
                             watch=True,
                             pipeline=pipe
                         )
-
-                        pipe.watch(job.dependencies_key)
 
                         pipe.multi()
 
@@ -286,7 +287,6 @@ class Queue(object):
                         continue
 
         job = self.enqueue_job(job, at_front=at_front)
-
         return job
 
     def run_job(self, job):

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -274,7 +274,7 @@ class Queue(object):
                         pipe.multi()
 
                         for dependency in dependencies:
-                            if dependency._status != JobStatus.FINISHED:
+                            if dependency.get_status(refresh=False) != JobStatus.FINISHED:
                                 job.set_status(JobStatus.DEFERRED, pipeline=pipe)
                                 job.register_dependency(pipeline=pipe)
                                 job.save(pipeline=pipe)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -273,8 +273,8 @@ class Queue(object):
                         pipe.multi()
 
                         for dependency in dependencies:
-                            if dependency.get_status() != JobStatus.FINISHED:
-                                job.set_status(JobStatus.DEFERRED)
+                            if dependency._status != JobStatus.FINISHED:
+                                job.set_status(JobStatus.DEFERRED, pipeline=pipe)
                                 job.register_dependency(pipeline=pipe)
                                 job.save(pipeline=pipe)
                                 job.cleanup(ttl=job.ttl, pipeline=pipe)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -13,7 +13,7 @@ from .defaults import DEFAULT_RESULT_TTL
 from .exceptions import (DequeueTimeout, InvalidJobDependency, NoSuchJobError,
                          UnpickleError)
 from .job import Job, JobStatus
-from .utils import backend_class, import_attribute, utcnow, parse_timeout
+from .utils import backend_class, import_attribute, parse_timeout, utcnow
 
 
 def compact(lst):
@@ -252,33 +252,35 @@ class Queue(object):
             depends_on=depends_on, timeout=timeout, id=job_id,
             origin=self.name, meta=meta)
 
-        # If job depends on an unfinished job, register itself on it's
-        # parent's dependents instead of enqueueing it.
-        # If WatchError is raised in the process, that means something else is
-        # modifying the dependency. In this case we simply retry
+        # If a _dependent_ job depends on any unfinished job, register all the
+        #_dependent_ job's dependencies instead of enqueueing it.
+        #
+        # `Job#fetch_dependencies` sets WATCH on all dependencies. If
+        # WatchError is raised in the when the pipeline is executed, that means
+        # something else has modified either the set of dependencies or the
+        # status of one of them. In this case, we simply retry.
         if depends_on is not None:
-            if not isinstance(depends_on, self.job_class):
-                depends_on = self.job_class(id=depends_on,
-                                            connection=self.connection)
             with self.connection.pipeline() as pipe:
                 while True:
                     try:
-                        pipe.watch(depends_on.key)
+                        dependencies = job.fetch_dependencies(
+                            watch=True,
+                            pipeline=pipe
+                        )
 
-                        # If the dependency does not exist, raise an
-                        # exception to avoid creating an orphaned job.
-                        if not self.job_class.exists(depends_on.id,
-                                                     self.connection):
-                            raise InvalidJobDependency('Job {0} does not exist'.format(depends_on.id))
+                        pipe.watch(job.dependencies_key)
 
-                        if depends_on.get_status() != JobStatus.FINISHED:
-                            pipe.multi()
-                            job.set_status(JobStatus.DEFERRED)
-                            job.register_dependency(pipeline=pipe)
-                            job.save(pipeline=pipe)
-                            job.cleanup(ttl=job.ttl, pipeline=pipe)
-                            pipe.execute()
-                            return job
+                        pipe.multi()
+
+                        for dependency in dependencies:
+                            if dependency.get_status() != JobStatus.FINISHED:
+                                job.set_status(JobStatus.DEFERRED)
+                                job.register_dependency(pipeline=pipe)
+                                job.save(pipeline=pipe)
+                                job.cleanup(ttl=job.ttl, pipeline=pipe)
+                                pipe.execute()
+                                return job
+
                         break
                     except WatchError:
                         continue

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -699,7 +699,7 @@ class TestJob(RQTestCase):
     def test_dependencies_key_should_have_prefixed_job_id(self):
         job_id = 'random'
         job = Job(id=job_id)
-        expected_key = Job.redis_job_namespace_prefix + job_id + ':dependencies'
+        expected_key = Job.redis_job_namespace_prefix + ":" + job_id + ':dependencies'
 
         assert job.dependencies_key == expected_key
 
@@ -725,19 +725,6 @@ class TestJob(RQTestCase):
         dependencies = dependent_job.fetch_dependencies(pipeline=self.testconn)
 
         self.assertListEqual(dependencies, [])
-
-    def test_fetch_dependencies_raises_if_dependency_deleted(self):
-        queue = Queue(connection=self.testconn)
-        dependency_job = queue.enqueue(fixtures.say_hello)
-        dependent_job = Job.create(func=fixtures.say_hello, depends_on=dependency_job)
-
-        dependent_job.register_dependency()
-        dependent_job.save()
-
-        dependency_job.delete()
-
-        with self.assertRaises(InvalidJobDependency):
-            dependent_job.fetch_dependencies(pipeline=self.testconn)
 
     def test_fetch_dependencies_raises_if_dependency_deleted(self):
         queue = Queue(connection=self.testconn)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -736,7 +736,7 @@ class TestJob(RQTestCase):
 
         dependency_job.delete()
 
-        with self.assertRaises(InvalidJobDependency):
+        with self.assertRaises(NoSuchJobError):
             dependent_job.fetch_dependencies(pipeline=self.testconn)
 
     def test_fetch_dependencies_watches(self):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,14 +2,13 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from tests import RQTestCase
-from tests.fixtures import echo, say_hello
-
 from rq import Queue
-from rq.exceptions import InvalidJobDependency
+from rq.exceptions import InvalidJobDependency, NoSuchJobError
 from rq.job import Job, JobStatus
 from rq.registry import DeferredJobRegistry
 from rq.worker import Worker
+from tests import RQTestCase
+from tests.fixtures import echo, say_hello
 
 
 class CustomJob(Job):
@@ -488,10 +487,10 @@ class TestQueue(RQTestCase):
         # without save() the job is not visible to others
 
         q = Queue()
-        with self.assertRaises(InvalidJobDependency):
+        with self.assertRaises(NoSuchJobError):
             q.enqueue_call(say_hello, depends_on=parent_job)
 
-        with self.assertRaises(InvalidJobDependency):
+        with self.assertRaises(NoSuchJobError):
             q.enqueue_call(say_hello, depends_on=parent_job.id)
 
         self.assertEqual(q.job_ids, [])


### PR DESCRIPTION
Internal API changes to support multiple dependencies.

Successor to  #1147.

* Store all of a job's _dependencies_ in a redis set. Delete that set when a job is deleted.
* Add `Job#fetch_dependencies` method - which return all jobs a job is dependent upon and optionally _WATCHES_ all dependency ids.
* Use `Job#fetch_dependencies` in `Queue#call_enqueue`. `fetch_dependencies` now sets WATCH and raises `InvalidJobDependency`, rather than `call_enqueue`.

`Queue` and `Job` public APIs still expect single ids of jobs for `depends_on` but internally register them in a way that could support multiple jobs being passed as dependencies.

Next up: updates to `Queue#enqueue_dependents`.