### PR TITLE
Add ssl_cert_reqs to cli as proposed in #1468

### DIFF
--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -71,6 +71,7 @@ def get_redis_from_config(settings, connection_class=Redis):
         'password': settings.get('REDIS_PASSWORD', None),
         'ssl': ssl,
         'ssl_ca_certs': settings.get('REDIS_SSL_CA_CERTS', None),
+        'ssl_cert_reqs': settings.get('REDIS_SSL_CERT_REQS', 'required'),
     }
 
     return connection_class(**kwargs)


### PR DESCRIPTION
Make REDIS_SSL_CERT_REQS available as a config/settings option. This is to be able to set this state from the default required to None, what is needed to deploy with SSL = True but without proper certificates (e.g. within datacenter like Heroku). Pull request proposed by @mgcdanny in #1468