### PR TITLE
Drop python2-specific syntax

### DIFF
--- a/examples/fib.py
+++ b/examples/fib.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-
 def slow_fib(n):
     if n <= 1:
         return 1

--- a/examples/run_example.py
+++ b/examples/run_example.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import os
 import time
 

--- a/examples/run_worker.py
+++ b/examples/run_worker.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from rq import Connection, Queue, Worker
 
 if __name__ == '__main__':

--- a/rq/__init__.py
+++ b/rq/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # flake8: noqa
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 
 from .connections import (Connection, get_current_connection, pop_connection,
                           push_connection, use_connection)

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 RQ command line tool
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 
 from functools import update_wrapper
 import os

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import sys
 import importlib
 import time

--- a/rq/compat/__init__.py
+++ b/rq/compat/__init__.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import sys
 
 

--- a/rq/compat/connections.py
+++ b/rq/compat/connections.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from functools import partial
 
 from redis import Redis

--- a/rq/connections.py
+++ b/rq/connections.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from contextlib import contextmanager
 
 from redis import Redis

--- a/rq/contrib/legacy.py
+++ b/rq/contrib/legacy.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-
 import logging
 from rq import get_current_connection
 from rq import Worker

--- a/rq/contrib/sentry.py
+++ b/rq/contrib/sentry.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-
 def register_sentry(sentry_dsn, **opts):
     """Given a Raven client and an RQ worker, registers exception handlers
     with the worker so exceptions are logged to Sentry.

--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from functools import wraps
 
 from rq.compat import string_types

--- a/rq/dummy.py
+++ b/rq/dummy.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 Some dummy tasks that are well-suited for generating load for testing purposes.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 
 import random
 import time

--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -25,7 +25,7 @@ class DequeueTimeout(Exception):
 class ShutDownImminentException(Exception):
     def __init__(self, msg, extra_info):
         self.extra_info = extra_info
-        super(ShutDownImminentException, self).__init__(msg)
+        super().__init__(msg)
 
 
 class TimeoutFormatError(Exception):

--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-
 class NoSuchJobError(Exception):
     pass
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import inspect
 import json
 import pickle

--- a/rq/local.py
+++ b/rq/local.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # flake8: noqa
 """
     werkzeug.local

--- a/rq/logutils.py
+++ b/rq/logutils.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import logging
 import sys
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import uuid
 import sys
 import warnings

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -264,7 +264,7 @@ class ScheduledJobRegistry(BaseRegistry):
     key_template = 'rq:scheduled:{0}'
 
     def __init__(self, *args, **kwargs):
