### PR TITLE
Implement Customizable Serializer Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
   - python: "3.6"
   - python: "3.7"
   - python: "3.8"
-  - python: "pypy"
+  - python: "pypy3"
 install:
   - pip install -e .
   - pip install pytest-cov sentry-sdk codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ services:
   - redis
 matrix:
   include:
-  - python: "2.7"
   - python: "3.4"
   - python: "3.5"
   - python: "3.6"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 mock
 pytest
+dill

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,2 @@
 mock
 pytest
-dill

--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -84,7 +84,7 @@ job = Job.create(count_words_at_url,
 
 ## Job / Queue Creation with Custom Serializer
 
-When creating a job or queue, you can pass in a custom serializer that will be used for serializing / de-serializing messages.
+When creating a job or queue, you can pass in a custom serializer that will be used for serializing / de-serializing job arguments.
 Serializers used should have at least `loads` and `dumps` method.
 The default serializer used is `pickle`
 

--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -82,6 +82,20 @@ job = Job.create(count_words_at_url,
           })
 ```
 
+## Job / Queue Creation with Custom Serializer
+
+When creating a job or queue, you can pass in a custom serializer that will be used for serializing / de-serializing messages.
+Serializers used should have at least `loads` and `dumps` method.
+The default serializer used is `pickle`
+
+```python
+import json
+from rq import Job, Queue
+
+job = Job(connection=connection, serializer=json)
+queue = Queue(connection=connection, serializer=json)
+```
+
 ## Retrieving a Job from Redis
 
 All job information is stored in Redis. You can inspect a job and its attributes

--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -202,6 +202,30 @@ queue = Queue('queue_name', connection=redis)
 workers = Worker.all(queue=queue)
 ```
 
+## Worker with Custom Serializer
+
+When creating a worker, you can pass in a custom serializer that will be implicitly passed to the queue.
+Serializers used should have at least `loads` and `dumps` method.
+The default serializer used is `pickle`
+
+```python
+import json
+from rq import Worker
+
+job = Worker('foo', serializer=json)
+```
+
+or when creating from a queue
+
+```python
+import json
+from rq import Queue, Worker
+
+w = Worker(Queue('foo'), serializer=json)
+```
+
+Queues will now use custom serializer
+
 
 ### Worker Statistics
 

--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -19,12 +19,6 @@ class InvalidJobOperation(Exception):
     pass
 
 
-class UnpickleError(Exception):
-    def __init__(self, message, raw_data, inner_exception=None):
-        super(UnpickleError, self).__init__(message, inner_exception)
-        self.raw_data = raw_data
-
-
 class DequeueTimeout(Exception):
     pass
 
@@ -37,9 +31,3 @@ class ShutDownImminentException(Exception):
 
 class TimeoutFormatError(Exception):
     pass
-
-
-class DeserializationError(Exception):
-    def __init__(self, message, raw_data, inner_exception=None):
-        super(DeserializationError, self).__init__(message, inner_exception)
-        self.raw_data = raw_data

--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -37,3 +37,9 @@ class ShutDownImminentException(Exception):
 
 class TimeoutFormatError(Exception):
     pass
+
+
+class DeserializationError(Exception):
+    def __init__(self, message, raw_data, inner_exception=None):
+        super(DeserializationError, self).__init__(message, inner_exception)
+        self.raw_data = raw_data

--- a/rq/job.py
+++ b/rq/job.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 from rq.compat import as_text, decode_redis_hash, string_types, text_type
 
 from .connections import resolve_connection
-from .exceptions import InvalidJobDependency, NoSuchJobError, UnpickleError, DeserializationError
+from .exceptions import InvalidJobDependency, NoSuchJobError
 from .local import LocalStack
 from .utils import (enum, import_attribute, parse_timeout, str_to_date,
                     utcformat, utcnow)
@@ -457,7 +457,7 @@ class Job(object):
         if result:
             try:
                 self._result = self.serializer.loads(obj.get('result'))
-            except (DeserializationError, UnpickleError) as e:
+            except Exception as e:
                 self._result = "Unserializable return value"
         self.timeout = parse_timeout(obj.get('timeout')) if obj.get('timeout') else None
         self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None  # noqa
@@ -513,7 +513,7 @@ class Job(object):
         if self._result is not None:
             try:
                 obj['result'] = self.serializer.dumps(self._result)
-            except (DeserializationError, UnpickleError) as e:
+            except Exception as e:
                 obj['result'] = "Unserializable return value"
         if self.exc_info is not None:
             obj['exc_info'] = zlib.compress(str(self.exc_info).encode('utf-8'))

--- a/rq/job.py
+++ b/rq/job.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 from rq.compat import as_text, decode_redis_hash, string_types, text_type
 
 from .connections import resolve_connection
