### PR TITLE
Respect timeout -1 in worker hard kill

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -688,7 +688,7 @@ class Worker(object):
                 self.heartbeat(self.job_monitoring_interval + 5)
 
                 # Kill the job from this side if something is really wrong (interpreter lock/etc).
-                if (utcnow() - job.started_at).total_seconds() > (job.timeout + 1):
+                if job.timeout != -1 and (utcnow() - job.started_at).total_seconds() > (job.timeout + 1):
                     self.kill_horse()
                     break
 


### PR DESCRIPTION
This PR alters the hard kill performed in the worker on heartbeat: timeout values of `-1` are considered "no timeout" or "infinite timeout", and no hard kill is performed.

Fixes #1186