### PR TITLE
Make `Queue.enqueue`, `Queue.enqueue_call`,  `Queue.enqueue_at``Queue.parse_args` accept `pipeline` arg, add `Queue.enqueue_many` method

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -75,6 +75,7 @@ results are kept. Expired jobs will be automatically deleted. Defaults to 500 se
 * `at_front` will place the job at the *front* of the queue, instead of the
   back
 * `description` to add additional description to enqueued jobs.
+* `pipeline` specifies a custom `redis.Pipeline` instance to enqueue the job with.
 * `args` and `kwargs`: use these to explicitly pass arguments and keyword to the
   underlying job function. This is useful if your function happens to have
   conflicting argument names with RQ, for example `description` or `ttl`.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -132,7 +132,7 @@ with q.connection.pipeline() as pipe:
 `Queue.prepare_data` accepts all arguments that `Queue.parse_args` does **EXCEPT** for `depends_on`,
 which is not supported at this time, so dependencies will be up to you to setup.
 
-## Working with Queues
+### Working with Queues
 
 Besides enqueuing jobs, Queues have a few useful methods:
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -75,7 +75,6 @@ results are kept. Expired jobs will be automatically deleted. Defaults to 500 se
 * `at_front` will place the job at the *front* of the queue, instead of the
   back
 * `description` to add additional description to enqueued jobs.
-* `pipeline` specifies a custom `redis.Pipeline` instance to enqueue the job with.
 * `args` and `kwargs`: use these to explicitly pass arguments and keyword to the
   underlying job function. This is useful if your function happens to have
   conflicting argument names with RQ, for example `description` or `ttl`.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -102,6 +102,35 @@ q = Queue('low', connection=redis_conn)
 q.enqueue('my_package.my_module.my_func', 3, 4)
 ```
 
+## Bulk Job Enqueueing
+_New in version 1.9.0._  
+You can also enqueue multiple jobs in bulk with `queue.enqueue_many()` and `Queue.prepare_data()`:
+
+```python
+jobs = q.enqueue_many(
+  [
+    Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_job_id'),
+    Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_other_job_id'),
+  ]
+)
+```
+
+which will enqueue all the jobs in a single redis `pipeline` which you can optionally pass in yourself:
+
+```python
+with q.connection.pipeline() as pipe:
+  jobs = q.enqueue_many(
+    [
+      Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_job_id'),
+      Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_other_job_id'),
+    ]
+    pipeline=pipe
+  )
+  pipe.execute()
+```
+
+`Queue.prepare_data` accepts all arguments that `Queue.parse_args` does **EXCEPT** for `depends_on`,
+which is not supported at this time, so dependencies will be up to you to setup.
 
 ## Working with Queues
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -102,7 +102,7 @@ q = Queue('low', connection=redis_conn)
 q.enqueue('my_package.my_module.my_func', 3, 4)
 ```
 
-## Bulk Job Enqueueing
+### Bulk Job Enqueueing
 _New in version 1.9.0._  
 You can also enqueue multiple jobs in bulk with `queue.enqueue_many()` and `Queue.prepare_data()`:
 
@@ -132,7 +132,7 @@ with q.connection.pipeline() as pipe:
 `Queue.prepare_data` accepts all arguments that `Queue.parse_args` does **EXCEPT** for `depends_on`,
 which is not supported at this time, so dependencies will be up to you to setup.
 
-### Working with Queues
+## Working with Queues
 
 Besides enqueuing jobs, Queues have a few useful methods:
 

--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -84,37 +84,6 @@ job = Job.create(count_words_at_url,
           })
 ```
 
-#### Bulk Job Enqueueing
-_New in version 1.9.0._  
-You can also enqueue multiple jobs in bulk with `queue.enqueue_many()` and `Queue.prepare_data()`:
-
-```python
-jobs = q.enqueue_many(
-  [
-    Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_job_id'),
-    Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_other_job_id'),
-  ]
-)
-```
-
-which will enqueue all the jobs in a single redis `pipeline` which you can optionally pass in yourself:
-
-```python
-with q.connection.pipeline() as pipe:
-  jobs = q.enqueue_many(
-    [
-      Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_job_id'),
-      Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_other_job_id'),
-    ]
-    pipeline=pipe
-  )
-  pipe.execute()
-```
-
-`Queue.prepare_data` accepts all arguments that `Queue.parse_args` does **EXCEPT** for `depends_on`,
-which is not supported at this time, so dependencies will be up to you to setup.
-
-
 ### Retrieving a Job from Redis
 
 All job information is stored in Redis. You can inspect a job and its attributes

--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -84,6 +84,37 @@ job = Job.create(count_words_at_url,
           })
 ```
 
