### PR TITLE
Gracefully handle both str and bytes in str_to_date

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -230,7 +230,7 @@ def str_to_date(date_str):
     if not date_str:
         return
     else:
-        return utcparse(date_str.decode())
+        return utcparse(as_text(date_str))
 
 
 def parse_timeout(timeout):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from redis import Redis
 
 from tests import RQTestCase, fixtures
 from rq.utils import backend_class, ensure_list, first, get_version, is_nonstring_iterable, parse_timeout, utcparse, \
-    split_list, ceildiv
+    split_list, ceildiv, str_to_date
 from rq.exceptions import TimeoutFormatError
 
 
@@ -113,3 +113,13 @@ class TestUtils(RQTestCase):
 
         expected_small_list_count = ceildiv(BIG_LIST_SIZE, SEGMENT_SIZE)
         self.assertEqual(len(small_lists), expected_small_list_count)
+
+    def test_str_to_date(self):
+        ts_empty = None
+        ts_str = '2021-01-01T00:00:00.0Z'
+        ts_bytes = b'2021-01-01T00:00:00.0Z'
+        dt = datetime.datetime(2021, 1, 1, 0, 0, 0, 0)
+
+        self.assertIsNone(str_to_date(ts_empty))
+        self.assertEqual(str_to_date(ts_str), dt)
+        self.assertEqual(str_to_date(ts_bytes), dt)


### PR DESCRIPTION
This PR restores the ability of `str_to_date` to handle timestamps encode as either `str` or `bytes`. This behavior was removed in #1299 (specifically commit b33f3b8a6667d0d6692b502e4b69941c19f85a24) but that breaks backwards compatibility. We have some custom logic that uses `str_to_date` to store extra timestamps in the Job meta. Those timestamps are stored as `str` and upgrading to the latest version of `rq` broke that functionality.

I ran `run_tests_in_docker.sh` and all tests are passing.