### PR TITLE
bugfix: Add self.serializer when calling self.fetch_many in fetch_dependencies

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -440,7 +440,7 @@ class Job(object):
             connection.watch(*self._dependency_ids)
 
         jobs = [job
-                for job in self.fetch_many(self._dependency_ids, connection=self.connection)
+                for job in self.fetch_many(self._dependency_ids, connection=self.connection, serializer=self.serializer)
                 if job]
 
         return jobs


### PR DESCRIPTION
Code fails when I use JSONSerializer and have dependencies. This fix solves it.