### PR TITLE
fix: use correct logging handler for scheduler

### DIFF
--- a/rq/logutils.py
+++ b/rq/logutils.py
@@ -10,8 +10,8 @@ from rq.defaults import (DEFAULT_LOGGING_FORMAT,
 
 
 def setup_loghandlers(level=None, date_format=DEFAULT_LOGGING_DATE_FORMAT,
-                      log_format=DEFAULT_LOGGING_FORMAT):
-    logger = logging.getLogger('rq.worker')
+                      log_format=DEFAULT_LOGGING_FORMAT, name='rq.worker'):
+    logger = logging.getLogger(name)
 
     if not _has_effective_handler(logger):
         formatter = logging.Formatter(fmt=log_format, datefmt=date_format)

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -11,13 +11,18 @@ from .job import Job
 from .queue import Queue
 from .registry import ScheduledJobRegistry
 from .utils import current_timestamp, enum
+from .logutils import setup_loghandlers
 
 
 SCHEDULER_KEY_TEMPLATE = 'rq:scheduler:%s'
 SCHEDULER_LOCKING_KEY_TEMPLATE = 'rq:scheduler-lock:%s'
 
-format = "%(asctime)s: %(message)s"
-logging.basicConfig(format=format, level=logging.INFO, datefmt="%H:%M:%S")
+setup_loghandlers(
+    level=logging.INFO,
+    name="rq.scheduler",
+    log_format="%(asctime)s: %(message)s",
+    date_format="%H:%M:%S"
+)
 
 
 class RQScheduler(object):


### PR DESCRIPTION
The current way the logger is configured in the scheduler impacts other loggers in our project. This probably relates to https://github.com/rq/rq/issues/1177 too.

This PR uses RQ's `setup_loghandlers` instead of calling `logging.basicConfig` directly.