### PR TITLE
Cross platform simple worker

### DIFF
--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -5,7 +5,7 @@ layout: docs
 
 ## Workers inside unit tests
 
-You may wish to include your RQ tasks inside unit tests. However many frameworks (such as Django) use in-memory databases which do not play nicely with the default `fork()` behaviour of RQ.
+You may wish to include your RQ tasks inside unit tests. However, many frameworks (such as Django) use in-memory databases, which do not play nicely with the default `fork()` behaviour of RQ.
 
 Therefore, you must use the SimpleWorker class to avoid fork();
 
@@ -19,6 +19,25 @@ worker = SimpleWorker([queue], connection=queue.connection)
 worker.work(burst=True)  # Runs enqueued job
 # Check for result...
 ```
+
+
+## Testing on Windows
+
+If you are testing on a Windows machine you can use the approach above, but with a slight tweak.
+You will need to subclass SimpleWorker to override the default timeout mechanism of the worker.
+Reason: Windows OS does not implement some underlying signals utilized by the default SimpleWorker.
+
+To subclass SimpleWorker for Windows you can do the following:
+
+```python
+from rq import SimpleWorker
+from rq.timeouts import TimerDeathPenalty
+
+class WindowsSimpleWorker(SimpleWorker):
+    death_penalty_class = TimerDeathPenalty
+```
+
+Now you can use WindowsSimpleWorker for running tasks on Windows.
 
 
 ## Running Jobs in unit tests

--- a/rq/timeouts.py
+++ b/rq/timeouts.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import ctypes
 import signal
 import threading
 
@@ -82,27 +83,42 @@ class UnixSignalDeathPenalty(BaseDeathPenalty):
 class TimerDeathPenalty(BaseDeathPenalty):
     def __init__(self, timeout, exception=JobTimeoutException, **kwargs):
         super().__init__(timeout, exception, **kwargs)
+        self._target_thread_id = threading.current_thread().ident
         self._timer = None
-        self.reset_timer()
 
-    def reset_timer(self):
-        """Creates a new timer since timers can only be used once."""
-        self._timer = threading.Timer(self._timeout, self.handle_death_penalty)
+        # Monkey-patch exception with the message ahead of time
+        # since PyThreadState_SetAsyncExc can only take a class
+        def init_with_message(self, *args, **kwargs):  # noqa
+            super(exception, self).__init__(
+                "Task exceeded maximum timeout value ({0} seconds)".format(timeout)
+            )
 
-    def handle_death_penalty(self, signum, frame):
-        raise self._exception(
-            "Task exceeded maximum timeout value ({0} seconds)".format(self._timeout)
+        self._exception.__init__ = init_with_message
+
+    def new_timer(self):
+        """Returns a new timer since timers can only be used once."""
+        return threading.Timer(self._timeout, self.handle_death_penalty)
+
+    def handle_death_penalty(self):
+        """Raises an asynchronous exception in another thread.
+
+        Reference http://docs.python.org/c-api/init.html#PyThreadState_SetAsyncExc for more info.
+        """
+        ret = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+            ctypes.c_long(self._target_thread_id), ctypes.py_object(self._exception)
         )
+        if ret == 0:
+            raise ValueError("Invalid thread ID {}".format(self._target_thread_id))
+        elif ret > 1:
+            ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(self._target_thread_id), 0)
+            raise SystemError("PyThreadState_SetAsyncExc failed")
 
     def setup_death_penalty(self):
-        """Sets up an alarm signal and a signal handler that raises
-        an exception after the timeout amount (expressed in seconds).
-        """
+        """Starts the timer."""
+        self._timer = self.new_timer()
         self._timer.start()
 
     def cancel_death_penalty(self):
-        """Removes the death penalty alarm and puts back the system into
-        default signal handling.
-        """
+        """Cancels the timer."""
         self._timer.cancel()
-        self.reset_timer()
+        self._timer = None

--- a/rq/timeouts.py
+++ b/rq/timeouts.py
@@ -79,7 +79,7 @@ class UnixSignalDeathPenalty(BaseDeathPenalty):
         signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
 
-class CrossPlatformDeathPenalty(BaseDeathPenalty):
+class TimerDeathPenalty(BaseDeathPenalty):
     def __init__(self, timeout, exception=JobTimeoutException, **kwargs):
         super().__init__(timeout, exception, **kwargs)
         self._timer = None

--- a/rq/timeouts.py
+++ b/rq/timeouts.py
@@ -91,7 +91,7 @@ class TimerDeathPenalty(BaseDeathPenalty):
 
     def handle_death_penalty(self, signum, frame):
         raise self._exception(
-            f"Task exceeded maximum timeout value ({self._timeout} seconds)"
+            "Task exceeded maximum timeout value ({0} seconds)".format(self._timeout)
         )
 
     def setup_death_penalty(self):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -41,7 +41,7 @@ from .registry import FailedJobRegistry, StartedJobRegistry, clean_registries
 from .scheduler import RQScheduler
 from .suspension import is_suspended
 from .timeouts import (JobTimeoutException, HorseMonitorTimeoutException,
-                       UnixSignalDeathPenalty, CrossPlatformDeathPenalty)
+                       UnixSignalDeathPenalty, TimerDeathPenalty)
 from .utils import (backend_class, ensure_list, get_version,
                     make_colorizer, utcformat, utcnow, utcparse)
 from .version import VERSION
@@ -1192,7 +1192,7 @@ class Worker:
 
 
 class SimpleWorker(Worker):
-    death_penalty_class = CrossPlatformDeathPenalty
+    death_penalty_class = TimerDeathPenalty
 
     def execute_job(self, job, queue):
         """Execute job in same thread/process, do not fork()"""

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1192,8 +1192,6 @@ class Worker:
 
 
 class SimpleWorker(Worker):
-    death_penalty_class = TimerDeathPenalty
-
     def execute_job(self, job, queue):
         """Execute job in same thread/process, do not fork()"""
         self.set_state(WorkerStatus.BUSY)

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -40,7 +40,8 @@ from .queue import Queue
 from .registry import FailedJobRegistry, StartedJobRegistry, clean_registries
 from .scheduler import RQScheduler
 from .suspension import is_suspended
-from .timeouts import JobTimeoutException, HorseMonitorTimeoutException, UnixSignalDeathPenalty
+from .timeouts import (JobTimeoutException, HorseMonitorTimeoutException,
+                       UnixSignalDeathPenalty, CrossPlatformDeathPenalty)
 from .utils import (backend_class, ensure_list, get_version,
                     make_colorizer, utcformat, utcnow, utcparse)
 from .version import VERSION
@@ -1191,6 +1192,7 @@ class Worker:
 
 
 class SimpleWorker(Worker):
+    death_penalty_class = CrossPlatformDeathPenalty
 
     def execute_job(self, job, queue):
         """Execute job in same thread/process, do not fork()"""

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,3 +1,4 @@
+import rq.defaults
 from rq import Queue, SimpleWorker
 from rq.timeouts import JobTimeoutException, TimerDeathPenalty
 from tests import RQTestCase
@@ -13,7 +14,8 @@ class TestTimeouts(RQTestCase):
         """Ensure TimerDeathPenalty works correctly."""
         q = Queue('foo')
         # make sure death_penalty_class persists
-        w = TimerBasedWorker(q, timeout=3)
+        rq.defaults.CALLBACK_TIMEOUT = 3
+        w = TimerBasedWorker([q])
         self.assertIsNotNone(w)
         self.assertEqual(w.death_penalty_class, TimerDeathPenalty)
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,0 +1,32 @@
+from rq import Queue, SimpleWorker
+from rq.timeouts import JobTimeoutException, TimerDeathPenalty
+from tests import RQTestCase
+from tests.fixtures import long_running_job, say_hello
+
+
+class TimerBasedWorker(SimpleWorker):
+    death_penalty_class = TimerDeathPenalty
+
+
+class TestTimeouts(RQTestCase):
+    def test_timer_death_penalty(self):
+        """Ensure TimerDeathPenalty works correctly."""
+        q = Queue('foo')
+        # make sure death_penalty_class persists
+        w = TimerBasedWorker(q, timeout=3)
+        self.assertIsNotNone(w)
+        self.assertEqual(w.death_penalty_class, TimerDeathPenalty)
+
+        # Test short-running job doesnt raise JobTimeoutException
+        job = q.enqueue(say_hello, name='Mike')
+        w.work(burst=True)
+        self.assertIn(job, job.finished_job_registry)
+        job.refresh()
+        self.assertNotIn('rq.timeouts.JobTimeoutException', job.exc_info)
+        
+        # Test long-running job raises JobTimeoutException
+        job = q.enqueue(long_running_job)
+        w.work(burst=True)
+        self.assertIn(job, job.failed_job_registry)
+        job.refresh()
+        self.assertIn('rq.timeouts.JobTimeoutException', job.exc_info)


### PR DESCRIPTION
Replaced `SimpleWorker`'s use of signals that are not available on Windows platform with a `threading.Timer` approach that should be platform-agnostic and allow for local testing.

Tests related to `SimpleWorker` pass:
`pytest ./tests/test_worker.py::TestWorker::test_work_via_simpleworker`
`pytest ./tests/test_worker.py::TestWorker::test_simpleworker_heartbeat_ttl`

Closes #1625 