### PR TITLE
CI: Only test redis-py 3.5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8]
         redis-version: [3, 4, 5, 6]
-        redis-py-version: [3.5.0, 3.5.3]
+        redis-py-version: [3.5.0]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Only test on major versions to reduce number of tests.

Signed-off-by: Paul Spooren <mail@aparcar.org>