### PR TITLE
Add rq.cli.__main__

### DIFF
--- a/rq/cli/__main__.py
+++ b/rq/cli/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from . import main
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This PR adds a `__main__` file, such that the RQ CLI can be launched with `python -m rq.cli`.

Currently the `setup.py` console scripts declaration causes a similar file to be generated for the `rq` script:

```python
# -*- coding: utf-8 -*-
import re
import sys
from rq.cli import main
if __name__ == '__main__':
    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
    sys.exit(main())

```

However, that's not available where I want it to be.