### PR TITLE
Allow retries to be set through decorator

### DIFF
--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -17,7 +17,7 @@ class job(object):  # noqa
     def __init__(self, queue, connection=None, timeout=None,
                  result_ttl=DEFAULT_RESULT_TTL, ttl=None,
                  queue_class=None, depends_on=None, at_front=None, meta=None,
-                 description=None, failure_ttl=None):
+                 description=None, failure_ttl=None, retry=None):
         """A decorator that adds a ``delay`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required
         ``queue`` argument that can be either a ``Queue`` instance or a string
@@ -40,6 +40,7 @@ class job(object):  # noqa
         self.at_front = at_front
         self.description = description
         self.failure_ttl = failure_ttl
+        self.retry = retry
 
     def __call__(self, f):
         @wraps(f)
@@ -63,6 +64,7 @@ class job(object):  # noqa
             return queue.enqueue_call(f, args=args, kwargs=kwargs,
                                       timeout=self.timeout, result_ttl=self.result_ttl,
                                       ttl=self.ttl, depends_on=depends_on, job_id=job_id, at_front=at_front,
-                                      meta=self.meta, description=self.description, failure_ttl=self.failure_ttl)
+                                      meta=self.meta, description=self.description, failure_ttl=self.failure_ttl,
+                                      retry=self.retry)
         f.delay = delay
         return f

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -6,7 +6,7 @@ import mock
 from redis import Redis
 
 from rq.decorators import job
-from rq.job import Job
+from rq.job import Job, Retry
 from rq.queue import Queue
 from rq.worker import DEFAULT_RESULT_TTL
 from tests import RQTestCase
@@ -221,3 +221,19 @@ class TestDecorator(RQTestCase):
             return 'Why hello'
         result = hello.delay()
         self.assertEqual(result.failure_ttl, 10)
+
+    def test_decorator_custom_retry(self):
+        """ Ensure that passing in retry to the decorator sets the
+        retry on the job
+        """
+        # Ensure default
+        result = decorated_job.delay(1, 2)
+        self.assertEqual(result.retries_left, None)
+        self.assertEqual(result.retry_intervals, None)
+
+        @job('default', retry=Retry(3, [2]))
+        def hello():
+            return 'Why hello'
+        result = hello.delay()
+        self.assertEqual(result.retries_left, 3)
+        self.assertEqual(result.retry_intervals, [2])


### PR DESCRIPTION
This pull request will close #1318. It allows retrying of jobs to be sat through the @job-decorator.