### PR TITLE
fix log level parameter override, Fixes #1166

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -249,6 +249,10 @@ def worker(cli_config, burst, logging_level, name, results_ttl,
             from rq.contrib.sentry import register_sentry
             register_sentry(sentry_dsn)
 
+        # if --verbose or --quiet, override --logging_level
+        if verbose or quiet:
+            logging_level = None
+
         worker.work(burst=burst, logging_level=logging_level, date_format=date_format, log_format=log_format, max_jobs=max_jobs)
     except ConnectionError as e:
         print(e)


### PR DESCRIPTION
When using both parameter, like this:

```
> rq worker -v --logging_level="INFO"
```

`-v` override `--logging_level`