### PR TITLE
Fixed job not getting enqueued due to parallel modification

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -343,6 +343,7 @@ class Queue:
         # something else has modified either the set of dependencies or the
         # status of one of them. In this case, we simply retry.
         if len(job._dependency_ids) > 0:
+            orig_status = job.get_status(refresh=False)
             pipe = pipeline if pipeline is not None else self.connection.pipeline()
             while True:
                 try:
@@ -360,6 +361,8 @@ class Queue:
 
                     for dependency in dependencies:
                         if dependency.get_status(refresh=False) != JobStatus.FINISHED:
+                            # NOTE: If the following code changes local variables, those values probably have
+                            # to be set back to their original values in the handling of WatchError below!
                             job.set_status(JobStatus.DEFERRED, pipeline=pipe)
                             job.register_dependency(pipeline=pipe)
                             job.save(pipeline=pipe)
@@ -370,6 +373,11 @@ class Queue:
                     break
                 except WatchError:
                     if pipeline is None:
+                        # The call to job.set_status(JobStatus.DEFERRED, pipeline=pipe) above has changed the
+                        # internal "_status". We have to reset it to its original value (probably QUEUED), so
+                        # if during the next run no unfinished dependencies exist anymore, the job gets
+                        # enqueued correctly by enqueue_call().
+                        job._status = orig_status
                         continue
                     else:
                         # if pipeline comes from caller, re-raise to them


### PR DESCRIPTION
I've found another bug in the dependency handling, which seems to be introduced with https://github.com/rq/rq/commit/456743b225c0b5a4339242a5b714c378b86f2fe0. It results in no job execution, if unfinished dependencies exist at the beginning, but all of them get finished in parallel.

**More details:**
If all of the unfinished dependencies get finished in parallel to the enqueuing of the job, the `execute()`-call will fire a WatchError [here](https://github.com/rq/rq/blob/c5a1ef17345e17269085e7f72858ac9bd6faf1dd/rq/queue.py#L368). This will leave the `job` instance in a changed state, where status is set to `DEFERRED` ([see](https://github.com/rq/rq/blob/c5a1ef17345e17269085e7f72858ac9bd6faf1dd/rq/queue.py#L363)).
In the following retry, no unfinished dependencies would be found, so the loop will be exited [here](https://github.com/rq/rq/blob/c5a1ef17345e17269085e7f72858ac9bd6faf1dd/rq/queue.py#L370) and the job will be returned.
This will then skip the actual `enqueue_job()` call [here](https://github.com/rq/rq/blob/c5a1ef17345e17269085e7f72858ac9bd6faf1dd/rq/queue.py#L405).

This was hard to find, because in that case `setup_dependencies()` does not save the `DEFERRED` job to redis, and since `enqueue_job()` was also not called, also no `QUEUED` job gets written.

For now I've only found the `_status` as the only local state that needs to be reset before enqueuing the job.

Related: #1605, #758