### PR TITLE
[Multi-Dependencies] Enqueuing of Dependents

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -744,9 +744,8 @@ class Job(object):
         pipe = pipeline if pipeline is not None else self.connection
 
         if watch:
-            pipe.watch(self.dependencies_key)
-            pipe.watch(*[self.redis_job_namespace_prefix + as_text(_id)
-                        for _id in pipe.smembers(self.dependencies_key)])
+            pipe.watch(*[Job.key_for(_id)
+                         for _id in self.connection.smembers(self.dependencies_key)])
 
         sort_by = self.redis_job_namespace_prefix + '*->ended_at'
         get_field = self.redis_job_namespace_prefix + '*->status'
@@ -761,6 +760,5 @@ class Job(object):
         ]
 
         return dependencies_statuses
-
 
 _job_stack = LocalStack()

--- a/rq/job.py
+++ b/rq/job.py
@@ -724,7 +724,7 @@ class Job(object):
             connection.sadd(dependents_key, self.id)
             connection.sadd(self.dependencies_key, dependency_id)
 
-    def dependencies_finished(
+    def dependencies_are_met(
             self,
             pipeline=None
     ):

--- a/rq/job.py
+++ b/rq/job.py
@@ -21,6 +21,7 @@ try:
 except ImportError:  # noqa  # pragma: no cover
     import pickle
 
+
 # Serialize pickle dumps using the highest pickle protocol (binary, default
 # uses ascii)
 dumps = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)
@@ -103,13 +104,11 @@ class Job(object):
             job._func_name = '{0}.{1}'.format(func.__module__, func.__name__)
         elif isinstance(func, string_types):
             job._func_name = as_text(func)
-        elif not inspect.isclass(func) and hasattr(func,
-                                                   '__call__'):  # a callable class instance
+        elif not inspect.isclass(func) and hasattr(func, '__call__'):  # a callable class instance
             job._instance = func
             job._func_name = '__call__'
         else:
-            raise TypeError(
-                'Expected a callable or a string, but got: {0}'.format(func))
+            raise TypeError('Expected a callable or a string, but got: {0}'.format(func))
         job._args = args
         job._kwargs = kwargs
 
@@ -124,8 +123,7 @@ class Job(object):
 
         # dependency could be job instance or id
         if depends_on is not None:
-            job._dependency_ids = [
-                depends_on.id if isinstance(depends_on, Job) else depends_on]
+            job._dependency_ids = [depends_on.id if isinstance(depends_on, Job) else depends_on]
         return job
 
     def get_status(self, refresh=True):
@@ -411,8 +409,8 @@ class Job(object):
         if watch and self._dependency_ids:
             connection.watch(*self._dependency_ids)
 
-        jobs = [job for
-                job in self.fetch_many(self._dependency_ids, connection=self.connection)
+        jobs = [job
+                for job in self.fetch_many(self._dependency_ids, connection=self.connection)
                 if job]
 
         return jobs
@@ -471,10 +469,8 @@ class Job(object):
             except Exception as e:
                 self._result = "Unserializable return value"
         self.timeout = parse_timeout(obj.get('timeout')) if obj.get('timeout') else None
-        self.result_ttl = int(obj.get('result_ttl')) if obj.get(
-            'result_ttl') else None  # noqa
-        self.failure_ttl = int(obj.get('failure_ttl')) if obj.get(
-            'failure_ttl') else None  # noqa
+        self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None  # noqa
+        self.failure_ttl = int(obj.get('failure_ttl')) if obj.get('failure_ttl') else None  # noqa
         self._status = as_text(obj.get('status')) if obj.get('status') else None
 
         dependency_id = obj.get('dependency_id', None)
@@ -791,6 +787,5 @@ class Job(object):
                    for dependency_id, created_at, status
                    in dependencies_statuses
                    if dependency_id not in exclude)
-
 
 _job_stack = LocalStack()

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -461,28 +461,18 @@ class Queue(object):
                 if pipeline is None:
                     pipe.watch(dependents_key)
 
-                dependent_jobs = [self.job_class.fetch(as_text(job_id), connection=self.connection)
-                                  for job_id in pipe.smembers(dependents_key)]
+                dependent_job_ids = [as_text(_id)
+                                     for _id in pipe.smembers(dependents_key)]
 
