### PR TITLE
Fix custom serializer in job fetches

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -65,7 +65,7 @@ def get_current_job(connection=None, job_class=None):
 
 
 def requeue_job(job_id, connection):
-    job = Job.fetch(job_id, connection=connection, serializer=self.serializer)
+    job = Job.fetch(job_id, connection=connection)
     return job.requeue()
 
 
@@ -301,7 +301,7 @@ class Job(object):
         return job
 
     @classmethod
-    def fetch_many(cls, job_ids, connection):
+    def fetch_many(cls, job_ids, connection, serializer=None):
         """
         Bulk version of Job.fetch
 
@@ -316,7 +316,7 @@ class Job(object):
         jobs = []
         for i, job_id in enumerate(job_ids):
             if results[i]:
-                job = cls(job_id, connection=connection)
+                job = cls(job_id, connection=connection, serializer=serializer)
                 job.restore(results[i])
                 jobs.append(job)
             else:

--- a/rq/job.py
+++ b/rq/job.py
@@ -65,7 +65,7 @@ def get_current_job(connection=None, job_class=None):
 
 
 def requeue_job(job_id, connection):
-    job = Job.fetch(job_id, connection=connection)
+    job = Job.fetch(job_id, connection=connection, serializer=self.serializer)
     return job.requeue()
 
 
@@ -190,7 +190,7 @@ class Job(object):
             return None
         if hasattr(self, '_dependency'):
             return self._dependency
-        job = self.fetch(self._dependency_ids[0], connection=self.connection)
+        job = self.fetch(self._dependency_ids[0], connection=self.connection, serializer=self.serializer)
         self._dependency = job
         return job
 
@@ -679,7 +679,7 @@ class Job(object):
         connection = pipeline if pipeline is not None else self.connection
         for dependent_id in self.dependent_ids:
             try:
-                job = Job.fetch(dependent_id, connection=self.connection)
+                job = Job.fetch(dependent_id, connection=self.connection, serializer=self.serializer)
                 job.delete(pipeline=pipeline,
                            remove_from_queue=False)
             except NoSuchJobError:

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -155,7 +155,7 @@ class Queue(object):
 
     def fetch_job(self, job_id):
         try:
-            job = self.job_class.fetch(job_id, connection=self.connection)
+            job = self.job_class.fetch(job_id, connection=self.connection, serializer=self.serializer)
         except NoSuchJobError:
             self.remove(job_id)
         else:
@@ -511,7 +511,8 @@ nd
                     dependent_job for dependent_job
                     in self.job_class.fetch_many(
                         dependent_job_ids,
-                        connection=self.connection
+                        connection=self.connection,
+                        serializer=self.serializer
                     ) if dependent_job.dependencies_are_met(
                         exclude_job_id=job.id,
                         pipeline=pipe

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -582,7 +582,7 @@ nd
             return None
 
     @classmethod
-    def dequeue_any(cls, queues, timeout, connection=None, job_class=None):
+    def dequeue_any(cls, queues, timeout, connection=None, job_class=None, serializer=None):
         """Class method returning the job_class instance at the front of the given
         set of Queues, where the order of the queues is important.
 
@@ -603,9 +603,10 @@ nd
             queue_key, job_id = map(as_text, result)
             queue = cls.from_queue_key(queue_key,
                                        connection=connection,
-                                       job_class=job_class)
+                                       job_class=job_class,
+                                       serializer=serializer)
             try:
-                job = job_class.fetch(job_id, connection=connection)
+                job = job_class.fetch(job_id, connection=connection, serializer=serializer)
             except NoSuchJobError:
                 # Silently pass on jobs that don't exist (anymore),
                 # and continue in the look

--- a/rq/serializers.py
+++ b/rq/serializers.py
@@ -1,5 +1,6 @@
 from functools import partial
 import pickle
+import json
 
 from .compat import string_types
 from .utils import import_attribute
@@ -8,6 +9,16 @@ from .utils import import_attribute
 class DefaultSerializer:
     dumps = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)
     loads = pickle.loads
+
+
+class JSONSerializer():
+    @staticmethod
+    def dumps(*args, **kwargs):
+        return json.dumps(*args, **kwargs).encode('utf-8')
+
+    @staticmethod
+    def loads(s, *args, **kwargs):
+        return json.loads(s.decode('utf-8'), *args, **kwargs)
 
 
 def resolve_serializer(serializer):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -638,7 +638,8 @@ class Worker(object):
             try:
                 result = self.queue_class.dequeue_any(self.queues, timeout,
                                                       connection=self.connection,
-                                                      job_class=self.job_class)
+                                                      job_class=self.job_class,
+                                                      serializer=self.serializer)
                 if result is not None:
 
                     job, queue = result

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -387,7 +387,7 @@ class Worker(object):
         if job_id is None:
             return None
 
-        return self.job_class.fetch(job_id, self.connection)
+        return self.job_class.fetch(job_id, self.connection, self.serializer)
 
     def _install_signal_handlers(self):
         """Installs signal handlers for handling SIGINT and SIGTERM

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -38,6 +38,7 @@ from rq.suspension import resume, suspend
 from rq.utils import utcnow
 from rq.version import VERSION
 from rq.worker import HerokuWorker, WorkerStatus
+from rq.serializers import JSONSerializer
 
 class CustomJob(Job):
     pass
@@ -45,15 +46,6 @@ class CustomJob(Job):
 
 class CustomQueue(Queue):
     pass
-
-class CustomSerializer():
-    @staticmethod
-    def dumps(*args, **kwargs):
-        return json.dumps(*args, **kwargs).encode('utf-8')
-
-    @staticmethod
-    def loads(s, *args, **kwargs):
-        return json.loads(s.decode('utf-8'), *args, **kwargs)
 
 
 class TestWorker(RQTestCase):
@@ -133,8 +125,8 @@ class TestWorker(RQTestCase):
 
     def test_work_and_quit_custom_serializer(self):
         """Worker processes work, then quits."""
-        fooq, barq = Queue('foo', serializer=CustomSerializer), Queue('bar', serializer=CustomSerializer)
-        w = Worker([fooq, barq], serializer=CustomSerializer)
+        fooq, barq = Queue('foo', serializer=JSONSerializer), Queue('bar', serializer=JSONSerializer)
+        w = Worker([fooq, barq], serializer=JSONSerializer)
         self.assertEqual(
             w.work(burst=True), False,
             'Did not expect any work on the queue.'


### PR DESCRIPTION
Adds `serializer` as an argument to the `fetch_many` and `dequeue_any` methods. Also adds `self.serializer` as an argument to `fetch` calls when fetching jobs. This ensures that the worker will correctly maintain the custom serializer when pulling jobs off a queue created with a custom serializer. Likely addresses issue in #1357. Encountered and solved with @nathanielweinman