### PR TITLE
Always set job.started_at in monitor_work_horse

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -678,7 +678,7 @@ class Worker(object):
         """
 
         ret_val = None
-        job.started_at = job.started_at or utcnow()
+        job.started_at = utcnow()
         while True:
             try:
                 with UnixSignalDeathPenalty(self.job_monitoring_interval, HorseMonitorTimeoutException):


### PR DESCRIPTION
Solves #1241 where `monitor_work_horse` could have a stale reference to `job.started_at` if the job is being reused by a scheduler (like rq-scheduler).