### PR TITLE
Extract `Job.get_call_string` logic to `utils.get_call_string`

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -753,7 +753,7 @@ class Job:
         """Returns a string representation of the call, formatted as a regular
         Python function invocation statement.
         """
-        return get_call_string(self.func_name, self.args, self.kwargs, truncate=True)
+        return get_call_string(self.func_name, self.args, self.kwargs, max_length=75)
 
     def cleanup(self, ttl=None, pipeline=None, remove_from_queue=True):
         """Prepare job for eventual deletion (if needed). This method is usually

--- a/rq/job.py
+++ b/rq/job.py
@@ -22,7 +22,7 @@ from .exceptions import DeserializationError, NoSuchJobError
 from .local import LocalStack
 from .serializers import resolve_serializer
 from .utils import (get_version, import_attribute, parse_timeout, str_to_date,
-                    utcformat, utcnow, ensure_list)
+                    utcformat, utcnow, ensure_list, get_call_string)
 
 # Serialize pickle dumps using the highest pickle protocol (binary, default
 # uses ascii)
@@ -759,17 +759,7 @@ class Job:
         """Returns a string representation of the call, formatted as a regular
         Python function invocation statement.
         """
-        if self.func_name is None:
-            return None
-
-        arg_list = [as_text(truncate_long_string(repr(arg))) for arg in self.args]
-
-        kwargs = ['{0}={1}'.format(k, as_text(truncate_long_string(repr(v)))) for k, v in self.kwargs.items()]
-        # Sort here because python 3.3 & 3.4 makes different call_string
-        arg_list += sorted(kwargs)
-        args = ', '.join(arg_list)
-
-        return '{0}({1})'.format(self.func_name, args)
+        return get_call_string(self.func_name, self.args, self.kwargs)
 
     def cleanup(self, ttl=None, pipeline=None, remove_from_queue=True):
         """Prepare job for eventual deletion (if needed). This method is usually

--- a/rq/job.py
+++ b/rq/job.py
@@ -45,12 +45,6 @@ class JobStatus(str, Enum):
 UNEVALUATED = object()
 
 
-def truncate_long_string(data, maxlen=75):
-    """ Truncates strings longer than maxlen
-    """
-    return (data[:maxlen] + '...') if len(data) > maxlen else data
-
-
 def cancel_job(job_id, connection=None):
     """Cancels the job with the given job ID, preventing execution.  Discards
     any job info (i.e. it can't be requeued later).
@@ -759,7 +753,7 @@ class Job:
         """Returns a string representation of the call, formatted as a regular
         Python function invocation statement.
         """
-        return get_call_string(self.func_name, self.args, self.kwargs)
+        return get_call_string(self.func_name, self.args, self.kwargs, truncate=True)
 
     def cleanup(self, ttl=None, pipeline=None, remove_from_queue=True):
         """Prepare job for eventual deletion (if needed). This method is usually

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -299,6 +299,13 @@ def split_list(a_list, segment_size):
         yield a_list[i:i + segment_size]
 
 
+def truncate_long_string(data, max_length=None):
+    """Truncate arguments with representation longer than max_length"""
+    if max_length is None:
+        return data
+    return (data[:max_length] + '...') if len(data) > max_length else data
+
+
 def get_call_string(func_name, args, kwargs, max_length=None):
     """Returns a string representation of the call, formatted as a regular
     Python function invocation statement. If max_length is not None, truncate
@@ -307,14 +314,9 @@ def get_call_string(func_name, args, kwargs, max_length=None):
     if func_name is None:
         return None
 
-    def truncate_long_string(data):
-        if max_length is None:
-            return data
-        return (data[:max_length] + '...') if len(data) > max_length else data
+    arg_list = [as_text(truncate_long_string(repr(arg), max_length)) for arg in args]
 
-    arg_list = [as_text(truncate_long_string(repr(arg))) for arg in args]
-
-    kwargs = ['{0}={1}'.format(k, as_text(truncate_long_string(repr(v)))) for k, v in kwargs.items()]
+    kwargs = ['{0}={1}'.format(k, as_text(truncate_long_string(repr(v), max_length))) for k, v in kwargs.items()]
     arg_list += sorted(kwargs)
     args = ', '.join(arg_list)
 

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -310,7 +310,6 @@ def get_call_string(func_name, args, kwargs):
     arg_list = [as_text(truncate_long_string(repr(arg))) for arg in args]
 
     kwargs = ['{0}={1}'.format(k, as_text(truncate_long_string(repr(v)))) for k, v in kwargs.items()]
-    # Sort here because python 3.3 & 3.4 makes different call_string
     arg_list += sorted(kwargs)
     args = ', '.join(arg_list)
 

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -297,3 +297,21 @@ def split_list(a_list, segment_size):
     """
     for i in range(0, len(a_list), segment_size):
         yield a_list[i:i + segment_size]
