### PR TITLE
setup: Set min Python version to 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=get_requirements(),
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     entry_points={
         'console_scripts': [
             'rq = rq.cli:main',
@@ -72,7 +72,6 @@ setup(
         'Operating System :: Unix',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
As `redis-py` in version 3.5.0 is now required, whoch only support
Python 3.5+, we should remove Python 3.4 from the supported Python
versions as well.

Signed-off-by: Paul Spooren <mail@aparcar.org>