### PR TITLE
Use unicode interpolation to avoid str(...)

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -516,7 +516,7 @@ class Job(object):
             except Exception:
                 obj['result'] = "Unserializable return value"
         if self.exc_info is not None:
-            _exec_info = u'%s' % (self.exc_info,)
+            _exec_info = '%s' % (self.exc_info,)
             obj['exc_info'] = zlib.compress(_exec_info.encode('utf-8'))
         if self.timeout is not None:
             obj['timeout'] = self.timeout

--- a/rq/job.py
+++ b/rq/job.py
@@ -513,10 +513,11 @@ class Job(object):
         if self._result is not None:
             try:
                 obj['result'] = self.serializer.dumps(self._result)
-            except Exception as e:
+            except Exception:
                 obj['result'] = "Unserializable return value"
         if self.exc_info is not None:
-            obj['exc_info'] = zlib.compress(str(self.exc_info).encode('utf-8'))
+            _exec_info = u'%s' % (self.exc_info,)
+            obj['exc_info'] = zlib.compress(_exec_info.encode('utf-8'))
         if self.timeout is not None:
             obj['timeout'] = self.timeout
         if self.result_ttl is not None:


### PR DESCRIPTION
Hey @selwin, thanks for merging my other #1247 patch so quickly; I wrote another small patch.

In Python 2, if a `UnicodeDecodeError` occurs in the Job, the Unicode value in `Job.exc_info` results in a new `UnicodeDecodeError` when trying to cast the `exc_info` value to a `str`.

This pull replaces that `str(...)` call with `u'%s' % (...,)`, which essentially functions as `unicode(value)` in Python 2 and `str(value)` in Python 3.