### PR TITLE
Store job exception as a result.

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -894,6 +894,7 @@ class Worker(object):
         except:  # NOQA
             job.ended_at = utcnow()
             exc_info = sys.exc_info()
+            job.result = exc_info[1]
             exc_string = self._get_safe_exception_string(
                 traceback.format_exception(*exc_info)
             )


### PR DESCRIPTION
When a job throws an exception, the exception should be stored in the result as per the documentation.

This commit fixes #1190 