### PR TITLE
Avoid deprecation warnings on redis-py 3.5.0 hmset

### DIFF
--- a/rq/compat/__init__.py
+++ b/rq/compat/__init__.py
@@ -104,3 +104,12 @@ except ImportError:
             return timedelta(0)
 
     utc = UTC()
+
+
+def hmset(pipe_or_connection, name, mapping):
+    # redis-py versions 3.5.0 and above accept a mapping parameter for hset
+    try:
+        return pipe_or_connection.hset(name, mapping=mapping)
+    # earlier versions require hmset to be used
+    except TypeError:
+        return pipe_or_connection.hmset(name, mapping)

--- a/rq/job.py
+++ b/rq/job.py
@@ -7,7 +7,8 @@ import warnings
 import zlib
 from uuid import uuid4
 
-from rq.compat import as_text, decode_redis_hash, string_types, text_type
+from rq.compat import (as_text, decode_redis_hash, hmset, string_types,
+                       text_type)
 
 from .connections import resolve_connection
 from .exceptions import NoSuchJobError
@@ -547,7 +548,7 @@ class Job(object):
         key = self.key
         connection = pipeline if pipeline is not None else self.connection
 
-        connection.hmset(key, self.to_dict(include_meta=include_meta))
+        hmset(connection, key, self.to_dict(include_meta=include_meta))
 
     def save_meta(self):
         """Stores job meta from the job instance to the corresponding Redis key."""

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -23,7 +23,7 @@ except ImportError:
 from redis import WatchError
 
 from . import worker_registration
-from .compat import PY2, as_text, string_types, text_type
+from .compat import PY2, as_text, hmset, string_types, text_type
 from .connections import get_current_connection, push_connection, pop_connection
 
 from .defaults import (DEFAULT_RESULT_TTL,
@@ -268,7 +268,7 @@ class Worker(object):
             now = utcnow()
             now_in_string = utcformat(now)
             self.birth_date = now
-            p.hmset(key, {
+            hmset(p, key, mapping={
                 'birth': now_in_string,
                 'last_heartbeat': now_in_string,
                 'queues': queues,


### PR DESCRIPTION
Re: https://github.com/rq/rq/issues/1244, this PR adds an `hmset` function to the compatibility module such that `hset` is preferred over `hmset` when running `redis-py` 3.5.0+.