### PR TITLE
Add send_add_queue_command to dynamically add listening queue

### DIFF
--- a/rq/__init__.py
+++ b/rq/__init__.py
@@ -5,9 +5,9 @@ from __future__ import (absolute_import, division, print_function,
 
 from .connections import (Connection, get_current_connection, pop_connection,
                           push_connection, use_connection)
-from .job import cancel_job, get_current_job, requeue_job, Retry
+from .job import cancel_job, get_current_job, requeue_job, Retry, Job
 from .queue import Queue
 from .version import VERSION
-from .worker import SimpleWorker, Worker
+from .worker import SimpleWorker, Worker, RoundRobinWorker
 
 __version__ = VERSION

--- a/rq/command.py
+++ b/rq/command.py
@@ -26,6 +26,10 @@ def send_shutdown_command(connection, worker_name):
     """Send shutdown command"""
     send_command(connection, worker_name, 'shutdown')
 
+def send_add_queue_command(connection, worker_name, queue):
+    """Send add-queue command"""
+    send_command(connection, worker_name, 'add-queue', queue=queue)
+
 
 def send_kill_horse_command(connection, worker_name):
     """Tell worker to kill it's horse"""
@@ -48,6 +52,8 @@ def handle_command(worker, payload):
         handle_shutdown_command(worker)
     elif payload['command'] == 'kill-horse':
         handle_kill_worker_command(worker, payload)
+    elif payload['command'] == 'add-queue':
+        handle_add_queue_command(worker, payload)
 
 
 def handle_shutdown_command(worker):
@@ -55,6 +61,11 @@ def handle_shutdown_command(worker):
     worker.log.info('Received shutdown command, sending SIGINT signal.')
     pid = os.getpid()
     os.kill(pid, signal.SIGINT)
+
+def handle_add_queue_command(worker, payload):
+    """Perform add-queue command"""
+    worker.log.info(f"Received add-queue command: {payload['command']}")
+    worker.add_queue(payload['queue'])
 
 
 def handle_kill_worker_command(worker, payload):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1266,7 +1266,6 @@ from rq import Connection, Queue
 class DynamicWorker(Worker):
     
     def reorder_queues(self, reference_queue):
-        self.log.info(f"Working on {reference_queue}")
         with Connection(self.connection):
             queues = Queue.all()
             if len(queues) == 0:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1250,7 +1250,6 @@ class RoundRobinWorker(Worker):
     Modified version of Worker that dequeues jobs from the queues using a round-robin strategy.
     """
     def reorder_queues(self, reference_queue):
-        self.log.info(f"Working on {reference_queue}")
         pos = self._ordered_queues.index(reference_queue)
         self._ordered_queues = self._ordered_queues[pos + 1:] + self._ordered_queues[:pos + 1]
 
@@ -1262,3 +1261,22 @@ class RandomWorker(Worker):
 
     def reorder_queues(self, reference_queue):
         shuffle(self._ordered_queues)
+
+from rq import Connection, Queue
+class DynamicWorker(Worker):
+    
+    def reorder_queues(self, reference_queue):
+        self.log.info(f"Working on {reference_queue}")
+        with Connection(redis):
+            queues = Queue.all()
+            if len(queues) == 0:
+                queues = Queue()
+            self.log.info('-------------------------------')
+            self.log.info(queues)
+            self.log.info('-------------------------------')
+
+        self.queues = queues
+        self._ordered_queues = self.queues[:]
+        
+        pos = self._ordered_queues.index(reference_queue)
+        self._ordered_queues = self._ordered_queues[pos + 1:] + self._ordered_queues[:pos + 1]

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1261,18 +1261,3 @@ class RandomWorker(Worker):
 
     def reorder_queues(self, reference_queue):
         shuffle(self._ordered_queues)
-
-from rq import Connection, Queue
-class DynamicWorker(Worker):
-    
-    def reorder_queues(self, reference_queue):
-        with Connection(self.connection):
-            queues = Queue.all()
-            if len(queues) == 0:
-                queues = Queue()
-
-        self.queues = queues
-        self._ordered_queues = self.queues[:]
-        
-        pos = self._ordered_queues.index(reference_queue)
-        self._ordered_queues = self._ordered_queues[pos + 1:] + self._ordered_queues[:pos + 1]

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1250,7 +1250,7 @@ class RoundRobinWorker(Worker):
     Modified version of Worker that dequeues jobs from the queues using a round-robin strategy.
     """
     def reorder_queues(self, reference_queue):
-        print("Working on", reference_queue)
+        self.log.info(f"Working on {reference_queue}")
         pos = self._ordered_queues.index(reference_queue)
         self._ordered_queues = self._ordered_queues[pos + 1:] + self._ordered_queues[:pos + 1]
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1267,7 +1267,7 @@ class DynamicWorker(Worker):
     
     def reorder_queues(self, reference_queue):
         self.log.info(f"Working on {reference_queue}")
-        with Connection(redis):
+        with Connection(self.connection):
             queues = Queue.all()
             if len(queues) == 0:
                 queues = Queue()

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1271,9 +1271,6 @@ class DynamicWorker(Worker):
             queues = Queue.all()
             if len(queues) == 0:
                 queues = Queue()
-            self.log.info('-------------------------------')
-            self.log.info(queues)
-            self.log.info('-------------------------------')
 
         self.queues = queues
         self._ordered_queues = self.queues[:]

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -492,6 +492,17 @@ class Worker:
     def handle_warm_shutdown_request(self):
         self.log.info('Warm shut down requested')
 
+    def add_queue(self, queue):
+        self.log.info(f'Asked to add queue: {queue}')
+        found = False
+        for q in self.queues:
+            if q.name == queue:
+                break
+        if not found:
+            self.queues.append(Queue(queue, connection=self.connection))
+            self._ordered_queues = self.queues[:]
+        
+
     def check_for_suspension(self, burst):
         """Check to see if workers have been suspended by `rq suspend`"""
         before_state = None
@@ -597,6 +608,7 @@ class Worker:
 
                     timeout = None if burst else max(1, self.default_worker_ttl - 15)
                     result = self.dequeue_job_and_maintain_ttl(timeout)
+                    
                     if result is None:
                         if burst:
                             self.log.info("Worker %s: done, quitting", self.key)

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1250,6 +1250,7 @@ class RoundRobinWorker(Worker):
     Modified version of Worker that dequeues jobs from the queues using a round-robin strategy.
     """
     def reorder_queues(self, reference_queue):
+        print("Working on", reference_queue)
         pos = self._ordered_queues.index(reference_queue)
         self._ordered_queues = self._ordered_queues[pos + 1:] + self._ordered_queues[:pos + 1]
 


### PR DESCRIPTION
I wrote this PR to be able to add dynamically Queues to Workers sending a command to the relevant ones.

I also exposed Job from rq module directly (as Queue and Worker) and added RoundRobinWorker.