### PR TITLE
fix snippet link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,4 +131,4 @@ heaviness of Celery or other AMQP-based queueing implementations.
 [p]: http://docs.python.org/library/pickle.html
 [1]: http://www.celeryproject.org/
 [2]: https://github.com/resque/resque
-[3]: http://flask.pocoo.org/snippets/73/
+[3]: https://github.com/fengsp/flask-snippets/blob/1f65833a4291c5b833b195a09c365aa815baea4e/utilities/rq.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,4 +98,4 @@ existing queueing frameworks, with a low barrier to entry.
 [p]: http://docs.python.org/library/pickle.html
 [1]: http://www.celeryproject.org/
 [2]: https://github.com/defunkt/resque
-[3]: http://flask.pocoo.org/snippets/73/
+[3]: https://github.com/fengsp/flask-snippets/blob/1f65833a4291c5b833b195a09c365aa815baea4e/utilities/rq.py


### PR DESCRIPTION
The former link is broken since http://flask.pocoo.org/snippets has been
taken down. See https://github.com/pallets/website/issues/41 for more
info.