-from .exceptions import InvalidJobDependency, NoSuchJobError
+from .exceptions import NoSuchJobError
 from .local import LocalStack
 from .utils import (enum, import_attribute, parse_timeout, str_to_date,
                     utcformat, utcnow)

--- a/rq/job.py
+++ b/rq/job.py
@@ -5,27 +5,17 @@ from __future__ import (absolute_import, division, print_function,
 import inspect
 import warnings
 import zlib
-from functools import partial
 from uuid import uuid4
 
 from rq.compat import as_text, decode_redis_hash, string_types, text_type
 
 from .connections import resolve_connection
-from .exceptions import InvalidJobDependency, NoSuchJobError, UnpickleError
+from .exceptions import InvalidJobDependency, NoSuchJobError, UnpickleError, DeserializationError
 from .local import LocalStack
 from .utils import (enum, import_attribute, parse_timeout, str_to_date,
                     utcformat, utcnow)
+from .serializers import resolve_serializer
 
-try:
-    import cPickle as pickle
-except ImportError:  # noqa  # pragma: no cover
-    import pickle
-
-
-# Serialize pickle dumps using the highest pickle protocol (binary, default
-# uses ascii)
-dumps = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)
-loads = pickle.loads
 
 JobStatus = enum(
     'JobStatus',
@@ -40,21 +30,6 @@ JobStatus = enum(
 # Sentinel value to mark that some of our lazily evaluated properties have not
 # yet been evaluated.
 UNEVALUATED = object()
-
-
-def unpickle(pickled_string):
-    """Unpickles a string, but raises a unified UnpickleError in case anything
-    fails.
-
-    This is a helper method to not have to deal with the fact that `loads()`
-    potentially raises many types of exceptions (e.g. AttributeError,
-    IndexError, TypeError, KeyError, etc.)
-    """
-    try:
-        obj = loads(pickled_string)
-    except Exception as e:
-        raise UnpickleError('Could not unpickle', pickled_string, e)
-    return obj
 
 
 def cancel_job(job_id, connection=None):
@@ -89,7 +64,7 @@ class Job(object):
     def create(cls, func, args=None, kwargs=None, connection=None,
                result_ttl=None, ttl=None, status=None, description=None,
                depends_on=None, timeout=None, id=None, origin=None, meta=None,
-               failure_ttl=None):
+               failure_ttl=None, serializer=None):
         """Creates a new Job instance for the given function, arguments, and
         keyword arguments.
         """
@@ -103,7 +78,7 @@ class Job(object):
         if not isinstance(kwargs, dict):
             raise TypeError('{0!r} is not a valid kwargs dict'.format(kwargs))
 
-        job = cls(connection=connection)
+        job = cls(connection=connection, serializer=serializer)
         if id is not None:
             job.set_id(id)
 
@@ -214,8 +189,8 @@ class Job(object):
 
         return import_attribute(self.func_name)
 
-    def _unpickle_data(self):
-        self._func_name, self._instance, self._args, self._kwargs = unpickle(self.data)
+    def _deserialize_data(self):
+        self._func_name, self._instance, self._args, self._kwargs = self.serializer.deserialize(self.data)
 
     @property
     def data(self):
@@ -233,7 +208,7 @@ class Job(object):
                 self._kwargs = {}
 
             job_tuple = self._func_name, self._instance, self._args, self._kwargs
-            self._data = dumps(job_tuple)
+            self._data = self.serializer.serialize(job_tuple)
         return self._data
 
     @data.setter
@@ -247,7 +222,7 @@ class Job(object):
     @property
     def func_name(self):
         if self._func_name is UNEVALUATED:
-            self._unpickle_data()
+            self._deserialize_data()
         return self._func_name
 
     @func_name.setter
@@ -258,7 +233,7 @@ class Job(object):
     @property
     def instance(self):
         if self._instance is UNEVALUATED:
-            self._unpickle_data()
+            self._deserialize_data()
         return self._instance
 
     @instance.setter
@@ -269,7 +244,7 @@ class Job(object):
     @property
     def args(self):
         if self._args is UNEVALUATED:
-            self._unpickle_data()
+            self._deserialize_data()
         return self._args
 
     @args.setter
@@ -280,7 +255,7 @@ class Job(object):
     @property
     def kwargs(self):
         if self._kwargs is UNEVALUATED:
-            self._unpickle_data()
+            self._deserialize_data()
         return self._kwargs
 
     @kwargs.setter
@@ -295,11 +270,11 @@ class Job(object):
         return conn.exists(cls.key_for(job_id))
 
     @classmethod
-    def fetch(cls, id, connection=None):
+    def fetch(cls, id, connection=None, serializer=None):
         """Fetches a persisted job from its corresponding Redis key and
         instantiates it.
         """
-        job = cls(id, connection=connection)
+        job = cls(id, connection=connection, serializer=serializer)
         job.refresh()
         return job
 
@@ -327,7 +302,7 @@ class Job(object):
 
         return jobs
 
-    def __init__(self, id=None, connection=None):
+    def __init__(self, id=None, connection=None, serializer=None):
         self.connection = resolve_connection(connection)
         self._id = id
         self.created_at = utcnow()
@@ -350,6 +325,7 @@ class Job(object):
         self._status = None
         self._dependency_ids = []
         self.meta = {}
+        self.serializer = resolve_serializer(serializer)
 
     def __repr__(self):  # noqa  # pragma: no cover
         return '{0}({1!r}, enqueued_at={2!r})'.format(self.__class__.__name__,
@@ -451,7 +427,7 @@ class Job(object):
             rv = self.connection.hget(self.key, 'result')
             if rv is not None:
                 # cache the result
-                self._result = loads(rv)
+                self._result = self.serializer.deserialize(rv)
         return self._result
 
     """Backwards-compatibility accessor property `return_value`."""
@@ -480,9 +456,9 @@ class Job(object):
         result = obj.get('result')
         if result:
             try:
-                self._result = unpickle(obj.get('result'))
-            except UnpickleError:
-                self._result = 'Unpickleable return value'
+                self._result = self.serializer.deserialize(obj.get('result'))
+            except (DeserializationError, UnpickleError) as e:
+                self._result = "Unserializable return value"
         self.timeout = parse_timeout(obj.get('timeout')) if obj.get('timeout') else None
         self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None  # noqa
         self.failure_ttl = int(obj.get('failure_ttl')) if obj.get('failure_ttl') else None  # noqa
@@ -492,7 +468,7 @@ class Job(object):
         self._dependency_ids = [as_text(dependency_id)] if dependency_id else []
 
         self.ttl = int(obj.get('ttl')) if obj.get('ttl') else None
-        self.meta = unpickle(obj.get('meta')) if obj.get('meta') else {}
+        self.meta = self.serializer.deserialize(obj.get('meta')) if obj.get('meta') else {}
 
         raw_exc_info = obj.get('exc_info')
         if raw_exc_info:
@@ -536,9 +512,9 @@ class Job(object):
         obj['ended_at'] = utcformat(self.ended_at) if self.ended_at else ''
         if self._result is not None:
             try:
-                obj['result'] = dumps(self._result)
-            except:
-                obj['result'] = 'Unpickleable return value'
+                obj['result'] = self.serializer.serialize(self._result)
+            except (DeserializationError, UnpickleError) as e:
+                obj['result'] = "Unserializable return value"
         if self.exc_info is not None:
             obj['exc_info'] = zlib.compress(str(self.exc_info).encode('utf-8'))
         if self.timeout is not None:
@@ -552,7 +528,7 @@ class Job(object):
         if self._dependency_ids:
             obj['dependency_id'] = self._dependency_ids[0]
         if self.meta and include_meta:
-            obj['meta'] = dumps(self.meta)
+            obj['meta'] = self.serializer.serialize(self.meta)
         if self.ttl:
             obj['ttl'] = self.ttl
 
@@ -575,7 +551,7 @@ class Job(object):
 
     def save_meta(self):
         """Stores job meta from the job instance to the corresponding Redis key."""
-        meta = dumps(self.meta)
+        meta = self.serializer.serialize(self.meta)
         self.connection.hset(self.key, 'meta', meta)
 
     def cancel(self, pipeline=None):

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -555,7 +555,7 @@ class Queue(object):
                 # Silently pass on jobs that don't exist (anymore),
                 # and continue in the look
                 continue
-            except (DeserializationError, UnpickleError) as e:
+            except Exception as e:
                 # Attach queue information on the exception for improved error
                 # reporting
                 e.job_id = job_id

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -12,7 +12,7 @@ from redis import WatchError
 from .compat import as_text, string_types, total_ordering, utc
 from .connections import resolve_connection
 from .defaults import DEFAULT_RESULT_TTL
-from .exceptions import DequeueTimeout, NoSuchJobError, UnpickleError, DeserializationError
+from .exceptions import DequeueTimeout, NoSuchJobError
 from .job import Job, JobStatus
 from .utils import backend_class, import_attribute, parse_timeout, utcnow
 from .serializers import resolve_serializer

--- a/rq/serializers.py
+++ b/rq/serializers.py
@@ -1,37 +1,20 @@
 import pickle
 
-from .exceptions import DeserializationError
-
-
-class MySerializer(object):
-    """MySerializer Class that uses the user specified serializer module."""
-    def __init__(self, serializer):
-        self.serializer = serializer
-
-    def dumps(self, data):
-        try:
-            serialized_data = self.serializer.dumps(data)
-        except Exception as e:
-            raise DeserializationError("Unserializable return value", data, e)
-
-        return serialized_data
-
-    def loads(self, serialized_string):
-        try:
-            obj = self.serializer.loads(serialized_string)
-        except Exception as e:
-            raise DeserializationError('Could not deserialize', serialized_string, e)
-
-        return obj
+from .compat import string_types
+from .utils import import_attribute
 
 
 def resolve_serializer(serializer):
     """This function checks the user defined serializer for ('dumps', 'loads') methods
     It returns a default pickle serializer if not found else it returns a MySerializer
     The returned serializer objects implement ('dumps', 'loads') methods
+    Also accepts a string path to serializer that will be loaded as the serializer
     """
     if not serializer:
         return pickle
+
+    if isinstance(serializer, string_types):
+        serializer = import_attribute(serializer)
 
     default_serializer_methods = ('dumps', 'loads')
 
@@ -39,4 +22,4 @@ def resolve_serializer(serializer):
         if not hasattr(serializer, instance_method):
             raise NotImplementedError('Serializer should have (dumps, loads) methods.')
 
-    return MySerializer(serializer)
+    return serializer

--- a/rq/serializers.py
+++ b/rq/serializers.py
@@ -1,0 +1,80 @@
+from abc import ABCMeta
+from functools import partial
+from .exceptions import UnpickleError, DeserializationError
+
+try:
+    import cPickle as pickle
+except ImportError:  # noqa  # pragma: no cover
+    import pickle
+
+
+class BaseSerializer(object):
+    __metaclass__ = ABCMeta
+
+    def serialize(self, value):
+        raise NotImplementedError('This method must be implemented')
+
+    def deserialize(self, value):
+        raise NotImplementedError('This method must be implemented')
+
+
+class DefaultSerializer(BaseSerializer):
+    """DefaultSerializer Class that uses the pickle module."""
+    def __init__(self):
+        self.serializer = pickle
+
+    def serialize(self, data):
+        try:
+            serialized_data = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)(data)
+        except Exception as e:
+            raise UnpickleError('Unpickleable return value', data, e)
+
+        return serialized_data
+
+    def deserialize(self, pickled_string):
+        try:
+            obj = self.serializer.loads(pickled_string)
+        except Exception as e:
+            raise UnpickleError('Could not unpickle', pickled_string, e)
+
+        return obj
+
+
+class CustomSerializer(BaseSerializer):
+    """CustomSerializer Class that uses the user specified serializer module."""
+    def __init__(self, serializer):
+        self.serializer = serializer
+
+    def serialize(self, data):
+        try:
+            serialized_data = self.serializer.dumps(data)
+        except Exception as e:
+            raise DeserializationError("Unserializable return value", data, e)
+
+        return serialized_data
+
+    def deserialize(self, serialized_string):
+        try:
+            obj = self.serializer.loads(serialized_string)
+        except Exception as e:
+            raise DeserializationError('Could not deserialize', serialized_string, e)
+
+        return obj
+
+
+def resolve_serializer(serializer):
+    """This function checks the user defined serializer for ('dumps', 'loads') methods
+    It returns a DefaultSerializer if not found else it returns a CustomSerializer
+    The returned serializer objects implement ('serialize', 'deserialize') methods
+    for the ('dumps', 'loads') methods respectively
+    """
+    if not serializer:
+        return DefaultSerializer()
+
+    default_serializer_methods = ('dumps', 'loads')
+
+    for instance_method in default_serializer_methods:
+        if not hasattr(serializer, instance_method):
+            return DefaultSerializer()
+
+    return CustomSerializer(serializer)

--- a/rq/serializers.py
+++ b/rq/serializers.py
@@ -75,6 +75,6 @@ def resolve_serializer(serializer):
 
     for instance_method in default_serializer_methods:
         if not hasattr(serializer, instance_method):
-            return DefaultSerializer()
+            raise NotImplementedError('Serializer should have (dumps, loads) methods.')
 
     return MySerializer(serializer)

--- a/rq/serializers.py
+++ b/rq/serializers.py
@@ -1,46 +1,9 @@
-from abc import ABCMeta
-from functools import partial
-from .exceptions import UnpickleError, DeserializationError
+import pickle
 
-try:
-    import cPickle as pickle
-except ImportError:  # noqa  # pragma: no cover
-    import pickle
+from .exceptions import DeserializationError
 
 
-class BaseSerializer(object):
-    __metaclass__ = ABCMeta
-
-    def dumps(self, value):
-        raise NotImplementedError('This method must be implemented')
-
-    def loads(self, value):
-        raise NotImplementedError('This method must be implemented')
-
-
-class DefaultSerializer(BaseSerializer):
-    """DefaultSerializer Class that uses the pickle module."""
-    def __init__(self):
-        self.serializer = pickle
-
-    def dumps(self, data):
-        try:
-            serialized_data = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)(data)
-        except Exception as e:
-            raise UnpickleError('Unpickleable return value', data, e)
-
-        return serialized_data
-
-    def loads(self, pickled_string):
-        try:
-            obj = self.serializer.loads(pickled_string)
-        except Exception as e:
-            raise UnpickleError('Could not unpickle', pickled_string, e)
-
-        return obj
-
-
-class MySerializer(BaseSerializer):
+class MySerializer(object):
     """MySerializer Class that uses the user specified serializer module."""
     def __init__(self, serializer):
         self.serializer = serializer
