### PR TITLE
Handle ResponseError when CLIENT command is not supported

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -221,8 +221,13 @@ class Worker:
         if prepare_for_work:
             self.hostname = socket.gethostname()
             self.pid = os.getpid()
-            connection.client_setname(self.name)
-            self.ip_address = [client['addr'] for client in connection.client_list() if client['name'] == self.name][0]
+            try:
+                connection.client_setname(self.name)
+            except redis.exceptions.ResponseError:
+                warnings.warn('CLIENT command not supported, setting ip_address to unknown')
+                self.ip_address = 'unknown'
+            else:
+                self.ip_address = [client['addr'] for client in connection.client_list() if client['name'] == self.name][0]
         else:
             self.hostname = None
             self.pid = None

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -224,7 +224,10 @@ class Worker:
             try:
                 connection.client_setname(self.name)
             except redis.exceptions.ResponseError:
-                warnings.warn('CLIENT command not supported, setting ip_address to unknown')
+                warnings.warn(
+                    'CLIENT command not supported, setting ip_address to unknown',
+                    Warning
+                )
                 self.ip_address = 'unknown'
             else:
                 self.ip_address = [client['addr'] for client in connection.client_list() if client['name'] == self.name][0]


### PR DESCRIPTION
The `CLIENT` redis command is not supported in Google Memorystore Redis. This PR catches the `ResponseError` thrown when `rq` tries to use the `CLIENT` command, logs a warning and sets the `ip_address` to `"unknown"`.

See https://github.com/rq/rq/issues/1508 for related issue.