### PR TITLE
bugfix: Allow using staticmethods as jobs

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -108,7 +108,7 @@ class Job(object):
             job._instance = func.__self__
             job._func_name = func.__name__
         elif inspect.isfunction(func) or inspect.isbuiltin(func):
-            job._func_name = '{0}.{1}'.format(func.__module__, func.__name__)
+            job._func_name = '{0}.{1}'.format(func.__module__, func.__qualname__)
         elif isinstance(func, string_types):
             job._func_name = as_text(func)
         elif not inspect.isclass(func) and hasattr(func, '__call__'):  # a callable class instance

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -143,6 +143,12 @@ class UnicodeStringObject(object):
         return u'é'
 
 
+class ClassWithAStaticMethod(object):
+    @staticmethod
+    def static_method():
+        return u"I'm a static method"
+
+
 with Connection():
     @job(queue='default')
     def decorated_job(x, y):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -772,6 +772,14 @@ class TestJob(RQTestCase):
         self.assertIsNotNone(job.get_call_string())
         job.perform()
 
+    def test_create_job_from_static_method(self):
+        """test creating jobs with static method"""
+        queue = Queue(connection=self.testconn)
+
+        job = queue.enqueue(fixtures.ClassWithAStaticMethod.static_method)
+        self.assertIsNotNone(job.get_call_string())
+        job.perform()
+
     def test_create_job_with_ttl_should_have_ttl_after_enqueued(self):
         """test creating jobs with ttl and checks if get_jobs returns it properly [issue502]"""
         queue = Queue(connection=self.testconn)


### PR DESCRIPTION
This PR fixes a problem reported in https://github.com/rq/rq/issues/1457 - it allows to enqueue class functions decorated with `staticmethod`, like `test_job`:

```python
class TestClass:
    @staticmethod
    def test_job():
        return 'Test static method'
```

All the existing tests and a newly created test case pass.

Unfortunately, I see at least one case, in which `staticmethod`s still can't be enqueued - it's when they're members of nested classes, like `nested_test_job`:
```python
class TestClass:
    class NestedClass:
        @staticmethod
        def nested_test_job():
            return 'Test static method'
```

I haven't implemented handling them as I'm not sure, if it's worth the effort - what do you think? :)