### PR TITLE
scheduler: now operates with chunks of jobs

### DIFF
--- a/rq/registry.py
+++ b/rq/registry.py
@@ -286,15 +286,11 @@ class ScheduledJobRegistry(BaseRegistry):
         score = timestamp if timestamp is not None else current_timestamp()
         return connection.zremrangebyscore(self.key, 0, score)
 
-    def get_jobs_to_schedule(self, timestamp=None, chunk_size=None):
+    def get_jobs_to_schedule(self, timestamp=None, chunk_size=1000):
         """Remove jobs whose timestamp is in the past from registry."""
         score = timestamp if timestamp is not None else current_timestamp()
-        if not chunk_size:
-            return [as_text(job_id) for job_id in
-                    self.connection.zrangebyscore(self.key, 0, score)]
-        else:
-            return [as_text(job_id) for job_id in
-                    self.connection.zrangebyscore(self.key, 0, score, start=0, num=chunk_size)]
+        return [as_text(job_id) for job_id in
+                self.connection.zrangebyscore(self.key, 0, score, start=0, num=chunk_size)]
 
     def get_scheduled_time(self, job_or_id):
         """Returns datetime (UTC) at which job is scheduled to be enqueued"""

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -38,8 +38,8 @@ class BaseRegistry(object):
 
     def __eq__(self, other):
         return (
-            self.name == other.name and
-            self.connection.connection_pool.connection_kwargs == other.connection.connection_pool.connection_kwargs
+                self.name == other.name and
+                self.connection.connection_pool.connection_kwargs == other.connection.connection_pool.connection_kwargs
         )
 
     def __contains__(self, item):
@@ -286,11 +286,15 @@ class ScheduledJobRegistry(BaseRegistry):
         score = timestamp if timestamp is not None else current_timestamp()
         return connection.zremrangebyscore(self.key, 0, score)
 
-    def get_jobs_to_schedule(self, timestamp=None):
+    def get_jobs_to_schedule(self, timestamp=None, chunk_size=None):
         """Remove jobs whose timestamp is in the past from registry."""
         score = timestamp if timestamp is not None else current_timestamp()
-        return [as_text(job_id) for job_id in
-                self.connection.zrangebyscore(self.key, 0, score)]
+        if not chunk_size:
+            return [as_text(job_id) for job_id in
+                    self.connection.zrangebyscore(self.key, 0, score)]
+        else:
+            return [as_text(job_id) for job_id in
+                    self.connection.zrangebyscore(self.key, 0, score, start=0, num=chunk_size)]
 
     def get_scheduled_time(self, job_or_id):
         """Returns datetime (UTC) at which job is scheduled to be enqueued"""

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -38,8 +38,8 @@ class BaseRegistry(object):
 
     def __eq__(self, other):
         return (
-                self.name == other.name and
-                self.connection.connection_pool.connection_kwargs == other.connection.connection_pool.connection_kwargs
+            self.name == other.name and
+            self.connection.connection_pool.connection_kwargs == other.connection.connection_pool.connection_kwargs
         )
 
     def __contains__(self, item):

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -128,7 +128,7 @@ class RQScheduler(object):
 
             # TODO: try to use Lua script to make get_jobs_to_schedule()
             # and remove_jobs() atomic
-            job_ids = registry.get_jobs_to_schedule(timestamp, chunk_size=1000)
+            job_ids = registry.get_jobs_to_schedule(timestamp)
 
             if not job_ids:
                 continue

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -28,7 +28,6 @@ setup_loghandlers(
 
 
 class RQScheduler(object):
-
     # STARTED: scheduler has been started but sleeping
     # WORKING: scheduler is in the midst of scheduling jobs
     # STOPPED: scheduler is in stopped condition
@@ -129,7 +128,7 @@ class RQScheduler(object):
 
             # TODO: try to use Lua script to make get_jobs_to_schedule()
             # and remove_jobs() atomic
-            job_ids = registry.get_jobs_to_schedule(timestamp)
+            job_ids = registry.get_jobs_to_schedule(timestamp, chunk_size=1000)
 
             if not job_ids:
                 continue
@@ -137,11 +136,11 @@ class RQScheduler(object):
             queue = Queue(registry.name, connection=self.connection)
 
             with self.connection.pipeline() as pipeline:
-                # This should be done in bulk
-                for job_id in job_ids:
-                    job = Job.fetch(job_id, connection=self.connection)
-                    queue.enqueue_job(job, pipeline=pipeline)
-                registry.remove_jobs(timestamp)
+                jobs = Job.fetch_many(job_ids, connection=self.connection)
+                for job in jobs:
+                    if job is not None:
+                        queue.enqueue_job(job, pipeline=pipeline)
+                        registry.remove(job, pipeline=pipeline)
                 pipeline.execute()
         self._status = self.Status.STARTED
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -43,7 +43,7 @@ class TestScheduledJobRegistry(RQTestCase):
         chunk_size = 1000
 
         for index in range(0, chunk_size * 2):
-            self.testconn.zadd(registry.key, {f'foo_{index}': 1})
+            self.testconn.zadd(registry.key, {'foo_{}'.format(index): 1})
 
         self.assertEqual(len(registry.get_jobs_to_schedule(timestamp, chunk_size)),
                          chunk_size)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -40,7 +40,7 @@ class TestScheduledJobRegistry(RQTestCase):
         queue = Queue(connection=self.testconn)
         registry = ScheduledJobRegistry(queue=queue)
         timestamp = current_timestamp()
-        chunk_size = 1000
+        chunk_size = 5
 
         for index in range(0, chunk_size * 2):
             self.testconn.zadd(registry.key, {'foo_{}'.format(index): 1})


### PR DESCRIPTION
Fixes #1354 
It might not be complete fix of this issue but prevent (in most cases) bug, reducing `enqueue_scheduled_jobs` function executing time to less than 5 seconds