### PR TITLE
[doc] worker burst mode

### DIFF
--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -36,9 +36,12 @@ You should use process managers like [Supervisor](/patterns/supervisor/) or
 ### Burst Mode
 
 By default, workers will start working immediately and will block and wait for
-new work when they run out of work.  Workers can also be started in _burst
+new work when they run out of work.  Workers can also be started in _burst     
 mode_ to finish all currently available work and quit as soon as all given
 queues are emptied.
+In _burst mode_, a worker will also quit if there are no available jobs
+prepared to start, even when there exists a non-empty queue. For example, if
+all remaining jobs are in _deferred_ status, block by unfinished depended job.
 
 ```console
 $ rq worker --burst high default low

--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -36,7 +36,7 @@ You should use process managers like [Supervisor](/patterns/supervisor/) or
 ### Burst Mode
 
 By default, workers will start working immediately and will block and wait for
-new work when they run out of work.  Workers can also be started in _burst     
+new work when they run out of work.  Workers can also be started in _burst
 mode_ to finish all currently available work and quit as soon as all given
 queues are emptied.
 In _burst mode_, a worker will also quit if there are no available jobs


### PR DESCRIPTION
Some more clarification for workers' burst mode.
Previously, it might give an impression that the worker will wait until the queue is empty in burst mode.