### PR TITLE
fix deprecated Iterable import

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -15,7 +15,7 @@ import logging
 import numbers
 import sys
 
-from collections import Iterable
+from collections.abc import Iterable
 from distutils.version import StrictVersion
 
 from redis.exceptions import ResponseError


### PR DESCRIPTION
when I ran pytest on my app I had this warning and fixed it in this PR
`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Iterable`