@@ -64,12 +27,11 @@ class MySerializer(BaseSerializer):
 
 def resolve_serializer(serializer):
     """This function checks the user defined serializer for ('dumps', 'loads') methods
-    It returns a DefaultSerializer if not found else it returns a MySerializer
+    It returns a default pickle serializer if not found else it returns a MySerializer
     The returned serializer objects implement ('dumps', 'loads') methods
-    for the ('dumps', 'loads') methods respectively
     """
     if not serializer:
-        return DefaultSerializer()
+        return pickle
 
     default_serializer_methods = ('dumps', 'loads')
 

--- a/rq/serializers.py
+++ b/rq/serializers.py
@@ -11,10 +11,10 @@ except ImportError:  # noqa  # pragma: no cover
 class BaseSerializer(object):
     __metaclass__ = ABCMeta
 
-    def serialize(self, value):
+    def dumps(self, value):
         raise NotImplementedError('This method must be implemented')
 
-    def deserialize(self, value):
+    def loads(self, value):
         raise NotImplementedError('This method must be implemented')
 
 
@@ -23,7 +23,7 @@ class DefaultSerializer(BaseSerializer):
     def __init__(self):
         self.serializer = pickle
 
-    def serialize(self, data):
+    def dumps(self, data):
         try:
             serialized_data = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)(data)
         except Exception as e:
