### PR TITLE
Remove extraneous try/except

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -747,15 +747,10 @@ class Worker(object):
         # that are different from the worker.
         random.seed()
 
-        try:
-            self.setup_work_horse_signals()
-            self._is_horse = True
-            self.log = logger
-            self.perform_job(job, queue)
-        except Exception as e:  # noqa
-            # Horse does not terminate properly
-            raise e
-            os._exit(1)
+        self.setup_work_horse_signals()
+        self._is_horse = True
+        self.log = logger
+        self.perform_job(job, queue)
 
         # os._exit() is the way to exit from childs after a fork(), in
         # contrast to the regular sys.exit()


### PR DESCRIPTION
This addresses issue #1246.

The exception handling block was raising the caught exception in-place, which caused the original traceback info to be lost. Rather than replace `raise e` with `raise`, I simply removed the whole try / except, since no action was being taken in the except block.