### PR TITLE
Newer pip install command from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Simply use the following command to install the latest released version:
 
 If you want the cutting edge version (that may well be broken), use this:
 
-    pip install -e git+https://github.com/nvie/rq.git@master#egg=rq
+    pip install git+https://github.com/nvie/rq.git@master#egg=rq
 
 
 ## Related Projects

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ Simply use the following command to install the latest released version:
 
 If you want the cutting edge version (that may well be broken), use this:
 
-    pip install -e git+git@github.com:nvie/rq.git@master#egg=rq
+    pip install git+https://github.com/nvie/rq.git@master#egg=rq
 
 
 ## Project history


### PR DESCRIPTION
Updated cutting edge pip install command to use HTTPS rather than insecure git+git protocol, as recommended by pip documentation. This allows the command to work with pip >= 21.0.1
This fixes issue #1439 