### PR TITLE
Fixed typo in workers docs: send_kill_horse_command() example

### DIFF
--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -406,7 +406,7 @@ redis = Redis()
 
 workers = Worker.all(redis)
 for worker in workers:
-   if worker.state = WorkerStatus.BUSY:
+   if worker.state == WorkerStatus.BUSY:
       send_kill_horse_command(redis, worker.name)
 ```
 


### PR DESCRIPTION
Small typo in the send_kill_horse_command() example in the workers docs. 