### PR TITLE
Truncate job args/kwargs to a reasonable length

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -664,6 +664,11 @@ class Job(object):
         """
         return default_ttl if self.result_ttl is None else self.result_ttl
 
+    def truncate_long_string(data, maxlen=75):
+        """ Truncates strings longer than maxlen
+        """
+        return (data[:maxlen] + '...') if len(data) > maxlen else data
+
     # Representation
     def get_call_string(self):  # noqa
         """Returns a string representation of the call, formatted as a regular
@@ -672,9 +677,9 @@ class Job(object):
         if self.func_name is None:
             return None
 
-        arg_list = [as_text(repr(arg)) for arg in self.args]
+        arg_list = [as_text(truncate_long_string(repr(arg))) for arg in self.args]
 
-        kwargs = ['{0}={1}'.format(k, as_text(repr(v))) for k, v in self.kwargs.items()]
+        kwargs = ['{0}={1}'.format(k, as_text(truncate_long_string(repr(v)))) for k, v in self.kwargs.items()]
         # Sort here because python 3.3 & 3.4 makes different call_string
         arg_list += sorted(kwargs)
         args = ', '.join(arg_list)

--- a/rq/job.py
+++ b/rq/job.py
@@ -39,6 +39,11 @@ JobStatus = enum(
 UNEVALUATED = object()
 
 
+def truncate_long_string(data, maxlen=75):
+    """ Truncates strings longer than maxlen
+    """
+    return (data[:maxlen] + '...') if len(data) > maxlen else data
+	
 def cancel_job(job_id, connection=None):
     """Cancels the job with the given job ID, preventing execution.  Discards
     any job info (i.e. it can't be requeued later).
@@ -663,11 +668,6 @@ class Job(object):
         for determining ttl for repeated jobs.
         """
         return default_ttl if self.result_ttl is None else self.result_ttl
-
-    def truncate_long_string(data, maxlen=75):
-        """ Truncates strings longer than maxlen
-        """
-        return (data[:maxlen] + '...') if len(data) > maxlen else data
 
     # Representation
     def get_call_string(self):  # noqa


### PR DESCRIPTION
Logging job's description with huge arguments makes terminal unreadable and log files too large.
It would be nice if arguments with more than N characters, let's say 75, get truncated.

See #1263 #1269 