+
+
+def get_call_string(func_name, args, kwargs):
+    """Returns a string representation of the call, formatted as a regular
+    Python function invocation statement.
+    """
+    if func_name is None:
+        return None
+    from .job import truncate_long_string  # work around circular import issue
+
+    arg_list = [as_text(truncate_long_string(repr(arg))) for arg in args]
+
+    kwargs = ['{0}={1}'.format(k, as_text(truncate_long_string(repr(v)))) for k, v in kwargs.items()]
+    # Sort here because python 3.3 & 3.4 makes different call_string
+    arg_list += sorted(kwargs)
+    args = ', '.join(arg_list)
+
+    return '{0}({1})'.format(func_name, args)

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -299,18 +299,18 @@ def split_list(a_list, segment_size):
         yield a_list[i:i + segment_size]
 
 
-def get_call_string(func_name, args, kwargs, truncate=False, maxlen=75):
+def get_call_string(func_name, args, kwargs, max_length=None):
     """Returns a string representation of the call, formatted as a regular
-    Python function invocation statement. If truncate is True, truncate
-    arguments with representation longer than maxlen.
+    Python function invocation statement. If max_length is not None, truncate
+    arguments with representation longer than max_length.
     """
     if func_name is None:
         return None
 
     def truncate_long_string(data):
-        if truncate is False:
+        if max_length is None:
             return data
-        return (data[:maxlen] + '...') if len(data) > maxlen else data
+        return (data[:max_length] + '...') if len(data) > max_length else data
 
     arg_list = [as_text(truncate_long_string(repr(arg))) for arg in args]
 

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -299,13 +299,18 @@ def split_list(a_list, segment_size):
         yield a_list[i:i + segment_size]
 
 
-def get_call_string(func_name, args, kwargs):
+def get_call_string(func_name, args, kwargs, truncate=False, maxlen=75):
     """Returns a string representation of the call, formatted as a regular
-    Python function invocation statement.
+    Python function invocation statement. If truncate is True, truncate
+    arguments with representation longer than maxlen.
     """
     if func_name is None:
         return None
-    from .job import truncate_long_string  # work around circular import issue
+
+    def truncate_long_string(data):
+        if truncate is False:
+            return data
+        return (data[:maxlen] + '...') if len(data) > maxlen else data
 
     arg_list = [as_text(truncate_long_string(repr(arg))) for arg in args]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from redis import Redis
 
 from tests import RQTestCase, fixtures
 from rq.utils import backend_class, ensure_list, first, get_version, is_nonstring_iterable, parse_timeout, utcparse, \
-    split_list, ceildiv
+    split_list, ceildiv, get_call_string
 from rq.exceptions import TimeoutFormatError
 
 
@@ -113,3 +113,8 @@ class TestUtils(RQTestCase):
 
         expected_small_list_count = ceildiv(BIG_LIST_SIZE, SEGMENT_SIZE)
         self.assertEqual(len(small_lists), expected_small_list_count)
+
+    def test_get_call_string(self):
+        """Ensure a case when all arguments are not None works properly"""
+        cs = get_call_string("f", ('some', 'args', 42), {"key1": "value1", "key2": True})
+        assert cs == "f('some', 'args', 42, key1='value1', key2=True)"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,6 +121,9 @@ class TestUtils(RQTestCase):
         assert truncate_long_string("1234", max_length=3) == "123..."
         assert truncate_long_string("12345", max_length=3) == "123..."
 
