### PR TITLE
Version aware

### DIFF
--- a/rq/compat/__init__.py
+++ b/rq/compat/__init__.py
@@ -104,14 +104,3 @@ except ImportError:
             return timedelta(0)
 
     utc = UTC()
-
-
-def hmset(pipe_or_connection, name, mapping):
-    # redis-py versions 3.5.0 and above accept a mapping parameter for hset
-    # This requires Redis server >= 4.0 so this is temporarily commented out
-    # and will be re-enabled at a later date
-    # try:
-    #    return pipe_or_connection.hset(name, mapping=mapping)
-    # earlier versions require hmset to be used
-    # except TypeError:
-    return pipe_or_connection.hmset(name, mapping)

--- a/rq/job.py
+++ b/rq/job.py
@@ -7,11 +7,11 @@ import pickle
 import warnings
 import zlib
 
+from distutils.version import StrictVersion
 from functools import partial
 from uuid import uuid4
 
-from rq.compat import (as_text, decode_redis_hash, hmset, string_types,
-                       text_type)
+from rq.compat import as_text, decode_redis_hash, string_types, text_type
 from .connections import resolve_connection
 from .exceptions import NoSuchJobError
 from .local import LocalStack
@@ -345,6 +345,7 @@ class Job(object):
         self._dependency_ids = []
         self.meta = {}
         self.serializer = resolve_serializer(serializer)
+        self.redis_server_version = None
 
     def __repr__(self):  # noqa  # pragma: no cover
         return '{0}({1!r}, enqueued_at={2!r})'.format(self.__class__.__name__,
@@ -565,7 +566,21 @@ class Job(object):
         key = self.key
         connection = pipeline if pipeline is not None else self.connection
 
-        hmset(connection, key, self.to_dict(include_meta=include_meta))
+        mapping = self.to_dict(include_meta=include_meta)
+
+        if self.get_redis_server_version() >= StrictVersion("4.0.0"):
+            connection.hset(key, mapping=mapping)
+        else:
+            connection.hmset(key, mapping)
+
+    def get_redis_server_version(self):
+        """Return Redis server version of connection"""
+        if not self.redis_server_version:
+            self.redis_server_version = StrictVersion(
+                self.connection.info("server")["redis_version"]
+            )
+
+        return self.redis_server_version
 
     def save_meta(self):
         """Stores job meta from the job instance to the corresponding Redis key."""


### PR DESCRIPTION
This is the first thing I came up with, however it's not perfect:

* I used the names `redis_version` and `connection_version`, however `library_version` and `server_version` or something entirely different might be easier to grasp?
* There is no certainty that `redis-py` 3.5.4 will actually support LPOS, I just came up with that version.
* Should the legacy and undocumented StrictVersion module be used (it's part of stdlib)
* Should `queue` contain the version information?
* There is a mixup of using the compat function `hmset` and directly `hset` in the `worker` class. Shouldn't we just raise the minimal version to `3.5.0`?
* Redis server supports `HSET` mappings starting from version 4.0, however there is no trivial way to check the version from within compat function `hmset` as a pipeline can be passed over.