@@ -31,7 +31,7 @@ class DefaultSerializer(BaseSerializer):
 
         return serialized_data
 
-    def deserialize(self, pickled_string):
+    def loads(self, pickled_string):
         try:
             obj = self.serializer.loads(pickled_string)
         except Exception as e:
@@ -40,12 +40,12 @@ class DefaultSerializer(BaseSerializer):
         return obj
 
 
-class CustomSerializer(BaseSerializer):
-    """CustomSerializer Class that uses the user specified serializer module."""
+class MySerializer(BaseSerializer):
+    """MySerializer Class that uses the user specified serializer module."""
     def __init__(self, serializer):
         self.serializer = serializer
 
-    def serialize(self, data):
+    def dumps(self, data):
         try:
             serialized_data = self.serializer.dumps(data)
         except Exception as e:
@@ -53,7 +53,7 @@ class CustomSerializer(BaseSerializer):
 
         return serialized_data
 
-    def deserialize(self, serialized_string):
+    def loads(self, serialized_string):
         try:
             obj = self.serializer.loads(serialized_string)
         except Exception as e:
@@ -64,8 +64,8 @@ class CustomSerializer(BaseSerializer):
 
 def resolve_serializer(serializer):
     """This function checks the user defined serializer for ('dumps', 'loads') methods
-    It returns a DefaultSerializer if not found else it returns a CustomSerializer
-    The returned serializer objects implement ('serialize', 'deserialize') methods
+    It returns a DefaultSerializer if not found else it returns a MySerializer
+    The returned serializer objects implement ('dumps', 'loads') methods
     for the ('dumps', 'loads') methods respectively
     """
     if not serializer:
