### PR TITLE
fix(scheduler): correctly restore ssl connection after forking

### DIFF
--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -13,8 +13,7 @@ from .registry import ScheduledJobRegistry
 from .utils import current_timestamp, enum
 from .logutils import setup_loghandlers
 
-from redis import Redis
-
+from redis import Redis, SSLConnection
 
 SCHEDULER_KEY_TEMPLATE = 'rq:scheduler:%s'
 SCHEDULER_LOCKING_KEY_TEMPLATE = 'rq:scheduler-lock:%s'
@@ -47,6 +46,9 @@ class RQScheduler(object):
         self._scheduled_job_registries = []
         self.lock_acquisition_time = None
         self._connection_kwargs = connection.connection_pool.connection_kwargs
+        connection_class = connection.connection_pool.connection_class
+        if issubclass(connection_class, SSLConnection):
+            self._connection_kwargs['ssl'] = True
         self._connection = None
         self.interval = interval
         self._stop_requested = False

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -46,6 +46,7 @@ class RQScheduler(object):
         self._scheduled_job_registries = []
         self.lock_acquisition_time = None
         self._connection_kwargs = connection.connection_pool.connection_kwargs
+        self._connection_class = connection.__class__  # client
         connection_class = connection.connection_pool.connection_class
         if issubclass(connection_class, SSLConnection):
             self._connection_kwargs['ssl'] = True
@@ -59,8 +60,8 @@ class RQScheduler(object):
     def connection(self):
         if self._connection:
             return self._connection
-        self._connection = Redis(**self._connection_kwargs)
-        return Redis(**self._connection_kwargs)
+        self._connection = self._connection_class(**self._connection_kwargs)
+        return self._connection
 
     @property
     def acquired_locks(self):


### PR DESCRIPTION
`ssl` attribute is lost after forking since `redis-py` doesn't store `ssl` attribute in connection kwargs https://github.com/andymccurdy/redis-py/blob/5a6a50b50db26e4b1c4b7a6cb9b2a2caa8ba5e8b/redis/client.py#L783
Apparently this PR also fixes https://github.com/rq/rq/issues/1310
Sorry, no Idea how to write unit test for ssl connection, just tested it manually.