### PR TITLE
Issue 1416: Use result_ttl for synchronous queues 

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -448,7 +448,7 @@ nd
         job.perform()
         job.set_status(JobStatus.FINISHED)
         job.save(include_meta=False)
-        job.cleanup(DEFAULT_RESULT_TTL)
+        job.cleanup(job.get_result_ttl(default_ttl=DEFAULT_RESULT_TTL))
         return job
 
     @classmethod

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -335,6 +335,18 @@ class TestQueue(RQTestCase):
         job = queue.enqueue_job(job)
         self.assertEqual(job.timeout, 15)
 
+    def test_synchronous_timeout(self):
+        queue = Queue(is_async=False)
+
+        no_expire_job = queue.enqueue(echo, result_ttl=-1)
+        self.assertEqual(queue.connection.ttl(no_expire_job.key), -1)
+
+        delete_job = queue.enqueue(echo, result_ttl=0)
+        self.assertEqual(queue.connection.ttl(delete_job.key), -2)
+
+        keep_job = queue.enqueue(echo, result_ttl=100)
+        self.assertLessEqual(queue.connection.ttl(keep_job.key), 100)
+
     def test_enqueue_explicit_args(self):
         """enqueue() works for both implicit/explicit args."""
         q = Queue()


### PR DESCRIPTION
Re: https://github.com/rq/rq/issues/1416, this PR updates queues with `is_async=False` to respect job result TTLs.

The issue diagnoses the problem correctly. The new tests cover the `Queue.run_job` method, which is making the `cleanup` call.