@@ -77,4 +77,4 @@ def resolve_serializer(serializer):
         if not hasattr(serializer, instance_method):
             return DefaultSerializer()
 
-    return CustomSerializer(serializer)
+    return MySerializer(serializer)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -175,3 +175,10 @@ def kill_worker(pid, double_kill, interval=0.5):
         # give the worker time to switch signal handler
         time.sleep(interval)
         os.kill(pid, signal.SIGTERM)
+
+
+class Serializer(object):
+    def loads(self): pass
+
+    def dumps(self): pass
+

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import json
 import time
-import queue as queue
+import queue
 import zlib
 from datetime import datetime
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -21,7 +21,7 @@ from rq.utils import utcformat
 from rq.worker import Worker
 from tests import RQTestCase, fixtures
 
-from pickle import loads, dumps, UnpicklingError
+from pickle import loads, dumps
 
 
 class TestJob(RQTestCase):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import dill
+import json
 import sys
 import time
 import zlib
@@ -120,8 +121,18 @@ class TestJob(RQTestCase):
 
     def test_create_job_with_serializer(self):
         """Creation of jobs with serializer for instance methods."""
+        # Test using dill serializer
         n = fixtures.Number(2)
         job = Job.create(func=n.div, args=(4,), serializer=dill)
+
+        self.assertIsNotNone(job.serializer)
+        self.assertEqual(job.func, n.div)
+        self.assertEqual(job.instance, n)
+        self.assertEqual(job.args, (4,))
+
+        # Test using json serializer
+        n = fixtures.Number(2)
+        job = Job.create(func=n.div, args=(4,), serializer=json)
 
         self.assertIsNotNone(job.serializer)
         self.assertEqual(job.func, n.div)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import dill
 import json
 import sys
 import time
