### PR TITLE
Fix `job.cancel` to remove job from registries if not in queue

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -710,7 +710,6 @@ class Job:
                     pipeline=pipe,
                     remove_from_queue=True
                 )
-                q.remove(self, pipeline=pipe)
 
                 self.set_status(JobStatus.CANCELED, pipeline=pipe)
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -708,7 +708,7 @@ class Job:
                     if pipeline is None:
                         pipe.watch(self.dependents_key)
                     q.enqueue_dependents(self, pipeline=pipeline)
-                self._remove_job_from_container(
+                self._remove_from_registries(
                     pipeline=pipe,
                     remove_from_queue=True
                 )
@@ -738,7 +738,7 @@ class Job:
         """Requeues job."""
         return self.failed_job_registry.requeue(self)
 
-    def _remove_job_from_container(self, pipeline=None, remove_from_queue=True):
+    def _remove_from_registries(self, pipeline=None, remove_from_queue=True):
         if remove_from_queue:
             from .queue import Queue
             q = Queue(name=self.origin, connection=self.connection, serializer=self.serializer)
@@ -793,7 +793,7 @@ class Job:
 
         connection = pipeline if pipeline is not None else self.connection
 
-        self._remove_job_from_container(pipeline=pipeline, remove_from_queue=True)
+        self._remove_from_registries(pipeline=pipeline, remove_from_queue=True)
 
         if delete_dependents:
             self.delete_dependents(pipeline=pipeline)

--- a/rq/job.py
+++ b/rq/job.py
@@ -691,7 +691,7 @@ class Job:
         """
 
         if self.is_canceled:
-            raise InvalidJobOperation(f"Cannot cancel already canceled job: {self.get_id()}")
+            raise InvalidJobOperation("Cannot cancel already canceled job: {}".format(self.get_id()))
         from .registry import CanceledJobRegistry
         from .queue import Queue
         pipe = pipeline or self.connection.pipeline()

--- a/rq/job.py
+++ b/rq/job.py
@@ -20,7 +20,7 @@ from redis import WatchError
 
 from rq.compat import as_text, decode_redis_hash, string_types
 from .connections import resolve_connection
-from .exceptions import DeserializationError, NoSuchJobError
+from .exceptions import DeserializationError, InvalidJobOperation, NoSuchJobError
 from .local import LocalStack
 from .serializers import resolve_serializer
 from .utils import (get_version, import_attribute, parse_timeout, str_to_date,
@@ -690,6 +690,8 @@ class Job:
         Same pipelining behavior as Queue.enqueue_dependents on whether or not a pipeline is passed in.
         """
 
+        if self.is_canceled:
+            raise InvalidJobOperation(f"Cannot cancel already canceled job: {self.get_id()}")
         from .registry import CanceledJobRegistry
         from .queue import Queue
         pipe = pipeline or self.connection.pipeline()


### PR DESCRIPTION
The `job.cancel` function was calling `remove` on the queue, assuming a job is in a queue, not in a registry, this assumption should not be made and this change ensures that it checks not only the queue but also its registries.

Would be nice to get this merged before #1562 is done.