### PR TITLE
Revert "Jobs that are run synchronously should always raise an except…

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -594,7 +594,6 @@ class Queue:
             job.set_status(JobStatus.FAILED)
             if job.failure_callback:
                 job.failure_callback(job, self.connection, *sys.exc_info())
-            raise
         else:
             if job.success_callback:
                 job.success_callback(job, self.connection, job.result)


### PR DESCRIPTION
…ion"

This reverts commit 0d21e714c33cfefba51a8c2b714a735bcad1264d.