### PR TITLE
Docs: don't break links at the header

### DIFF
--- a/docs/css/screen.css
+++ b/docs/css/screen.css
@@ -86,6 +86,7 @@ header a:hover
 .subnav a
 {
     text-decoration: none;
+    white-space: nowrap;
 }
 
 .container


### PR DESCRIPTION
Hi there!

Thank you very much for creating this! I've been using it for over a year and it's brilliant!

I had a small problem while browsing the docs: I wanted to click on "Jobs" section, and was sure that i'm selecting it, but i kept landing on "scheduling":

![image](https://user-images.githubusercontent.com/40139196/159236788-f95af779-66d4-4a63-9a1a-47919e8d79c5.png)

Until i realized this is just two words broke in half :joy:

I added one css line to prevent that in future:

![image](https://user-images.githubusercontent.com/40139196/159236912-528894a8-8db8-4a03-abed-50b8036d030d.png)
