### PR TITLE
Add option to enqueue a jobs dependents when canceling

### DIFF
--- a/docs/contrib/index.md
+++ b/docs/contrib/index.md
@@ -55,9 +55,12 @@ Any job ID that is encountered by a worker for which no job hash is found in
 Redis is simply ignored.  This makes it easy to cancel jobs by simply removing
 the job hash.  In Python:
 
+```python
     from rq import cancel_job
     cancel_job('2eafc1e6-48c2-464b-a0ff-88fd199d039c')
+```
 
 Note that it is irrelevant on which queue the job resides.  When a worker
 eventually pops the job ID from the queue and notes that the Job hash does not
 exist (anymore), it simply discards the job ID and continues with the next.
+

--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -171,6 +171,17 @@ Canceling a job will remove:
 Note that `job.cancel()` does **not** delete the job itself from Redis. If you want to
 delete the job from Redis and reclaim memory, use `job.delete()`.
 
+Note: if you want to enqueue the dependents of the job you 
+are trying to cancel use the following:
+
+```python
+from rq import cancel_job
+cancel_job(
+  '2eafc1e6-48c2-464b-a0ff-88fd199d039c',
+  enqueue_dependents=True
+)
+```
+
 ## Job / Queue Creation with Custom Serializer
 
 When creating a job or queue, you can pass in a custom serializer that will be used for serializing / de-serializing job arguments.


### PR DESCRIPTION
After seeing #1546 merged, I have a use case where if I cancel a job, I would like to be able to optionally enqueue its dependents, without having to mark it as finished.  This PR does not make this the default but lets users do so if they want to.