+#### Bulk Job Enqueueing
+_New in version 1.9.0._  
+You can also enqueue multiple jobs in bulk with `queue.enqueue_many()` and `Queue.prepare_data()`:
+
+```python
+jobs = q.enqueue_many(
+  [
+    Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_job_id'),
+    Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_other_job_id'),
+  ]
+)
+```
+
+which will enqueue all the jobs in a single redis `pipeline` which you can optionally pass in yourself:
+
+```python
+with q.connection.pipeline() as pipe:
+  jobs = q.enqueue_many(
+    [
+      Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_job_id'),
+      Queue.prepare_data(count_words_at_url, 'http://nvie.com', job_id='my_other_job_id'),
+    ]
+    pipeline=pipe
+  )
+  pipe.execute()
+```
+
+`Queue.prepare_data` accepts all arguments that `Queue.parse_args` does **EXCEPT** for `depends_on`,
+which is not supported at this time, so dependencies will be up to you to setup.
+
+
 ### Retrieving a Job from Redis
 
 All job information is stored in Redis. You can inspect a job and its attributes

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -24,7 +24,7 @@ def compact(lst):
     return [item for item in lst if item is not None]
 
 
-class JobEnqueueData(namedtuple('JobData', ["func", "args", "kwargs", "timeout",
+class JobEnqueueData(namedtuple('JobEnqueueData', ["func", "args", "kwargs", "timeout",
                                             "result_ttl", "ttl", "failure_ttl",
                                             "description", "job_id",
                                             "at_front", "meta", "retry"])):

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -340,7 +340,7 @@ nd
             pipe = pipeline if pipeline is not None else self.connection.pipeline()
             while True:
                 try:
-                    # Also calling watch even if caller 
+                    # Also calling watch even if caller
                     # passed in a pipeline since Queue#create_job
                     # is called from within this method.
                     pipe.watch(job.dependencies_key)
@@ -372,8 +372,8 @@ nd
                         # if pipeline comes from caller, re-raise to them
                         raise
         # No need for multi or While True loop because in this case
-        # Anything being watched came from caller, so 
-        # it will simply raise back up to them.    
+        # Anything being watched came from caller, so
+        # it will simply raise back up to them.
         job = self.enqueue_job(job, pipeline=pipeline, at_front=at_front)
         return job
 

--- a/rq/version.py
+++ b/rq/version.py
@@ -2,4 +2,4 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-VERSION = '1.8.1'
+VERSION = '1.9.0'

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -4,7 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 
 import json
 from datetime import datetime, timedelta, timezone
-from os import pipe
 from mock.mock import patch
 from redis import WatchError
 
@@ -36,6 +35,7 @@ class MultipleDependencyJob(Job):
         _job = cls.create_job(*args, **kwargs)
         _job._dependency_ids = dependency_ids
         return _job
+
 
 class TestQueue(RQTestCase):
     def test_create_queue(self):
@@ -521,15 +521,14 @@ class TestQueue(RQTestCase):
                     job = q.enqueue_call(say_hello, depends_on=parent_job, pipeline=pipe)
                     self.assertEqual(q.job_ids, [])
                     self.assertEqual(job.get_status(refresh=False), JobStatus.DEFERRED)
-                    # Not in registry before execute, since passed in pipeline 
+                    # Not in registry before execute, since passed in pipeline
                     self.assertEqual(len(q.deferred_job_registry), 0)
                     pipe.execute()
                     break
                 except WatchError:
                     continue
-            # Only in registry after execute, since passed in pipeline 
+            # Only in registry after execute, since passed in pipeline
             self.assertEqual(len(q.deferred_job_registry), 1)
-
 
         # Jobs dependent on finished jobs are immediately enqueued
         parent_job.set_status(JobStatus.FINISHED)
@@ -697,7 +696,7 @@ class TestQueue(RQTestCase):
         self.assertEqual(queue.failed_job_registry, FailedJobRegistry(queue=queue))
         self.assertEqual(queue.deferred_job_registry, DeferredJobRegistry(queue=queue))
         self.assertEqual(queue.finished_job_registry, FinishedJobRegistry(queue=queue))
-    
+
     def test_enqueue_with_retry(self):
         """Enqueueing with retry_strategy works"""
         queue = Queue('example', connection=self.testconn)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -9,6 +9,7 @@ from redis import WatchError
 
 from rq import Retry, Queue
 from rq.job import Job, JobStatus
+from rq.queue import JobEnqueueData
 from rq.registry import (DeferredJobRegistry, FailedJobRegistry,
                          FinishedJobRegistry, ScheduledJobRegistry,
                          StartedJobRegistry)
@@ -549,6 +550,73 @@ class TestQueue(RQTestCase):
             self.assertEqual(q.job_ids, [job.id])
             self.assertEqual(job.timeout, Queue.DEFAULT_TIMEOUT)
             self.assertEqual(job.get_status(refresh=False), JobStatus.QUEUED)
+
+    def test_enqueue_many_internal_pipeline(self):
+        """Jobs should be enqueued in bulk with an internal pipeline, enqueued in order provided
+        (but at_front still applies)"""
+        # Job with unfinished dependency is not immediately enqueued
+        q = Queue()
+        job_1_data = JobEnqueueData.create(
+            say_hello,
+            job_id='fake_job_id_1',
+            at_front=False
+        )
+        job_2_data = JobEnqueueData.create(
+            say_hello,
+            job_id='fake_job_id_2',
+            at_front=False
+        )
+        job_3_data = JobEnqueueData.create(
+            say_hello,
+            job_id='fake_job_id_3',
+            at_front=True
+        )
+        jobs = q.enqueue_many(
+            [job_1_data, job_2_data, job_3_data],
+        )
+        for job in jobs:
+            self.assertEqual(job.get_status(refresh=False), JobStatus.QUEUED)
+        # Only in registry after execute, since passed in pipeline
+        self.assertEqual(len(q), 3)
+        self.assertEqual(q.job_ids, ['fake_job_id_3', 'fake_job_id_1', 'fake_job_id_2'])
+
+    def test_enqueue_many_with_passed_pipeline(self):
+        """Jobs should be enqueued in bulk with a passed pipeline, enqueued in order provided
+        (but at_front still applies)"""
+        # Job with unfinished dependency is not immediately enqueued
+        q = Queue()
+        with q.connection.pipeline() as pipe:
+            while True:
+                try:
+                    job_1_data = JobEnqueueData.create(
+                        say_hello,
+                        job_id='fake_job_id_1',
+                        at_front=False
+                    )
+                    job_2_data = JobEnqueueData.create(
+                        say_hello,
+                        job_id='fake_job_id_2',
+                        at_front=False
+                    )
+                    job_3_data = JobEnqueueData.create(
+                        say_hello,
+                        job_id='fake_job_id_3',
+                        at_front=True
+                    )
+                    jobs = q.enqueue_many(
+                        [job_1_data, job_2_data, job_3_data],
+                        pipeline=pipe
+                    )
+                    self.assertEqual(q.job_ids, [])
+                    for job in jobs:
+                        self.assertEqual(job.get_status(refresh=False), JobStatus.QUEUED)
+                    pipe.execute()
+                    break
+                except WatchError:
+                    continue
+            # Only in registry after execute, since passed in pipeline
+            self.assertEqual(len(q), 3)
+            self.assertEqual(q.job_ids, ['fake_job_id_3', 'fake_job_id_1', 'fake_job_id_2'])
 
     def test_enqueue_job_with_dependency_by_id(self):
         """Can specify job dependency with job object or job id."""


### PR DESCRIPTION
Resolves #753 

See also: #241

Allow user to pass in a `pipeline` argument to the enqueue methods.

One main use case is the ability for the caller to use their own pipeline and still be able to utilize the dependency logic defined in `enqueue_call`.

-cc @selwin