-                dependencies_statuses = [
-                    dependent.get_dependencies_statuses(watch=True, pipeline=pipe)
-                    for dependent in dependent_jobs
+                dependent_jobs = [
+                    job for job in self.job_class.fetch_many(dependent_job_ids,
+                                                             connection=self.connection)
+                    if job.dependencies_finished(pipeline=pipe)
                 ]
 
                 pipe.multi()
 
-                for dependent, dependents_dependencies in zip(dependent_jobs,
-                                                              dependencies_statuses):
-
-                    # Enqueue this dependent job only if all of it's _other_
-                    # dependencies are FINISHED.
-                    if not all(
-                        status == JobStatus.FINISHED
-                        for job_id, status
-                        in dependents_dependencies
-                    ):
-                        continue
-
+                for dependent in dependent_jobs:
                     registry = DeferredJobRegistry(dependent.origin,
                                                    self.connection,
                                                    job_class=self.job_class)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -282,7 +282,7 @@ class Queue(object):
                      at_front=False, meta=None):
         """Creates a job to represent the delayed function call and enqueues
         it.
-
+nd
         It is much like `.enqueue()`, except that it takes the function's args
         and kwargs as explicit arguments.  Any kwargs passed to this function
         contain options for RQ itself.

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -466,7 +466,8 @@ class Queue(object):
 
                 pipe.multi()
 
-                for dependent in dependent_jobs:
+                for dependent, dependents_dependencies in dependent_jobs:
+
                     registry = DeferredJobRegistry(dependent.origin,
                                                    self.connection,
                                                    job_class=self.job_class)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -13,8 +13,8 @@ from .connections import resolve_connection
 from .defaults import DEFAULT_RESULT_TTL
 from .exceptions import DequeueTimeout, NoSuchJobError
 from .job import Job, JobStatus
-from .utils import backend_class, import_attribute, parse_timeout, utcnow
 from .serializers import resolve_serializer
+from .utils import backend_class, import_attribute, parse_timeout, utcnow
 
 
 def compact(lst):
@@ -65,8 +65,7 @@ class Queue(object):
 
         if 'async' in kwargs:
             self._is_async = kwargs['async']
-            warnings.warn('The `async` keyword is deprecated. Use `is_async` instead',
-                          DeprecationWarning)
+            warnings.warn('The `async` keyword is deprecated. Use `is_async` instead', DeprecationWarning)
 
         # override class attribute job_class if one was passed
         if job_class is not None:
@@ -317,8 +316,7 @@ class Queue(object):
                         pipe.multi()
 
                         for dependency in dependencies:
-                            if dependency.get_status(
-                                refresh=False) != JobStatus.FINISHED:
+                            if dependency.get_status(refresh=False) != JobStatus.FINISHED:
                                 job.set_status(JobStatus.DEFERRED, pipeline=pipe)
                                 job.register_dependency(pipeline=pipe)
                                 job.save(pipeline=pipe)
@@ -380,8 +378,7 @@ class Queue(object):
         """Creates a job to represent the delayed function call and enqueues it."""
 
         (f, timeout, description, result_ttl, ttl, failure_ttl,
-         depends_on, job_id, at_front, meta, args, kwargs) = Queue.parse_args(f, *args,
-                                                                              **kwargs)
+         depends_on, job_id, at_front, meta, args, kwargs) = Queue.parse_args(f, *args, **kwargs)
 
         return self.enqueue_call(
             func=f, args=args, kwargs=kwargs, timeout=timeout,
@@ -395,8 +392,7 @@ class Queue(object):
         from .registry import ScheduledJobRegistry
 
         (f, timeout, description, result_ttl, ttl, failure_ttl,
-         depends_on, job_id, at_front, meta, args, kwargs) = Queue.parse_args(f, *args,
-                                                                              **kwargs)
+         depends_on, job_id, at_front, meta, args, kwargs) = Queue.parse_args(f, *args, **kwargs)
         job = self.create_job(f, status=JobStatus.SCHEDULED, args=args, kwargs=kwargs,
                               timeout=timeout, result_ttl=result_ttl, ttl=ttl,
                               failure_ttl=failure_ttl, description=description,
@@ -488,8 +484,7 @@ class Queue(object):
                     if dependent.origin == self.name:
                         self.enqueue_job(dependent, pipeline=pipe)
                     else:
-                        queue = self.__class__(name=dependent.origin,
-                                               connection=self.connection)
+                        queue = self.__class__(name=dependent.origin, connection=self.connection)
                         queue.enqueue_job(dependent, pipeline=pipe)
 
                 pipe.delete(dependents_key)
@@ -528,8 +523,7 @@ class Queue(object):
         connection = resolve_connection(connection)
         if timeout is not None:  # blocking variant
             if timeout == 0:
-                raise ValueError(
-                    'RQ does not support indefinite timeouts. Please pick a timeout value > 0')
+                raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
             result = connection.blpop(queue_keys, timeout)
             if result is None:
                 raise DequeueTimeout(timeout, queue_keys)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -467,7 +467,7 @@ class Queue(object):
                 dependent_jobs = [
                     job for job in self.job_class.fetch_many(dependent_job_ids,
                                                              connection=self.connection)
-                    if job.dependencies_finished(pipeline=pipe)
+                    if job.dependencies_are_met(pipeline=pipe)
                 ]
 
                 pipe.multi()

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -463,7 +463,7 @@ class Queue(object):
                 dependent_job_ids = [as_text(_id)
                                      for _id in pipe.smembers(dependents_key)]
 
-                dependent_jobs = [
+                jobs_to_enqueue = [
                     dependent_job for dependent_job
                     in self.job_class.fetch_many(
                         dependent_job_ids,
@@ -476,7 +476,7 @@ class Queue(object):
 
                 pipe.multi()
 
-                for dependent in dependent_jobs:
+                for dependent in jobs_to_enqueue:
                     registry = DeferredJobRegistry(dependent.origin,
                                                    self.connection,
                                                    job_class=self.job_class)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -480,7 +480,6 @@ class Queue(object):
                         status == JobStatus.FINISHED
                         for job_id, status
                         in dependents_dependencies
-                        if job_id != job.id
                     ):
                         continue
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -469,8 +469,8 @@ class Queue(object):
                         dependent_job_ids,
                         connection=self.connection
                     ) if dependent_job.dependencies_are_met(
-                        pipeline=pipe,
-                        exclude={job.id}
+                        exclude_job_id=job.id,
+                        pipeline=pipe
                     )
                 ]
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -845,6 +845,7 @@ class Worker(object):
                     # if dependencies are inserted after enqueue_dependents
                     # a WatchError is thrown by execute()
                     pipeline.watch(job.dependents_key)
+                    # TODO: This was moved 
                     job.set_status(JobStatus.FINISHED, pipeline=pipeline)
                     # enqueue_dependents calls multi() on the pipeline!
                     queue.enqueue_dependents(job, pipeline=pipeline)

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -15,15 +15,20 @@ import warnings
 from datetime import timedelta
 from uuid import uuid4
 
+try:
+    from signal import SIGKILL
+except ImportError:
+    from signal import SIGTERM as SIGKILL
+
 from redis import WatchError
 
 from . import worker_registration
 from .compat import PY2, as_text, string_types, text_type
-from .connections import (get_current_connection, pop_connection,
-                          push_connection)
-from .defaults import (DEFAULT_JOB_MONITORING_INTERVAL,
-                       DEFAULT_LOGGING_DATE_FORMAT, DEFAULT_LOGGING_FORMAT,
-                       DEFAULT_RESULT_TTL, DEFAULT_WORKER_TTL)
+from .connections import get_current_connection, push_connection, pop_connection
+
+from .defaults import (DEFAULT_RESULT_TTL,
+                       DEFAULT_WORKER_TTL, DEFAULT_JOB_MONITORING_INTERVAL,
+                       DEFAULT_LOGGING_FORMAT, DEFAULT_LOGGING_DATE_FORMAT)
 from .exceptions import DequeueTimeout, ShutDownImminentException
 from .job import Job, JobStatus
 from .logutils import setup_loghandlers
@@ -31,21 +36,12 @@ from .queue import Queue
 from .registry import FailedJobRegistry, StartedJobRegistry, clean_registries
 from .scheduler import RQScheduler
 from .suspension import is_suspended
-from .timeouts import (HorseMonitorTimeoutException, JobTimeoutException,
-                       UnixSignalDeathPenalty)
-from .utils import (backend_class, ensure_list, enum, make_colorizer,
-                    utcformat, utcnow, utcparse)
+from .timeouts import JobTimeoutException, HorseMonitorTimeoutException, UnixSignalDeathPenalty
+from .utils import (backend_class, ensure_list, enum,
+                    make_colorizer, utcformat, utcnow, utcparse)
 from .version import VERSION
 from .worker_registration import clean_worker_registry, get_keys
 from .serializers import resolve_serializer
-
-try:
-    from signal import SIGKILL
-except ImportError:
-    from signal import SIGTERM as SIGKILL
-
-
-
 
 try:
     from setproctitle import setproctitle as setprocname

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -845,8 +845,6 @@ class Worker(object):
                     # if dependencies are inserted after enqueue_dependents
                     # a WatchError is thrown by execute()
                     pipeline.watch(job.dependents_key)
-                    # TODO: This was moved 
-                    job.set_status(JobStatus.FINISHED, pipeline=pipeline)
                     # enqueue_dependents calls multi() on the pipeline!
                     queue.enqueue_dependents(job, pipeline=pipeline)
 
@@ -858,6 +856,7 @@ class Worker(object):
 
                     result_ttl = job.get_result_ttl(self.default_result_ttl)
                     if result_ttl != 0:
+                        job.set_status(JobStatus.FINISHED, pipeline=pipeline)
                         # Don't clobber the user's meta dictionary!
                         job.save(pipeline=pipeline, include_meta=False)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -910,5 +910,5 @@ class TestJob(RQTestCase):
         w = Worker([queue])
         w.work(burst=True, max_jobs=1)
 
-        assert dependent_job.get_status() == JobStatus.QUEUED
         assert dependent_job.dependencies_are_met()
+        assert dependent_job.get_status() == JobStatus.QUEUED

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -810,7 +810,7 @@ class TestJob(RQTestCase):
         dependent_job._dependency_ids = dependency_job_ids
         dependent_job.register_dependency()
 
-        dependencies_finished = dependent_job.dependencies_finished()
+        dependencies_finished = dependent_job.dependencies_are_met()
 
         self.assertFalse(dependencies_finished)
 
@@ -820,7 +820,7 @@ class TestJob(RQTestCase):
         dependent_job = Job.create(func=fixtures.say_hello)
         dependent_job.register_dependency()
 
-        dependencies_finished = dependent_job.dependencies_finished()
+        dependencies_finished = dependent_job.dependencies_are_met()
 
         self.assertTrue(dependencies_finished)
 
@@ -842,7 +842,7 @@ class TestJob(RQTestCase):
             job.ended_at = now - timedelta(seconds=i)
             job.save()
 
-        dependencies_finished = dependent_job.dependencies_finished()
+        dependencies_finished = dependent_job.dependencies_are_met()
 
         self.assertTrue(dependencies_finished)
 
@@ -863,7 +863,7 @@ class TestJob(RQTestCase):
 
         now = utcnow()
 
-        dependencies_finished = dependent_job.dependencies_finished()
+        dependencies_finished = dependent_job.dependencies_are_met()
 
         self.assertFalse(dependencies_finished)
 
@@ -878,7 +878,7 @@ class TestJob(RQTestCase):
 
         with self.testconn.pipeline() as pipeline:
 
-            dependent_job.dependencies_finished(
+            dependent_job.dependencies_are_met(
                 pipeline=pipeline,
             )
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -798,7 +798,7 @@ class TestJob(RQTestCase):
                 pipeline.touch(dependency_job.id)
                 pipeline.execute()
 
-    def test_get_dependencies_statuses_returns_ids_and_statuses(self):
+    def test_dependencies_finished_returns_false_if_dependencies_queued(self):
         queue = Queue(connection=self.testconn)
 
         dependency_job_ids = [
@@ -810,27 +810,21 @@ class TestJob(RQTestCase):
         dependent_job._dependency_ids = dependency_job_ids
         dependent_job.register_dependency()
 
-        dependencies_statuses = dependent_job.get_dependencies_statuses()
+        dependencies_finished = dependent_job.dependencies_finished()
 
-        self.assertSetEqual(
-            set(dependencies_statuses),
-            {(_id, JobStatus.QUEUED) for _id in dependency_job_ids}
-        )
+        self.assertFalse(dependencies_finished)
 
-    def test_get_dependencies_statuses_returns_empty_list_if_no_dependencies(self):
+    def test_dependencies_finished_returns_true_if_no_dependencies(self):
         queue = Queue(connection=self.testconn)
 
         dependent_job = Job.create(func=fixtures.say_hello)
         dependent_job.register_dependency()
 
-        dependencies_statuses = dependent_job.get_dependencies_statuses()
+        dependencies_finished = dependent_job.dependencies_finished()
 
-        self.assertListEqual(
-            dependencies_statuses,
-            []
-        )
+        self.assertTrue(dependencies_finished)
 
-    def test_get_dependencies_statuses_returns_ordered_by_end_time(self):
+    def test_dependencies_finished_returns_true_if_all_dependencies_finished(self):
         dependency_jobs = [
             Job.create(fixtures.say_hello)
             for _ in range(5)
@@ -842,19 +836,17 @@ class TestJob(RQTestCase):
 
         now = utcnow()
 
+        # Set ended_at timestamps
         for i, job in enumerate(dependency_jobs):
             job._status = JobStatus.FINISHED
             job.ended_at = now - timedelta(seconds=i)
             job.save()
 
-        dependencies_statuses = dependent_job.get_dependencies_statuses()
+        dependencies_finished = dependent_job.dependencies_finished()
 
-        self.assertListEqual(
-            dependencies_statuses,
-            [(job.id, JobStatus.FINISHED) for job in reversed(dependency_jobs)]
-        )
+        self.assertTrue(dependencies_finished)
 
-    def test_get_dependencies_statuses_returns_not_finished_job_ordered_first(self):
+    def test_dependencies_finished_returns_false_if_unfinished_job(self):
         dependency_jobs = [Job.create(fixtures.say_hello) for _ in range(2)]
 
         dependency_jobs[0]._status = JobStatus.FINISHED
@@ -871,19 +863,11 @@ class TestJob(RQTestCase):
 
         now = utcnow()
 
-        dependencies_statuses = dependent_job.get_dependencies_statuses()
+        dependencies_finished = dependent_job.dependencies_finished()
 
-        self.assertEqual(
-            dependencies_statuses[0],
-            (dependency_jobs[1].id, JobStatus.STARTED)
-        )
+        self.assertFalse(dependencies_finished)
 
-        self.assertEqual(
-            dependencies_statuses[1],
-            (dependency_jobs[0].id, JobStatus.FINISHED)
-        )
-
-    def test_get_dependencies_statuses_watches_job(self):
+    def test_dependencies_finished_watches_job(self):
         queue = Queue(connection=self.testconn)
 
         dependency_job = queue.enqueue(fixtures.say_hello)
@@ -894,9 +878,8 @@ class TestJob(RQTestCase):
 
         with self.testconn.pipeline() as pipeline:
 
-            dependent_job.get_dependencies_statuses(
+            dependent_job.dependencies_finished(
                 pipeline=pipeline,
-                watch=True
             )
 
             dependency_job.set_status(JobStatus.FAILED, pipeline=self.testconn)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -6,8 +6,9 @@ import json
 import time
 import queue
 import zlib
-from datetime import datetime
+from datetime import datetime, timedelta
 
+import pytest
 from redis import WatchError
 
 from rq.compat import PY2, as_text
@@ -17,7 +18,7 @@ from rq.queue import Queue
 from rq.registry import (DeferredJobRegistry, FailedJobRegistry,
                          FinishedJobRegistry, StartedJobRegistry,
                          ScheduledJobRegistry)
-from rq.utils import utcformat
+from rq.utils import utcformat, utcnow
 from rq.worker import Worker
 from tests import RQTestCase, fixtures
 
@@ -795,4 +796,138 @@ class TestJob(RQTestCase):
             with self.assertRaises(WatchError):
                 self.testconn.set(dependency_job.id, 'somethingelsehappened')
                 pipeline.touch(dependency_job.id)
+                pipeline.execute()
+
+    def test_get_dependencies_statuses_returns_ids_and_statuses(self):
+        queue = Queue(connection=self.testconn)
+
+        dependency_job_ids = [
+            queue.enqueue(fixtures.say_hello).id
+            for _ in range(5)
+        ]
+
+        dependent_job = Job.create(func=fixtures.say_hello)
+        dependent_job._dependency_ids = dependency_job_ids
+        dependent_job.register_dependency()
+
+        dependencies_statuses = dependent_job.get_dependencies_statuses()
+
+        self.assertSetEqual(
+            set(dependencies_statuses),
+            {(_id, JobStatus.QUEUED) for _id in dependency_job_ids}
+        )
+
+    def test_get_dependencies_statuses_returns_empty_list_if_no_dependencies(self):
+        queue = Queue(connection=self.testconn)
+
+        dependent_job = Job.create(func=fixtures.say_hello)
+        dependent_job.register_dependency()
+
+        dependencies_statuses = dependent_job.get_dependencies_statuses()
+
+        self.assertListEqual(
+            dependencies_statuses,
+            []
+        )
+
+    def test_get_dependencies_statuses_returns_ordered_by_end_time(self):
+        dependency_jobs = [
+            Job.create(fixtures.say_hello)
+            for _ in range(5)
+        ]
+
+        dependent_job = Job.create(func=fixtures.say_hello)
+        dependent_job._dependency_ids = [job.id for job in dependency_jobs]
+        dependent_job.register_dependency()
+
+        now = utcnow()
+
+        for i, job in enumerate(dependency_jobs):
+            job._status = JobStatus.FINISHED
+            job.ended_at = now - timedelta(seconds=i)
+            job.save()
+
+        dependencies_statuses = dependent_job.get_dependencies_statuses()
+
+        self.assertListEqual(
+            dependencies_statuses,
+            [(job.id, JobStatus.FINISHED) for job in reversed(dependency_jobs)]
+        )
+
+    def test_get_dependencies_statuses_returns_not_finished_job_ordered_first(self):
+        dependency_jobs = [Job.create(fixtures.say_hello) for _ in range(2)]
+
+        dependency_jobs[0]._status = JobStatus.FINISHED
+        dependency_jobs[0].ended_at = utcnow()
+        dependency_jobs[0].save()
+
+        dependency_jobs[1]._status = JobStatus.STARTED
+        dependency_jobs[1].ended_at = None
+        dependency_jobs[1].save()
+
+        dependent_job = Job.create(func=fixtures.say_hello)
+        dependent_job._dependency_ids = [job.id for job in dependency_jobs]
+        dependent_job.register_dependency()
+
+        now = utcnow()
+
+        dependencies_statuses = dependent_job.get_dependencies_statuses()
+
+        self.assertEqual(
+            dependencies_statuses[0],
+            (dependency_jobs[1].id, JobStatus.STARTED)
+        )
+
+        self.assertEqual(
+            dependencies_statuses[1],
+            (dependency_jobs[0].id, JobStatus.FINISHED)
+        )
+
+    def test_get_dependencies_statuses_watches_job(self):
+        queue = Queue(connection=self.testconn)
+
+        dependency_job = queue.enqueue(fixtures.say_hello)
+
+        dependent_job = Job.create(func=fixtures.say_hello)
+        dependent_job._dependency_ids = [dependency_job.id]
+        dependent_job.register_dependency()
+
+        with self.testconn.pipeline() as pipeline:
+
+            dependent_job.get_dependencies_statuses(
+                pipeline=pipeline,
+                watch=True
+            )
+
+            dependency_job.set_status(JobStatus.FAILED, pipeline=self.testconn)
+            pipeline.multi()
+
+            with self.assertRaises(WatchError):
+                pipeline.touch(Job.key_for(dependent_job.id))
+                pipeline.execute()
+
+    def test_get_dependencies_statuses_watches_dependency_set(self):
+        queue = Queue(connection=self.testconn)
+
+        dependency_job = queue.enqueue(fixtures.say_hello)
+        dependent_job = Job.create(func=fixtures.say_hello)
+        dependent_job._dependency_ids = [dependency_job.id]
+        dependent_job.register_dependency()
+
+        with self.testconn.pipeline() as pipeline:
+
+            dependent_job.get_dependencies_statuses(
+                pipeline=pipeline,
+                watch=True
+            )
+
+            self.testconn.sadd(
+                dependent_job.dependencies_key,
+                queue.enqueue(fixtures.say_hello).id,
+            )
+
+            pipeline.multi()
+
+            with self.assertRaises(WatchError):
+                pipeline.touch(Job.key_for(dependent_job.id))
                 pipeline.execute()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -905,29 +905,3 @@ class TestJob(RQTestCase):
             with self.assertRaises(WatchError):
                 pipeline.touch(Job.key_for(dependent_job.id))
                 pipeline.execute()
-
-    def test_get_dependencies_statuses_watches_dependency_set(self):
-        queue = Queue(connection=self.testconn)
-
-        dependency_job = queue.enqueue(fixtures.say_hello)
-        dependent_job = Job.create(func=fixtures.say_hello)
-        dependent_job._dependency_ids = [dependency_job.id]
-        dependent_job.register_dependency()
-
-        with self.testconn.pipeline() as pipeline:
-
-            dependent_job.get_dependencies_statuses(
-                pipeline=pipeline,
-                watch=True
-            )
-
-            self.testconn.sadd(
-                dependent_job.dependencies_key,
-                queue.enqueue(fixtures.say_hello).id,
-            )
-
-            pipeline.multi()
-
-            with self.assertRaises(WatchError):
-                pipeline.touch(Job.key_for(dependent_job.id))
-                pipeline.execute()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -531,20 +531,6 @@ class TestQueue(RQTestCase):
         self.assertEqual(q.job_ids, [job.id])
         self.assertEqual(job.timeout, 123)
 
-    def test_enqueue_job_with_invalid_dependency(self):
-        """Enqueuing a job fails, if the dependency does not exist at all."""
-        parent_job = Job.create(func=say_hello)
-        # without save() the job is not visible to others
-
-        q = Queue()
-        with self.assertRaises(NoSuchJobError):
-            q.enqueue_call(say_hello, depends_on=parent_job)
-
-        with self.assertRaises(NoSuchJobError):
-            q.enqueue_call(say_hello, depends_on=parent_job.id)
-
-        self.assertEqual(q.job_ids, [])
-
     def test_enqueue_job_with_multiple_queued_dependencies(self):
 
         parent_jobs = [Job.create(func=say_hello) for _ in range(2)]

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -24,6 +24,20 @@ class CustomJob(Job):
     pass
 
 
+class MultipleDependencyJob(Job):
+    """
+    Allows for the patching of `_dependency_ids` to simulate multi-dependency
+    support without modifying the public interface of `Job`
+    """
+    create_job = Job.create
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+        dependency_ids = kwargs.pop('kwargs').pop('_dependency_ids')
+        _job = cls.create_job(*args, **kwargs)
+        _job._dependency_ids = dependency_ids
+        return _job
+
 class TestQueue(RQTestCase):
     def test_create_queue(self):
         """Creating queues."""
@@ -539,17 +553,10 @@ class TestQueue(RQTestCase):
             job._status = JobStatus.QUEUED
             job.save()
 
-        job_create = Job.create
-
-        def create_job_patch(*args, **kwargs):
-            # patch Job#create to set parent jobs as dependencies.
-            job = job_create(*args, **kwargs)
-            job._dependency_ids = [job.id for job in parent_jobs]
-            return job
-
         q = Queue()
-        with patch.object(Job, 'create', create_job_patch) as patch_create_job:
-            job = q.enqueue(say_hello, depends_on=parent_jobs[0])
+        with patch('rq.queue.Job.create', new=MultipleDependencyJob.create):
+            job = q.enqueue(say_hello, depends_on=parent_jobs[0],
+                            _dependency_ids = [job.id for job in parent_jobs])
             self.assertEqual(job.get_status(), JobStatus.DEFERRED)
             self.assertEqual(q.job_ids, [])
             self.assertEqual(job.fetch_dependencies(), parent_jobs)
@@ -562,17 +569,10 @@ class TestQueue(RQTestCase):
             job._status = JobStatus.FINISHED
             job.save()
 
-        job_create = Job.create
-
-        def create_job_patch(*args, **kwargs):
-            # patch Job#create to set parent jobs as dependencies.
-            job = job_create(*args, **kwargs)
-            job._dependency_ids = [job.id for job in parent_jobs]
-            return job
-
         q = Queue()
-        with patch.object(Job, 'create', create_job_patch) as patch_create_job:
-            job = q.enqueue(say_hello, depends_on=parent_jobs[0])
+        with patch('rq.queue.Job.create', new=MultipleDependencyJob.create):
+            job = q.enqueue(say_hello, depends_on=parent_jobs[0],
+                            _dependency_ids=[job.id for job in parent_jobs])
             self.assertEqual(job.get_status(), JobStatus.QUEUED)
             self.assertEqual(q.job_ids, [job.id])
             self.assertEqual(job.fetch_dependencies(), parent_jobs)
@@ -580,7 +580,7 @@ class TestQueue(RQTestCase):
     def test_enqueues_dependent_if_other_dependencies_finished(self):
 
         parent_jobs = [Job.create(func=say_hello) for _ in
-                       range(2)]
+                       range(3)]
 
         parent_jobs[0]._status = JobStatus.STARTED
         parent_jobs[0].save()
@@ -588,18 +588,15 @@ class TestQueue(RQTestCase):
         parent_jobs[1]._status = JobStatus.FINISHED
         parent_jobs[1].save()
 
-        job_create = Job.create
-
-        def create_job_patch(*args, **kwargs):
-            # patch Job#create to set parent jobs as dependencies.
-            job = job_create(*args, **kwargs)
-            job._dependency_ids = [job.id for job in parent_jobs]
-            return job
+        parent_jobs[2]._status = JobStatus.FINISHED
+        parent_jobs[2].save()
 
         q = Queue()
-        with patch.object(Job, 'create', create_job_patch) as patch_create_job:
+        with patch('rq.queue.Job.create',
+                   new=MultipleDependencyJob.create):
             # dependent job deferred, b/c parent_job 0 is still 'started'
-            dependent_job = q.enqueue(say_hello, depends_on=parent_jobs[0])
+            dependent_job = q.enqueue(say_hello, depends_on=parent_jobs[0],
+                                      _dependency_ids=[job.id for job in parent_jobs])
             self.assertEqual(dependent_job.get_status(), JobStatus.DEFERRED)
 
         # now set parent job 0 to 'finished'
@@ -617,17 +614,10 @@ class TestQueue(RQTestCase):
         queued_dependency = Job.create(func=say_hello, status=JobStatus.QUEUED)
         queued_dependency.save()
 
-        job_create = Job.create
-
-        def create_job_patch(*args, **kwargs):
-            # patch Job#create to set parent jobs as dependencies.
-            job = job_create(*args, **kwargs)
-            job._dependency_ids = [job.id for job in [started_dependency, queued_dependency]]
-            return job
-
         q = Queue()
-        with patch.object(Job, 'create', create_job_patch) as patch_create_job:
-            dependent_job = q.enqueue(say_hello, depends_on=[started_dependency])
+        with patch('rq.queue.Job.create', new=MultipleDependencyJob.create):
+            dependent_job = q.enqueue(say_hello, depends_on=[started_dependency],
+                                      _dependency_ids=[started_dependency.id, queued_dependency.id])
             self.assertEqual(dependent_job.get_status(), JobStatus.DEFERRED)
 
         q.enqueue_dependents(started_dependency)


### PR DESCRIPTION
successor to #1155 

This PR updates `Queue#enqueue_dependents` such that only those _dependents_ for which all _dependencies_ are complete, will be enqueued. It includes:

- New method on `Job#get_dependencies_statuses` to retrieve the status of all of a jobs _dependencies_.
- A modification to `Queue#enqueue_dependents` (as described above).
- A modification to `Worker#handle_job_success` so that the status of **ALL** successful jobs is persisted to `FINISHED` in Redis.
- A small fix(?) to `Job#set_status` so that it uses a pipeline when appropriate.

Notwithstanding any bugs, I believe the next step here is to modify `Job` such that it accepts more than one dependency(in `depends_on`.