### PR TITLE
Took into account DST when computing localtime zones.  This wasn't ac…

### DIFF
--- a/rq/registry.py
+++ b/rq/registry.py
@@ -265,7 +265,7 @@ class ScheduledJobRegistry(BaseRegistry):
                 from datetime import timezone
             except ImportError:
                 raise ValueError('datetime object with no timezone')
-            tz = timezone(timedelta(seconds=-time.timezone))
+            tz = timezone(timedelta(seconds=-(time.timezone if time.daylight == 0 else time.altzone)))
             scheduled_datetime = scheduled_datetime.replace(tzinfo=tz)
 
         timestamp = calendar.timegm(scheduled_datetime.utctimetuple())


### PR DESCRIPTION
This change accounts for local DST offsets when queuing a job with enqueue_at and local time.  As it stands right now, if you were to queue a task for today at 10 PM local time (on the America/EST5EDT time zone) the task would actually get sent in for running at 11 PM due to the fact that time.timezone reports 5 hours of difference whereas because time.daylight. != 0, the time.altzone should be used which correctly makes the offset 4 hours.