### PR TITLE
prevent job exception being logged twice

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1046,7 +1046,7 @@ class Worker(object):
     def handle_exception(self, job, *exc_info):
         """Walks the exception handler stack to delegate exception handling."""
         exc_string = ''.join(traceback.format_exception(*exc_info))
-        self.log.error(exc_string, exc_info=True, extra={
+        self.log.error(exc_string, extra={
             'func': job.func_name,
             'arguments': job.args,
             'kwargs': job.kwargs,


### PR DESCRIPTION
Currently, the traceback of an exception occurring in a job ends up being printed twice:

```
15:35:23 Handling failed execution of job 8593dcd5-9b83-4342-8e7d-8d0b7ad8d39e
15:35:23 Traceback (most recent call last):
  File "/Users/peter/devel/rq/rq/worker.py", line 1008, in perform_job
    rv = job.perform()
  File "/Users/peter/devel/rq/rq/job.py", line 706, in perform
    self._result = self._execute()
  File "/Users/peter/devel/rq/rq/job.py", line 729, in _execute
    result = self.func(*self.args, **self.kwargs)
  File "./tasks.py", line 2, in buggy
    raise Exception("Whooops! A daisy!")
Exception: Whooops! A daisy!
Traceback (most recent call last):
  File "/Users/peter/devel/rq/rq/worker.py", line 1008, in perform_job
    rv = job.perform()
  File "/Users/peter/devel/rq/rq/job.py", line 706, in perform
    self._result = self._execute()
  File "/Users/peter/devel/rq/rq/job.py", line 729, in _execute
    result = self.func(*self.args, **self.kwargs)
  File "./tasks.py", line 2, in buggy
    raise Exception("Whooops! A daisy!")
Exception: Whooops! A daisy!
15:35:23 Sent heartbeat to prevent worker timeout. Next one should arrive within 480 seconds.
```

This is because the traceback is printed as the log message and by `logging.error`'s `exc_info` handling.

This small changes fixes it and hopefully doesn't break something I'm not aware of.
