### PR TITLE
fixing HerokuWorkerShutdownTestCase

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -471,7 +471,7 @@ class Worker(object):
 
         The return value indicates whether any jobs were processed.
         """
-        setup_loghandlers(logging_level, date_format, log_format)        
+        setup_loghandlers(logging_level, date_format, log_format)
         completed_jobs = 0
         self.register_birth()
         self.log.info("Worker %s: started, version %s", self.key, VERSION)


### PR DESCRIPTION
after #1194

fix #1212

@selwin in future I would suggest you get tests to pass before merging PRs rather than merging them with failing tests, then asking someone else to resolve the broken tests.

I'm not at all clear why `p.exitcode is None` even though the processes seems to have been successfully killed, so this is the best I can do.
