### PR TITLE
Improve requirements handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ services:
   - redis
 matrix:
   include:
-  - python: "3.4"
   - python: "3.5"
   - python: "3.6"
   - python: "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-redis>=3.0
-click>=3.0.0
+redis>=3.5.0
+click>=5.0.0

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,15 @@ def get_version():
         raise RuntimeError('No version info found.')
 
 
+def get_requirements():
+    basedir = os.path.dirname(__file__)
+    try:
+        with open(os.path.join(basedir, 'requirements.txt')) as f:
+            return f.readlines()
+    except FileNotFoundError:
+        raise RuntimeError('No requirements info found.')
+
+
 setup(
     name='rq',
     version=get_version(),
@@ -31,10 +40,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    install_requires=[
-        'redis >= 3.0.0',
-        'click >= 5.0'
-    ],
+    install_requires=get_requirements(),
     python_requires='>=3.4',
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Better handling of requirements by keeping them in sync and raise `redis-py` to 3.5.0.