### PR TITLE
Added logging trace for failed import for user-level debugging

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -142,8 +142,7 @@ def import_attribute(name):
             module = importlib.import_module(module_name)
             break
         except ImportError:
-            logging.warning("Import error for '%s'" % module_name)
-            logging.warning("Import error trace:", exc_info=True)
+            logging.warning("Import error for '%s'" % module_name, exc_info=True)
             attribute_bits.insert(0, module_name_bits.pop())
 
     if module is None:

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -132,12 +132,18 @@ def import_attribute(name):
     # dotted path is not the last-before-end word
     # E.g.: package_a.package_b.module_a.ClassA.my_static_method
     # Thus we remove the bits from the end of the name until we can import it
+    #
+    # Sometimes the failure during importing is due to a genuine coding error in the imported module
+    # In this case, the exception is logged as a warning for ease of debugging.
+    # The above logic will apply anyways regardless of the cause of the import error.
     while len(module_name_bits):
         try:
             module_name = '.'.join(module_name_bits)
             module = importlib.import_module(module_name)
             break
         except ImportError:
+            logging.warning("Import error for '%s'" % module_name)
+            logging.warning("Import error trace:", exc_info=True)
             attribute_bits.insert(0, module_name_bits.pop())
 
     if module is None:


### PR DESCRIPTION
Sometimes the failure during importing is due to a genuine coding error in the imported module. In this case, the exception is logged as a warning for ease of debugging of the imported user code.  The logic is unchanged and it will be applied anyways regardless of the cause of the import error.

A case where it seems beneficial to have more feedback on the import error has been reported in issue #1488