### PR TITLE
Add the queue to the Redis queues set when scheduling a job

### DIFF
--- a/rq/logutils.py
+++ b/rq/logutils.py
@@ -20,7 +20,9 @@ def setup_loghandlers(level=None, date_format=DEFAULT_LOGGING_DATE_FORMAT,
         logger.addHandler(handler)
 
     if level is not None:
-        logger.setLevel(level)
+        # The level may be a numeric value (e.g. when using the logging module constants)
+        # Or a string representation of the logging level
+        logger.setLevel(level if isinstance(level, int) else level.upper())
 
 
 def _has_effective_handler(logger):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -208,7 +208,7 @@ class Worker(object):
 
         self.disable_default_exception_handler = disable_default_exception_handler
 
-        if isinstance(exception_handlers, list):
+        if isinstance(exception_handlers, (list, tuple)):
             for handler in exception_handlers:
                 self.push_exc_handler(handler)
         elif exception_handlers is not None:


### PR DESCRIPTION
Hello,

This pull request adds the queue to the Redis queues set when a job is scheduled, previously if you schedule a job on a queue that doesn't have any jobs then the job will be added to the `ScheduledJobRegistry` but the queue won't be available in the queues set:

```console
127.0.0.1:6379> keys *
1) "rq:scheduled:default"
2) "rq:job:52c77ae6-e85c-43c6-9649-38f293be5bcb"
```

So when getting all the queues using `Queue.all()` we won't get this queue in the list because it wasn't added, so now when scheduling a job the queue will be added to the set in the `Queue.enqueue_at` method which is also used by `Queue.enqueue_in` matching the behavior of the `Queue.enqueue_job` method which adds the queue:

```python
# Add Queue key set
pipe.sadd(self.redis_queues_keys, self.key)
```

This is useful for monitoring purposes and also consistency.
