### PR TITLE
Pass serializer to queue at cli

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -100,16 +100,18 @@ def main():
 @click.option('--all', '-a', is_flag=True, help='Empty all queues')
 @click.argument('queues', nargs=-1)
 @pass_cli_config
-def empty(cli_config, all, queues, **options):
+def empty(cli_config, all, queues, serializer, **options):
     """Empty given queues."""
 
     if all:
         queues = cli_config.queue_class.all(connection=cli_config.connection,
-                                            job_class=cli_config.job_class)
+                                            job_class=cli_config.job_class,
+                                            serializer=serializer)
     else:
         queues = [cli_config.queue_class(queue,
                                          connection=cli_config.connection,
-                                         job_class=cli_config.job_class)
+                                         job_class=cli_config.job_class,
+                                         serializer=serializer)
                   for queue in queues]
 
     if not queues:
@@ -249,7 +251,8 @@ def worker(cli_config, burst, logging_level, name, results_ttl,
 
         queues = [cli_config.queue_class(queue,
                                          connection=cli_config.connection,
-                                         job_class=cli_config.job_class)
+                                         job_class=cli_config.job_class,
+                                         serializer=serializer)
                   for queue in queues]
         worker = cli_config.worker_class(
             queues, name=name, connection=cli_config.connection,

--- a/rq/version.py
+++ b/rq/version.py
@@ -2,4 +2,4 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-VERSION = '1.10.0'
+VERSION = '1.10.1'


### PR DESCRIPTION
Making a quick patch fix (and bumping the patch version) to pass serializer across the cli commands.


Tests were not added because it does not break immediately, the example that came up was only later when maint tasks were being run to clean up registries.