### PR TITLE
Fix `Job.delete()` with `remove_from_queue` argument

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -792,7 +792,7 @@ class Job:
 
         connection = pipeline if pipeline is not None else self.connection
 
-        self._remove_from_registries(pipeline=pipeline, remove_from_queue=True)
+        self._remove_from_registries(pipeline=pipeline, remove_from_queue=remove_from_queue)
 
         if delete_dependents:
             self.delete_dependents(pipeline=pipeline)


### PR DESCRIPTION
Apparently, the `remove_from_queue` argument of `Job.delete()` must be passed to `Job._remove_from_registries()`.

Fixes #1598