@@ -121,15 +120,6 @@ class TestJob(RQTestCase):
 
     def test_create_job_with_serializer(self):
         """Creation of jobs with serializer for instance methods."""
-        # Test using dill serializer
-        n = fixtures.Number(2)
-        job = Job.create(func=n.div, args=(4,), serializer=dill)
-
-        self.assertIsNotNone(job.serializer)
-        self.assertEqual(job.func, n.div)
-        self.assertEqual(job.instance, n)
-        self.assertEqual(job.args, (4,))
-
         # Test using json serializer
         n = fixtures.Number(2)
         job = Job.create(func=n.div, args=(4,), serializer=json)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -32,7 +32,7 @@ class TestQueue(RQTestCase):
         self.assertEqual(str(q), '<Queue my-queue>')
 
     def test_create_queue_with_serializer(self):
-        """Creating queues."""
+        """Creating queues with serializer."""
         # Test using dill serializer
         q = Queue('queue-with-serializer', serializer=dill)
         self.assertEqual(q.name, 'queue-with-serializer')

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,7 +2,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import dill
 import json
 from datetime import datetime, timedelta
 
@@ -33,12 +32,6 @@ class TestQueue(RQTestCase):
 
     def test_create_queue_with_serializer(self):
         """Creating queues with serializer."""
-        # Test using dill serializer
-        q = Queue('queue-with-serializer', serializer=dill)
-        self.assertEqual(q.name, 'queue-with-serializer')
-        self.assertEqual(str(q), '<Queue queue-with-serializer>')
-        self.assertIsNotNone(q.serializer)
-
         # Test using json serializer
         q = Queue('queue-with-serializer', serializer=json)
         self.assertEqual(q.name, 'queue-with-serializer')

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -32,7 +32,7 @@ class TestQueue(RQTestCase):
 
     def test_create_queue_with_serializer(self):
         """Creating queues."""
-        q = Queue('my-queue', serializer=dill)
+        q = Queue('queue-with-serializer', serializer=dill)
         self.assertEqual(q.name, 'queue-with-serializer')
         self.assertEqual(str(q), '<Queue queue-with-serializer>')
         self.assertIsNotNone(q.serializer)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import dill
+import json
 from datetime import datetime, timedelta
 
 from rq import Queue
@@ -32,7 +33,14 @@ class TestQueue(RQTestCase):
 
     def test_create_queue_with_serializer(self):
         """Creating queues."""
+        # Test using dill serializer
         q = Queue('queue-with-serializer', serializer=dill)
+        self.assertEqual(q.name, 'queue-with-serializer')
+        self.assertEqual(str(q), '<Queue queue-with-serializer>')
+        self.assertIsNotNone(q.serializer)
+
+        # Test using json serializer
+        q = Queue('queue-with-serializer', serializer=json)
         self.assertEqual(q.name, 'queue-with-serializer')
         self.assertEqual(str(q), '<Queue queue-with-serializer>')
         self.assertIsNotNone(q.serializer)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import dill
 from datetime import datetime, timedelta
 
 from rq import Queue
@@ -28,6 +29,13 @@ class TestQueue(RQTestCase):
         q = Queue('my-queue')
         self.assertEqual(q.name, 'my-queue')
         self.assertEqual(str(q), '<Queue my-queue>')
+
+    def test_create_queue_with_serializer(self):
+        """Creating queues."""
+        q = Queue('my-queue', serializer=dill)
+        self.assertEqual(q.name, 'queue-with-serializer')
+        self.assertEqual(str(q), '<Queue queue-with-serializer>')
+        self.assertIsNotNone(q.serializer)
 
     def test_create_default_queue(self):
         """Instantiating the default queue."""

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -3,12 +3,20 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import json
+import sys
 from rq.serializers import resolve_serializer, MySerializer
