### PR TITLE
bugfix: worker: Launch pubsub thread in `daemon` mode.

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -533,7 +533,7 @@ class Worker:
         self.log.info('Subscribing to channel %s', self.pubsub_channel_name)
         self.pubsub = self.connection.pubsub()
         self.pubsub.subscribe(**{self.pubsub_channel_name: self.handle_payload})
-        self.pubsub_thread = self.pubsub.run_in_thread(sleep_time=0.2)
+        self.pubsub_thread = self.pubsub.run_in_thread(sleep_time=0.2, daemon=True)
 
     def unsubscribe(self):
         """Unsubscribe from pubsub channel"""


### PR DESCRIPTION
In #1496, we observed a situation where the `work()` method crashes after
`.subscribe()`, but prior to the `try/except` block which normally cleans up
after `.subscribe()`.

Specifically, `.subscribe()` launches a thread in non-daemon mode. Because of
that setting, Python will keep the calling worker process active, even if the
main thread has crashed. This resulted in a syndrome where a worker process was
running, but doing no work.

The change launches this thread in daemon mode, i.e. prevents a "zombie" pubsub
thread from keeping the process up.

(An additional change we could make, discussed in #1496 but deferred, would be
to improve the error handling/trapping scope in `.work()` such that all
failures trigger resource cleanup.)