+        s = "long string but no max_length provided so no truncating should occur" * 10
+        assert truncate_long_string(s) == s
+
     def test_get_call_string(self):
         """Ensure a case, when func_name, args and kwargs are not None, works properly"""
         cs = get_call_string("f", ('some', 'args', 42), {"key1": "value1", "key2": True})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,3 +118,11 @@ class TestUtils(RQTestCase):
         """Ensure a case, when func_name, args and kwargs are not None, works properly"""
         cs = get_call_string("f", ('some', 'args', 42), {"key1": "value1", "key2": True})
         assert cs == "f('some', 'args', 42, key1='value1', key2=True)"
+
+    def test_get_call_string_with_max_length(self):
+        """Ensure get_call_string works properly when max_length is provided"""
+        func_name = "f"
+        args = (1234, 12345, 123456)
+        kwargs = {"len4": 1234, "len5": 12345, "len6": 123456}
+        cs = get_call_string(func_name, args, kwargs, max_length=5)
+        assert cs == "f(1234, 12345, 12345..., len4=1234, len5=12345, len6=12345...)"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,6 +115,6 @@ class TestUtils(RQTestCase):
         self.assertEqual(len(small_lists), expected_small_list_count)
 
     def test_get_call_string(self):
-        """Ensure a case when all arguments are not None works properly"""
+        """Ensure a case, when func_name, args and kwargs are not None, works properly"""
         cs = get_call_string("f", ('some', 'args', 42), {"key1": "value1", "key2": True})
         assert cs == "f('some', 'args', 42, key1='value1', key2=True)"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from redis import Redis
 
 from tests import RQTestCase, fixtures
 from rq.utils import backend_class, ensure_list, first, get_version, is_nonstring_iterable, parse_timeout, utcparse, \
-    split_list, ceildiv, get_call_string
+    split_list, ceildiv, get_call_string, truncate_long_string
 from rq.exceptions import TimeoutFormatError
 
 
@@ -113,6 +113,13 @@ class TestUtils(RQTestCase):
 
         expected_small_list_count = ceildiv(BIG_LIST_SIZE, SEGMENT_SIZE)
         self.assertEqual(len(small_lists), expected_small_list_count)
+
+    def test_truncate_long_string(self):
+        """Ensure truncate_long_string works properly"""
+        assert truncate_long_string("12", max_length=3) == "12"
+        assert truncate_long_string("123", max_length=3) == "123"
+        assert truncate_long_string("1234", max_length=3) == "123..."
+        assert truncate_long_string("12345", max_length=3) == "123..."
 
     def test_get_call_string(self):
         """Ensure a case, when func_name, args and kwargs are not None, works properly"""


### PR DESCRIPTION
# Motivation / use case

Let's say you want to enqueue invocation of the following function: `f(arg1, arg2, secret_passphrase)`.
Currently, to avoid logging `secret_passphrase`, possible solutions include disabling logging or providing custom `Job.description`.

If you want to mimic rq's default `Job.description`, you have to create a fake `Job` with `func_name`, `args` and `kwargs` attributes. Then you can call `Job.get_call_string(fake_object)`. Such workaround has a potential to break application when the implementation details of `Job` change.

# Proposed solution

Move `Job.get_call_string` logic to `utils` with the following signature `get_call_string(func_name, args, kwargs)`. This way that helper function can be used by applications, for example in the following way:

```python
func_name, args, kwargs = ..., ..., ...
q = get_queue()

kwargs_without_secrets = kwargs.copy()
kwargs_without_secrets['secret_passphrase'] = "**REDACTED**"

my_desc = get_call_string(func_name, args, kwargs_without_secrets)
q.enqueue(f, *args, description=my_desc, **kwargs)
```

# Additional considerations

`job.truncate_long_string` is only used by `get_call_string`. I'm not sure whether it's part of public API so I didn't move it to `utils`.

If you'd like to have it in `utils` instead of keeping it in `job`, I'm ready to help.