+from rq.exceptions import DeserializationError
 
 try:
     import unittest
 except ImportError:
     import unittest2 as unittest  # noqa
+
+is_py2 = sys.version[0] == '2'
+if is_py2:
+    import Queue as queue
+else:
+    import queue as queue
 
 
 class TestSerializers(unittest.TestCase):
@@ -31,3 +39,7 @@ class TestSerializers(unittest.TestCase):
         # Test raise NotImplmentedError
         with self.assertRaises(NotImplementedError):
             resolve_serializer(object)
+
+        # Test raise DeserializationError
+        with self.assertRaises(DeserializationError):
+            serializer.dumps(queue.Queue())

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import json
+import pickle
 import queue
 import unittest
 
@@ -14,9 +15,7 @@ class TestSerializers(unittest.TestCase):
         """Ensure function resolve_serializer works correctly"""
         serializer = resolve_serializer(None)
         self.assertIsNotNone(serializer)
-
-        self.assertTrue(hasattr(serializer, 'dumps'))
-        self.assertTrue(hasattr(serializer, 'loads'))
+        self.assertEqual(serializer, pickle)
 
         # Test using json serializer
         serializer = resolve_serializer(json)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -3,20 +3,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import json
-import sys
+import queue as queue
+import unittest
+
 from rq.serializers import resolve_serializer, MySerializer
 from rq.exceptions import DeserializationError
-
-try:
-    import unittest
-except ImportError:
-    import unittest2 as unittest  # noqa
-
-is_py2 = sys.version[0] == '2'
-if is_py2:
-    import Queue as queue
-else:
-    import queue as queue
 
 
 class TestSerializers(unittest.TestCase):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import dill
+from rq.serializers import resolve_serializer, DefaultSerializer, CustomSerializer
+
+try:
+    import unittest
+except ImportError:
+    import unittest2 as unittest  # noqa
+
+
+class TestSerializers(unittest.TestCase):
+    def test_resolve_serializer(self):
+        """Ensure function parse_timeout works correctly"""
+        serializer = resolve_serializer(None)
+        self.assertIsNotNone(serializer)
+        self.assertIsInstance(serializer, DefaultSerializer)
+
+        self.assertTrue(hasattr(serializer, 'serialize'))
+        self.assertTrue(hasattr(serializer, 'deserialize'))
+
+        serializer = resolve_serializer(dill)
+        self.assertIsNotNone(serializer)
+        self.assertIsInstance(serializer, CustomSerializer)
+
+        self.assertTrue(hasattr(serializer, 'serialize'))
+        self.assertTrue(hasattr(serializer, 'deserialize'))

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -14,7 +14,7 @@ except ImportError:
 
 class TestSerializers(unittest.TestCase):
     def test_resolve_serializer(self):
-        """Ensure function parse_timeout works correctly"""
+        """Ensure function resolve_serializer works correctly"""
         serializer = resolve_serializer(None)
         self.assertIsNotNone(serializer)
         self.assertIsInstance(serializer, DefaultSerializer)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import json
-import queue as queue
+import queue
 import unittest
 
 from rq.serializers import resolve_serializer

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -2,9 +2,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import dill
 import json
-from rq.serializers import resolve_serializer, DefaultSerializer, MySerializer
+from rq.serializers import resolve_serializer, MySerializer
 
 try:
     import unittest
@@ -17,15 +16,6 @@ class TestSerializers(unittest.TestCase):
         """Ensure function resolve_serializer works correctly"""
         serializer = resolve_serializer(None)
         self.assertIsNotNone(serializer)
-        self.assertIsInstance(serializer, DefaultSerializer)
-
-        self.assertTrue(hasattr(serializer, 'dumps'))
-        self.assertTrue(hasattr(serializer, 'loads'))
-
-        # Test using dill serializer
-        serializer = resolve_serializer(dill)
-        self.assertIsNotNone(serializer)
-        self.assertIsInstance(serializer, MySerializer)
 
         self.assertTrue(hasattr(serializer, 'dumps'))
         self.assertTrue(hasattr(serializer, 'loads'))
@@ -37,3 +27,7 @@ class TestSerializers(unittest.TestCase):
 
         self.assertTrue(hasattr(serializer, 'dumps'))
         self.assertTrue(hasattr(serializer, 'loads'))
+
+        # Test raise NotImplmentedError
+        with self.assertRaises(NotImplementedError):
+            resolve_serializer(object)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import dill
-from rq.serializers import resolve_serializer, DefaultSerializer, CustomSerializer
+from rq.serializers import resolve_serializer, DefaultSerializer, MySerializer
 
 try:
     import unittest
