### PR TITLE
Add job.fail

### DIFF
--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -31,3 +31,14 @@ class ShutDownImminentException(Exception):
 
 class TimeoutFormatError(Exception):
     pass
+
+
+class JobFailture(Exception):
+    def __init__(self, msg, retry=None, seconds_until_next_retry=None, decrease_retries=True, show_traceback=True,
+                 use_exc_handlers=True):
+        super(JobFailture, self).__init__(msg)
+        self.retry = retry
+        self.seconds_until_next_retry = seconds_until_next_retry
+        self.decrease_retries = decrease_retries
+        self.show_traceback = show_traceback
+        self.use_exc_handlers = use_exc_handlers

--- a/rq/job.py
+++ b/rq/job.py
@@ -907,10 +907,7 @@ class Job:
         job_failture = JobFailture(_msg, retry, seconds_until_next_retry, decrease_retries, show_traceback,
                                    use_exc_handlers)
 
-        if exception is None:
-            raise job_failture
-        else:
-            raise job_failture from exception
+        raise job_failture from exception
 
 
 _job_stack = LocalStack()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -121,6 +121,18 @@ def echo(*args, **kwargs):
     return args, kwargs
 
 
+def fail():
+    get_current_job().fail()
+
+
+def fail_with_retry():
+    """Fails with retry=True. decrease_retries is read from the meta and set to True afterwards"""
+    current_job = get_current_job()
+    decrease_retries = current_job.meta['decrease_retries']
+    current_job.meta['decrease_retries'] = True
+    current_job.fail(retry=True, decrease_retries=decrease_retries)
+
+
 class Number:
     def __init__(self, value):
         self.value = value


### PR DESCRIPTION
Added method `job.fail` to fail the job using a method.

`job.fail` takes some args to change the failture behavior. Not specifying anything affects the same as raising an exception, apart from printing the traceback which is disabled by default in `job.fail`.


**For review**: Please tell me if I should change `exc_info` to `orig_exc_info` in some places in 
https://github.com/rq/rq/blob/2ee3416aa1a1653ff5bc3974ed5566ea60c49d93/rq/worker.py#L1045-L1051

Closes #1313 
View: https://github.com/rq/rq/issues/1313#issuecomment-847300810