### PR TITLE
Make RQScheduler work with a serializer

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -62,7 +62,7 @@ shared_options = [
                  default=DEFAULT_CONNECTION_CLASS,
                  help='Redis client class to use'),
     click.option('--path', '-P',
-                 default='.',
+                 default=['.'],
                  help='Specify the import path.',
                  multiple=True),
     click.option('--serializer', '-S',

--- a/rq/version.py
+++ b/rq/version.py
@@ -2,4 +2,4 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-VERSION = '1.8.0'
+VERSION = '1.8.1'

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -558,7 +558,7 @@ class Worker(object):
         if with_scheduler:
             self.scheduler = RQScheduler(
                 self.queues, connection=self.connection, logging_level=logging_level,
-                date_format=date_format, log_format=log_format)
+                date_format=date_format, log_format=log_format, serializer=self.serializer)
             self.scheduler.acquire_locks()
             # If lock is acquired, start scheduler
             if self.scheduler.acquired_locks:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -9,6 +9,7 @@ from rq.exceptions import NoSuchJobError
 from rq.job import Job, Retry
 from rq.registry import FinishedJobRegistry, ScheduledJobRegistry
 from rq.scheduler import RQScheduler
+from rq.serializers import JSONSerializer
 from rq.utils import current_timestamp
 from rq.worker import Worker
 
@@ -309,6 +310,18 @@ class TestWorker(RQTestCase):
         registry = FinishedJobRegistry(queue=queue)
         self.assertEqual(len(registry), 1)
 
+    def test_work_with_serializer(self):
+        queue = Queue(connection=self.testconn, serializer=JSONSerializer)
+        worker = Worker(queues=[queue], connection=self.testconn, serializer=JSONSerializer)
+        p = Process(target=kill_worker, args=(os.getpid(), False, 5))
+
+        p.start()
+        queue.enqueue_at(datetime(2019, 1, 1, tzinfo=timezone.utc), say_hello)
+        worker.work(burst=False, with_scheduler=True)
+        p.join(1)
+        self.assertIsNotNone(worker.scheduler)
+        registry = FinishedJobRegistry(queue=queue)
+        self.assertEqual(len(registry), 1)
 
 class TestQueue(RQTestCase):
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -316,7 +316,10 @@ class TestWorker(RQTestCase):
         p = Process(target=kill_worker, args=(os.getpid(), False, 5))
 
         p.start()
-        queue.enqueue_at(datetime(2019, 1, 1, tzinfo=timezone.utc), say_hello)
+        queue.enqueue_at(
+            datetime(2019, 1, 1, tzinfo=timezone.utc), 
+            say_hello, meta={'foo': 'bar'}
+        )
         worker.work(burst=False, with_scheduler=True)
         p.join(1)
         self.assertIsNotNone(worker.scheduler)


### PR DESCRIPTION
1. Fixes: https://github.com/rq/rq/issues/1453
2. making cli.py compatible with click 8.x

-cc @selwin 