### PR TITLE
Fixed wrong keys used to WATCH dependencies

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -485,7 +485,8 @@ class Job:
         connection = pipeline if pipeline is not None else self.connection
 
         if watch and self._dependency_ids:
-            connection.watch(*self._dependency_ids)
+            connection.watch(*[self.key_for(dependency_id)
+                               for dependency_id in self._dependency_ids])
 
         jobs = [job
                 for job in self.fetch_many(self._dependency_ids, connection=self.connection, serializer=self.serializer)
@@ -970,7 +971,8 @@ class Job:
         connection = pipeline if pipeline is not None else self.connection
 
         if pipeline is not None:
-            connection.watch(*self.dependency_ids)
+            connection.watch(*[self.key_for(dependency_id)
+                               for dependency_id in self._dependency_ids])
 
         dependencies_ids = {_id.decode()
                             for _id in connection.smembers(self.dependencies_key)}

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -998,7 +998,7 @@ class TestJob(RQTestCase):
             pipeline.multi()
 
             with self.assertRaises(WatchError):
-                self.testconn.set(dependency_job.id, 'somethingelsehappened')
+                self.testconn.set(Job.key_for(dependency_job.id), 'somethingelsehappened')
                 pipeline.touch(dependency_job.id)
                 pipeline.execute()
 


### PR DESCRIPTION
**TL;DR:**
This bug has opened a lot of possible race-conditions, since the watch-logic from redis did not fail anymore, if dependencies have been changed in parallel.

This seems related to #758, especially https://github.com/rq/rq/issues/758#issuecomment-791603930, where jobs were hanging in deferred state, but I can't say, that my changes fix all issues in #758.

**Details:**
I found this issue during an upgrade of a project from RQ 0.13.0 to 1.10.1, which heavily uses job dependencies. Fortunately, during first tests I saw hanging jobs in "deferred" state.
Actually, I'm a co-author of the whole watch-logic for dependencies introduced in RQ 0.7.1, which has fixed race-conditions for single dependencies here: https://github.com/rq/rq/issues/739
Unfortunately, with the switch to multiple job dependencies (in RQ 1.2), the job-ids of dependencies have not been prefixed correctly, so probably since 1.2 the whole watch-logic basically does not work correctly, which results in race-conditions.