### PR TITLE
Accept lowercase logging level names and accept tuples when setting exception handlers

### DIFF
--- a/rq/logutils.py
+++ b/rq/logutils.py
@@ -20,7 +20,9 @@ def setup_loghandlers(level=None, date_format=DEFAULT_LOGGING_DATE_FORMAT,
         logger.addHandler(handler)
 
     if level is not None:
-        logger.setLevel(level)
+        # The level may be a numeric value (e.g. when using the logging module constants)
+        # Or a string representation of the logging level
+        logger.setLevel(level if isinstance(level, int) else level.upper())
 
 
 def _has_effective_handler(logger):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -208,7 +208,7 @@ class Worker(object):
 
         self.disable_default_exception_handler = disable_default_exception_handler
 
-        if isinstance(exception_handlers, list):
+        if isinstance(exception_handlers, (list, tuple)):
             for handler in exception_handlers:
                 self.push_exc_handler(handler)
         elif exception_handlers is not None:


### PR DESCRIPTION
Hello,

This pull request contains 2 small changes to allow passing lowercase logging levels:

```shell
# Using a lowercase logging level throws a ValueError: Unknown level: 'debug'
rq worker --logging_level debug
```

Now `logutils.setup_loghandlers` accepts both lowercase and uppercase logging level names and numeric values, for example when setting the level from the `logging` module constants (e.g. `logging.DEBUG`).

The second change allows passing the `exception_handlers` of the `Worker` class as a `list` or a `tuple`.

```python
from rq import Worker
import handlers

# This was silently appending the tuple to self._exc_handlers
w = Worker(exception_handlers=(handlers.one, handlers.two))
```
