### PR TITLE
[worker.kill_horse] Default to SIGTERM to exit worker gracefully, send SIGKILL after timeout.

### DIFF
--- a/rq/timeouts.py
+++ b/rq/timeouts.py
@@ -70,7 +70,7 @@ class UnixSignalDeathPenalty(BaseDeathPenalty):
         an exception after the timeout amount (expressed in seconds).
         """
         signal.signal(signal.SIGALRM, self.handle_death_penalty)
-        signal.alarm(self._timeout)
+        signal.alarm(int(self._timeout))
 
     def cancel_death_penalty(self):
         """Removes the death penalty alarm and puts back the system into


### PR DESCRIPTION
I have a use case where I need to terminate a currently running job with `send_stop_job_command(redis, job_id)`, but I want to give the worker the opportunity to exit cleanly.

Currently, this is not possible as this command will trigger `Worker.kill_horse` which defaults to sig=SIGKILL, which immediately kills the worker. We could fix it by calling `Worker.request_stop`, however, we still want to forcefully kill the worker if it does not respond.

As implemented, my solution extends `Worker.kill_horse` to attempt to kill the worker by sending the requested signal first. If the worker does not exit within a timeout, a SIGKILL signal is sent to force termination.