### PR TITLE
Add the queue to the Redis queues set when scheduling a job

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -380,7 +380,7 @@ class Queue(object):
 
         (f, timeout, description, result_ttl, ttl, failure_ttl,
          depends_on, job_id, at_front, meta, args, kwargs) = Queue.parse_args(f, *args, **kwargs)
-        
+
         return self.enqueue_call(
             func=f, args=args, kwargs=kwargs, timeout=timeout,
             result_ttl=result_ttl, ttl=ttl, failure_ttl=failure_ttl,
@@ -401,6 +401,8 @@ class Queue(object):
 
         registry = ScheduledJobRegistry(queue=self)
         with self.connection.pipeline() as pipeline:
+            # Add Queue key set
+            pipeline.sadd(self.redis_queues_keys, self.key)
             job.save(pipeline=pipeline)
             registry.schedule(job, datetime, pipeline=pipeline)
             pipeline.execute()

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -192,25 +192,25 @@ class Queue(object):
 
     @property
     def started_job_registry(self):
-        """Returns this queue's FailedJobRegistry."""
+        """Returns this queue's StartedJobRegistry."""
         from rq.registry import StartedJobRegistry
         return StartedJobRegistry(queue=self, job_class=self.job_class)
 
     @property
     def finished_job_registry(self):
-        """Returns this queue's FailedJobRegistry."""
+        """Returns this queue's FinishedJobRegistry."""
         from rq.registry import FinishedJobRegistry
         return FinishedJobRegistry(queue=self)
 
     @property
     def deferred_job_registry(self):
-        """Returns this queue's FailedJobRegistry."""
+        """Returns this queue's DeferredJobRegistry."""
         from rq.registry import DeferredJobRegistry
         return DeferredJobRegistry(queue=self, job_class=self.job_class)
 
     @property
     def scheduled_job_registry(self):
-        """Returns this queue's FailedJobRegistry."""
+        """Returns this queue's ScheduledJobRegistry."""
         from rq.registry import ScheduledJobRegistry
         return ScheduledJobRegistry(queue=self, job_class=self.job_class)
 


### PR DESCRIPTION
Hello,

This pull request adds the queue to the Redis queues set when a job is scheduled, previously if you schedule a job on a queue that doesn't have any jobs then the job will be added to the `ScheduledJobRegistry` but the queue won't be available in the queues set:

```console
127.0.0.1:6379> keys *
1) "rq:scheduled:default"
2) "rq:job:52c77ae6-e85c-43c6-9649-38f293be5bcb"
```

So when getting all the queues using `Queue.all()` we won't get this queue in the list because it wasn't added, so now when scheduling a job the queue will be added to the set in the `Queue.enqueue_at` method which is also used by `Queue.enqueue_in` matching the behavior of the `Queue.enqueue_job` method which adds the queue:

```python
# Add Queue key set
pipe.sadd(self.redis_queues_keys, self.key)
```

This is useful for monitoring purposes and also consistency.
