### PR TITLE
run_tests: remove special case using rq

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -10,23 +10,10 @@ if ! check_redis_running; then
     exit 2
 fi
 
-if command -v rg >/dev/null; then
-    safe_rg=rg
-else
-    # Fall back for systems that don't have rg installed
-    safe_rg=cat
-fi
-
 export RUN_SLOW_TESTS_TOO=1
 if [ "$1" = '-f' ]; then  # Poor man's argparse
     unset RUN_SLOW_TESTS_TOO
     shift 1
 fi
 
-# For use on build server, we need exit code to be representative of success/failure
-if [ "$1" = '-x' ]; then
-    shift 1
-    /usr/bin/env python -m pytest -v tests $@ 2>&1
-else
-    /usr/bin/env python -m pytest -v tests $@ 2>&1 | egrep -v '^test_' | $safe_rg
-fi
+/usr/bin/env python -m pytest -v tests $@ 2>&1


### PR DESCRIPTION
The tool seems outdated anyway and the CI uses plain pytest instead of
the script anyway.

Signed-off-by: Paul Spooren <mail@aparcar.org>