### PR TITLE
Add exception to catch redis connection failure to retry after wait time

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -596,11 +596,11 @@ class Worker(object):
                 pass
             except redis.exceptions.ConnectionError as conn_err:
                 self.log.error('Could not connect to Redis instance: %s '
-                               f'Retrying in {connection_wait_time} seconds...', conn_err)
+                               'Retrying in %f seconds...' %connection_wait_time, conn_err)
                 time.sleep(connection_wait_time)
                 connection_wait_time *= self.exponential_backoff_factor
-                if connection_wait_time > max_connection_wait_time:
-                    connection_wait_time = max_connection_wait_time
+                if connection_wait_time > self.max_connection_wait_time:
+                    connection_wait_time = self.max_connection_wait_time
             else:
                 connection_wait_time = 1.0
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -599,8 +599,7 @@ class Worker(object):
                                 conn_err, connection_wait_time)
                 time.sleep(connection_wait_time)
                 connection_wait_time *= self.exponential_backoff_factor
-                if connection_wait_time > self.max_connection_wait_time:
-                    connection_wait_time = self.max_connection_wait_time
+                connection_wait_time = min(connection_wait_time, self.max_connection_wait_time)
             else:
                 connection_wait_time = 1.0
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -595,8 +595,8 @@ class Worker(object):
             except DequeueTimeout:
                 pass
             except redis.exceptions.ConnectionError as conn_err:
-                self.log.error('Could not connect to Redis instance: %s '
-                               'Retrying in %f seconds...' %connection_wait_time, conn_err)
+                self.log.error('Could not connect to Redis instance: %s Retrying in %d seconds...', 
+                                conn_err, connection_wait_time)
                 time.sleep(connection_wait_time)
                 connection_wait_time *= self.exponential_backoff_factor
                 if connection_wait_time > self.max_connection_wait_time:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -17,6 +17,7 @@ from time import sleep
 
 from unittest import skipIf
 
+import redis.exceptions
 import pytest
 import mock
 from mock import Mock
@@ -264,6 +265,19 @@ class TestWorker(RQTestCase):
         # for compatibility reasons
         self.testconn.hdel(w.key, 'birth')
         w.refresh()
+
+    @slow
+    def test_heartbeat_survives_lost_connection(self):
+        with mock.patch.object(Worker, 'heartbeat') as mocked:
+            # None -> Heartbeat is first called before the job loop
+            mocked.side_effect = [None, redis.exceptions.ConnectionError()]
+            q = Queue()
+            w = Worker([q])
+            w.work(burst=True)
+            # First call is prior to job loop, second raises the error,
+            # third is successful, after "recovery"
+            assert mocked.call_count == 3
+
 
     @slow
     def test_heartbeat_busy(self):


### PR DESCRIPTION
Resolves #1153
Could be also potential fix for #998

formatted the code following the comments made by @selwin  on #1261 . Also, added the `max_connection_wait_time` to limit max retry timeout to 60 seconds.