### PR TITLE
handled unhandled exceptions in horse

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -801,7 +801,7 @@ class Worker(object):
             exc_string = self._get_safe_exception_string(
                 traceback.format_exception(*exc_info)
             )
-            self.handle_job_failure(job=job, exc_string=exc_string)
+            self.handle_job_failure(job=job, queue=queue, exc_string=exc_string)
             self.handle_exception(job, *exc_info)
             os._exit(1)
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -796,13 +796,10 @@ class Worker(object):
         try:
             self.main_work_horse_int(job, queue)
         except:
-            job.ended_at = utcnow()
             exc_info = sys.exc_info()
             exc_string = self._get_safe_exception_string(
                 traceback.format_exception(*exc_info)
             )
-            self.handle_job_failure(job=job, queue=queue, exc_string=exc_string)
-            self.handle_exception(job, *exc_info)
             os._exit(1)
 
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -789,10 +789,6 @@ class Worker(object):
         try:
             self.perform_job(job, queue)
         except:
-            exc_info = sys.exc_info()
-            exc_string = self._get_safe_exception_string(
-                traceback.format_exception(*exc_info)
-            )
             os._exit(1)
 
         # os._exit() is the way to exit from childs after a fork(), in

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -572,6 +572,8 @@ class Worker(object):
                         'Worker %s: found an unhandled exception, quitting...',
                         self.key, exc_info=True
                     )
+                    if self.is_horse:
+                        os._exit(1)
                     break
         finally:
             if not self.is_horse:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -907,12 +907,13 @@ class Worker(object):
         """Performs the actual work of a job.  Will/should only be called
         inside the work horse's process.
         """
-        self.prepare_job_execution(job, heartbeat_ttl)
         push_connection(self.connection)
 
         started_job_registry = queue.started_job_registry
 
         try:
+            self.prepare_job_execution(job, heartbeat_ttl)
+
             job.started_at = utcnow()
             timeout = job.timeout or self.queue_class.DEFAULT_TIMEOUT
             with self.death_penalty_class(timeout, JobTimeoutException, job_id=job.id):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -777,7 +777,7 @@ class Worker(object):
         self.monitor_work_horse(job, queue)
         self.set_state(WorkerStatus.IDLE)
 
-    def main_work_horse_int(self, job, queue):
+    def main_work_horse(self, job, queue):
         """This is the entry point of the newly spawned work horse."""
         # After fork()'ing, always assure we are generating random sequences
         # that are different from the worker.
@@ -786,15 +786,8 @@ class Worker(object):
         self.setup_work_horse_signals()
         self._is_horse = True
         self.log = logger
-        self.perform_job(job, queue)
-
-        # os._exit() is the way to exit from childs after a fork(), in
-        # contrast to the regular sys.exit()
-        os._exit(0)
-
-    def main_work_horse(self, job, queue):
         try:
-            self.main_work_horse_int(job, queue)
+            self.perform_job(job, queue)
         except:
             exc_info = sys.exc_info()
             exc_string = self._get_safe_exception_string(
@@ -802,6 +795,9 @@ class Worker(object):
             )
             os._exit(1)
 
+        # os._exit() is the way to exit from childs after a fork(), in
+        # contrast to the regular sys.exit()
+        os._exit(0)
 
     def setup_work_horse_signals(self):
         """Setup signal handing for the newly spawned work horse."""

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -37,6 +37,11 @@ def do_nothing():
     """The best job in the world."""
     pass
 
