### PR TITLE
Use pickle.HIGHEST_PROTOCOL by default

### DIFF
--- a/rq/serializers.py
+++ b/rq/serializers.py
@@ -1,7 +1,13 @@
+from functools import partial
 import pickle
 
 from .compat import string_types
 from .utils import import_attribute
+
+
+class DefaultSerializer:
+    dumps = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)
+    loads = pickle.loads
 
 
 def resolve_serializer(serializer):
@@ -11,7 +17,7 @@ def resolve_serializer(serializer):
     Also accepts a string path to serializer that will be loaded as the serializer
     """
     if not serializer:
-        return pickle
+        return DefaultSerializer
 
     if isinstance(serializer, string_types):
         serializer = import_attribute(serializer)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -4,10 +4,11 @@ from __future__ import (absolute_import, division, print_function,
 
 import json
 import pickle
+import pickletools
 import queue
 import unittest
 
-from rq.serializers import resolve_serializer
+from rq.serializers import DefaultSerializer, resolve_serializer
 
 
 class TestSerializers(unittest.TestCase):
@@ -15,7 +16,16 @@ class TestSerializers(unittest.TestCase):
         """Ensure function resolve_serializer works correctly"""
         serializer = resolve_serializer(None)
         self.assertIsNotNone(serializer)
-        self.assertEqual(serializer, pickle)
+        self.assertEqual(serializer, DefaultSerializer)
+
+        # Test round trip with default serializer
+        test_data = {'test': 'data'}
+        serialized_data = serializer.dumps(test_data)
+        self.assertEqual(serializer.loads(serialized_data), test_data)
+        self.assertEqual(
+            next(pickletools.genops(serialized_data))[1],
+            pickle.HIGHEST_PROTOCOL
+        )
 
         # Test using json serializer
         serializer = resolve_serializer(json)


### PR DESCRIPTION
Re: https://github.com/rq/rq/issues/1252, this PR sets the default serializer to use `pickle.HIGHEST_PROTOCOL`, to match with the versions before 1.4.0.

Use can provide a class similar to `DefaultSerializer` to use a different protocol version.