-        super(ScheduledJobRegistry, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # The underlying implementation of get_jobs_to_enqueue() is
         # the same as get_expired_job_ids, but get_expired_job_ids() doesn't
         # make sense in this context

--- a/rq/timeouts.py
+++ b/rq/timeouts.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import ctypes
 import signal
 import threading

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -99,7 +99,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
 
     def __init__(self, exclude=None, *args, **kwargs):
         self.exclude = exclude
-        super(ColorizingStreamHandler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def is_tty(self):

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -1,12 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 Miscellaneous helper functions.
 
 The formatter for ANSI colored console output is heavily based on Pygments
 terminal colorizing code, originally by Georg Brandl.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 
 import calendar
 import datetime

--- a/rq/version.py
+++ b/rq/version.py
@@ -1,5 +1,1 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 VERSION = '1.10.1'

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import errno
 import logging
 import os

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import logging
 import os
 

--- a/tests/config_files/dummy.py
+++ b/tests/config_files/dummy.py
@@ -1,5 +1,1 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 REDIS_HOST = "testhost.example.com"

--- a/tests/config_files/dummy_override.py
+++ b/tests/config_files/dummy_override.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 REDIS_HOST = "testhost.example.com"
 REDIS_PORT = 6378
 REDIS_DB = 2

--- a/tests/config_files/sentry.py
+++ b/tests/config_files/sentry.py
@@ -1,6 +1,2 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 REDIS_HOST = "testhost.example.com"
 SENTRY_DSN = 'https://123@sentry.io/123'

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -147,7 +147,7 @@ class UnicodeStringObject:
         return u'é'
 
 
-class ClassWithAStaticMethod(object):
+class ClassWithAStaticMethod:
     @staticmethod
     def static_method():
         return u"I'm a static method"

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 This file contains all jobs that are used in tests.  Each of these test
 fixtures has a slighty different characteristics.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 
 import os
 import time

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ class TestRQCli(RQTestCase):
 
     """Test rq_cli script"""
     def setUp(self):
-        super(TestRQCli, self).setUp()
+        super().setUp()
         db_num = self.testconn.connection_pool.connection_kwargs['db']
         self.redis_url = 'redis://127.0.0.1:6379/%d' % db_num
         self.connection = Redis.from_url(self.redis_url)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from datetime import datetime, timezone, timedelta
 from time import sleep
 from uuid import uuid4

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from redis import Redis
 
 from rq import Connection, Queue, use_connection, get_current_connection, pop_connection

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -12,7 +12,7 @@ from tests.fixtures import decorated_job
 class TestDecorator(RQTestCase):
 
     def setUp(self):
-        super(TestDecorator, self).setUp()
+        super().setUp()
 
     def test_decorator_preserves_functionality(self):
         """Ensure that a decorated function's functionality is still preserved.

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import mock
 from redis import Redis
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from rq import Queue
 
 from tests import RQTestCase, fixtures

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 from rq.serializers import JSONSerializer
 import time

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import json
 from datetime import datetime, timedelta, timezone
 from rq.serializers import DefaultSerializer, JSONSerializer

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -23,7 +23,7 @@ class CustomJob(Job):
 class TestRegistry(RQTestCase):
 
     def setUp(self):
-        super(TestRegistry, self).setUp()
+        super().setUp()
         self.registry = StartedJobRegistry(connection=self.testconn)
 
     def test_init(self):
@@ -270,7 +270,7 @@ class TestRegistry(RQTestCase):
 class TestFinishedJobRegistry(RQTestCase):
 
     def setUp(self):
-        super(TestFinishedJobRegistry, self).setUp()
+        super().setUp()
         self.registry = FinishedJobRegistry(connection=self.testconn)
 
     def test_key(self):
@@ -318,7 +318,7 @@ class TestFinishedJobRegistry(RQTestCase):
 class TestDeferredRegistry(RQTestCase):
 
     def setUp(self):
-        super(TestDeferredRegistry, self).setUp()
+        super().setUp()
         self.registry = DeferredJobRegistry(connection=self.testconn)
 
     def test_key(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from datetime import datetime, timedelta
 from rq.serializers import JSONSerializer
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -21,7 +21,7 @@ class FakeSentry:
 class TestSentry(RQTestCase):
 
     def setUp(self):
-        super(TestSentry, self).setUp()
+        super().setUp()
         db_num = self.testconn.connection_pool.connection_kwargs['db']
         self.redis_url = 'redis://127.0.0.1:6379/%d' % db_num
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from rq import Queue
 from rq.cli import main
 from rq.cli.helpers import read_config_file

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import json
 import pickle
 import pickletools

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import re
 import datetime
 import mock

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import json
 import os
 import psutil

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1250,7 +1250,7 @@ def schedule_access_self():
 @pytest.mark.skipif(sys.platform == 'darwin', reason='Fails on OS X')
 class TestWorkerSubprocess(RQTestCase):
     def setUp(self):
-        super(TestWorkerSubprocess, self).setUp()
+        super().setUp()
         db_num = self.testconn.connection_pool.connection_kwargs['db']
         self.redis_url = 'redis://127.0.0.1:6379/%d' % db_num
 
@@ -1282,7 +1282,7 @@ class TestWorkerSubprocess(RQTestCase):
 @skipIf('pypy' in sys.version.lower(), 'these tests often fail on pypy')
 class HerokuWorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
     def setUp(self):
-        super(HerokuWorkerShutdownTestCase, self).setUp()
+        super().setUp()
         self.sandbox = '/tmp/rq_shutdown/'
         os.makedirs(self.sandbox)
 
@@ -1368,7 +1368,7 @@ class HerokuWorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
 class TestExceptionHandlerMessageEncoding(RQTestCase):
 
     def setUp(self):
-        super(TestExceptionHandlerMessageEncoding, self).setUp()
+        super().setUp()
         self.worker = Worker("foo")
         self.worker._exc_handlers = []
         # Mimic how exception info is actually passed forwards


### PR DESCRIPTION
No longer required, since Python2 is not supported at all.