### PR TITLE
[doc] notes for len(queue)

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -115,6 +115,7 @@ redis_conn = Redis()
 q = Queue(connection=redis_conn)
 
 # Getting the number of jobs in the queue
+# Note: Only queued jobs are counted, not including deferred ones
 print(len(q))
 
 # Retrieving jobs


### PR DESCRIPTION
In general, if we enqueue one job into the queue but this job cannot be started yet, then the queue size will not enlarge.