@@ -18,12 +18,12 @@ class TestSerializers(unittest.TestCase):
         self.assertIsNotNone(serializer)
         self.assertIsInstance(serializer, DefaultSerializer)
 
-        self.assertTrue(hasattr(serializer, 'serialize'))
-        self.assertTrue(hasattr(serializer, 'deserialize'))
+        self.assertTrue(hasattr(serializer, 'dumps'))
+        self.assertTrue(hasattr(serializer, 'loads'))
 
         serializer = resolve_serializer(dill)
         self.assertIsNotNone(serializer)
-        self.assertIsInstance(serializer, CustomSerializer)
+        self.assertIsInstance(serializer, MySerializer)
 
-        self.assertTrue(hasattr(serializer, 'serialize'))
-        self.assertTrue(hasattr(serializer, 'deserialize'))
+        self.assertTrue(hasattr(serializer, 'dumps'))
+        self.assertTrue(hasattr(serializer, 'loads'))

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -6,8 +6,7 @@ import json
 import queue as queue
 import unittest
 
-from rq.serializers import resolve_serializer, MySerializer
-from rq.exceptions import DeserializationError
+from rq.serializers import resolve_serializer
 
 
 class TestSerializers(unittest.TestCase):
@@ -22,7 +21,6 @@ class TestSerializers(unittest.TestCase):
         # Test using json serializer
         serializer = resolve_serializer(json)
         self.assertIsNotNone(serializer)
-        self.assertIsInstance(serializer, MySerializer)
 
         self.assertTrue(hasattr(serializer, 'dumps'))
         self.assertTrue(hasattr(serializer, 'loads'))
@@ -31,6 +29,10 @@ class TestSerializers(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             resolve_serializer(object)
 
-        # Test raise DeserializationError
-        with self.assertRaises(DeserializationError):
-            serializer.dumps(queue.Queue())
+        # Test raise Exception
+        with self.assertRaises(Exception):
+            resolve_serializer(queue.Queue())
+
+        # Test using path.to.serializer string
+        serializer = resolve_serializer('tests.fixtures.Serializer')
+        self.assertIsNotNone(serializer)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import dill
+import json
 from rq.serializers import resolve_serializer, DefaultSerializer, MySerializer
 
 try:
@@ -21,7 +22,16 @@ class TestSerializers(unittest.TestCase):
         self.assertTrue(hasattr(serializer, 'dumps'))
         self.assertTrue(hasattr(serializer, 'loads'))
 
+        # Test using dill serializer
         serializer = resolve_serializer(dill)
+        self.assertIsNotNone(serializer)
+        self.assertIsInstance(serializer, MySerializer)
+
+        self.assertTrue(hasattr(serializer, 'dumps'))
+        self.assertTrue(hasattr(serializer, 'loads'))
+
+        # Test using json serializer
+        serializer = resolve_serializer(json)
         self.assertIsNotNone(serializer)
         self.assertIsInstance(serializer, MySerializer)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import json
 import os
 import shutil
 import signal
@@ -96,6 +97,14 @@ class TestWorker(RQTestCase):
         w = Worker([Queue('foo'), Queue('bar')])
         self.assertEqual(w.queues[0].name, 'foo')
         self.assertEqual(w.queues[1].name, 'bar')
+
+        # With string and serializer
+        w = Worker('foo', serializer=json)
+        self.assertEqual(w.queues[0].name, 'foo')
+
+        # With queue having serializer
+        w = Worker(Queue('foo', serializer=json))
+        self.assertEqual(w.queues[0].name, 'foo')
 
     def test_work_and_quit(self):
         """Worker processes work, then quits."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -103,7 +103,7 @@ class TestWorker(RQTestCase):
         self.assertEqual(w.queues[0].name, 'foo')
 
         # With queue having serializer
-        w = Worker(Queue('foo', serializer=json))
+        w = Worker(Queue('foo'), serializer=json)
         self.assertEqual(w.queues[0].name, 'foo')
 
     def test_work_and_quit(self):


### PR DESCRIPTION
Based of inspiration gotten from https://github.com/rq/rq/pull/1141

This is an approach to create Queues and Jobs with customized serializer objects.
The serializer object should have at least dumps and loads methods.
If no serializer is specified, it defaults to pickle

Usage:

```
import dill
import json, pickle

job = Job(connection=connection, serializer=dill)
queue = Queue(connection=connection, serializer=dill)

queue = Queue(connection=connection, serializer=pickle)  # pickle serializer
queue = Queue(connection=connection, serializer=json)
```

Closes issue https://github.com/rq/rq/issues/369

I'd appreciate any and all feedback on this approach!