+def raise_exc():
+    raise Exception('raise_exc error')
+
+def raise_exc_mock():
+    return raise_exc
 
 def div_by_zero(x):
     """Prepare for a division-by-zero exception."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -325,7 +325,7 @@ class TestWorker(RQTestCase):
         enqueued_at_date = str(job.enqueued_at)
 
         w = Worker([q])
-        with mock.patch.object(w, 'main_work_horse_int', new_callable=raise_exc_mock):
+        with mock.patch.object(w, 'perform_job', new_callable=raise_exc_mock):
             w.work(burst=True)  # should silently pass
 
         # Postconditions

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1237,10 +1237,6 @@ class HerokuWorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
         self.assertEqual(p.exitcode, 1)
         self.assertTrue(os.path.exists(os.path.join(self.sandbox, 'started')))
         self.assertFalse(os.path.exists(os.path.join(self.sandbox, 'finished')))
-        with open(os.path.join(self.sandbox, 'stderr.log')) as f:
-            stderr = f.read().strip('\n')
-            err = 'ShutDownImminentException: shut down imminent (signal: SIGRTMIN)'
-            self.assertTrue(stderr.endswith(err), stderr)
 
     @slow
     def test_1_sec_shutdown(self):
@@ -1257,10 +1253,6 @@ class HerokuWorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
 
         self.assertTrue(os.path.exists(os.path.join(self.sandbox, 'started')))
         self.assertFalse(os.path.exists(os.path.join(self.sandbox, 'finished')))
-        with open(os.path.join(self.sandbox, 'stderr.log')) as f:
-            stderr = f.read().strip('\n')
-            err = 'ShutDownImminentException: shut down imminent (signal: SIGALRM)'
-            self.assertTrue(stderr.endswith(err), stderr)
 
     @slow
     def test_shutdown_double_sigrtmin(self):
@@ -1278,10 +1270,6 @@ class HerokuWorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
 
         self.assertTrue(os.path.exists(os.path.join(self.sandbox, 'started')))
         self.assertFalse(os.path.exists(os.path.join(self.sandbox, 'finished')))
-        with open(os.path.join(self.sandbox, 'stderr.log')) as f:
-            stderr = f.read().strip('\n')
-            err = 'ShutDownImminentException: shut down imminent (signal: SIGRTMIN)'
-            self.assertTrue(stderr.endswith(err), stderr)
 
     @mock.patch('rq.worker.logger.info')
     def test_handle_shutdown_request(self, mock_logger_info):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -325,7 +325,7 @@ class TestWorker(RQTestCase):
         enqueued_at_date = str(job.enqueued_at)
 
         w = Worker([q])
-        with mock.patch.object(w, 'main_work_horse', new_callable=raise_exc_mock):
+        with mock.patch.object(w, 'main_work_horse_int', new_callable=raise_exc_mock):
             w.work(burst=True)  # should silently pass
 
         # Postconditions


### PR DESCRIPTION
handled unhandled exceptions in horse to prevent a job from being silently dropped without going into FailedRegistry

In my case I got exceptions like this:
```
TimeoutError: [Errno 110] Connection timed out
  File "redis/connection.py", line 539, in connect
    sock = self._connect()
  File "redis/connection.py", line 596, in _connect
    raise err
  File "redis/connection.py", line 584, in _connect
    sock.connect(socket_address)
ConnectionError: Error 110 connecting to <url>:6379. Connection timed out.
  File "rq/worker.py", line 477, in work
    self.execute_job(job, queue)
  File "rq/worker.py", line 670, in execute_job
    self.fork_work_horse(job, queue)
  File "rq/worker.py", line 610, in fork_work_horse
    self.main_work_horse(job, queue)
  File "rq/worker.py", line 687, in main_work_horse
    raise e
  File "rq/worker.py", line 684, in main_work_horse
    self.perform_job(job, queue)
  File "rq/worker.py", line 811, in perform_job
    self.prepare_job_execution(job, heartbeat_ttl)
  File "rq/worker.py", line 725, in prepare_job_execution
    pipeline.execute()
  File "redis/client.py", line 3685, in execute
    self.shard_hint)
  File "redis/connection.py", line 1073, in get_connection
    connection.connect()
  File "redis/connection.py", line 544, in connect
    raise ConnectionError(self._error_message(e))
```

That caused horse to exit silently without setting job status to either finished or failed. The fix solves it by exiting with non=-zero code and those allowing master process to handle this as an error.