### PR TITLE
Improve the lint situation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --select=E9,F63,F7,F82 --show-source
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=5 --max-line-length=120 --statistics
+        flake8 . --exit-zero --max-complexity=5

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -24,7 +24,6 @@ from rq.defaults import (DEFAULT_CONNECTION_CLASS, DEFAULT_JOB_CLASS,
 from rq.exceptions import InvalidJobOperationError
 from rq.registry import FailedJobRegistry, clean_registries
 from rq.utils import import_attribute, get_call_string, make_colorizer
-from rq.serializers import DefaultSerializer
 from rq.suspension import (suspend as connection_suspend,
                            resume as connection_resume, is_suspended)
 from rq.worker_registration import clean_worker_registry

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -11,7 +11,6 @@ from ast import literal_eval
 from shutil import get_terminal_size
 
 import click
-import redis
 from redis import Redis
 from redis.sentinel import Sentinel
 from rq.defaults import (DEFAULT_CONNECTION_CLASS, DEFAULT_JOB_CLASS,

--- a/rq/compat/__init__.py
+++ b/rq/compat/__init__.py
@@ -3,8 +3,7 @@ import sys
 
 def is_python_version(*versions):
     for version in versions:
-        if (sys.version_info[0] == version[0] and
-                sys.version_info >= version):
+        if (sys.version_info[0] == version[0] and sys.version_info >= version):
             return True
     return False
 

--- a/rq/compat/connections.py
+++ b/rq/compat/connections.py
@@ -1,8 +1,3 @@
-from functools import partial
-
-from redis import Redis
-
-
 def fix_return_type(func):
     # deliberately no functools.wraps() call here, since the function being
     # wrapped is a partial, which has no module

--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -13,7 +13,7 @@ class job:  # noqa
     def __init__(self, queue, connection=None, timeout=None,
                  result_ttl=DEFAULT_RESULT_TTL, ttl=None,
                  queue_class=None, depends_on=None, at_front=None, meta=None,
-                 description=None, failure_ttl=None, retry=None, on_failure=None, 
+                 description=None, failure_ttl=None, retry=None, on_failure=None,
                  on_success=None):
         """A decorator that adds a ``delay`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required

--- a/rq/job.py
+++ b/rq/job.py
@@ -711,7 +711,7 @@ class Job:
         without worrying about the internals required to implement job
         cancellation.
 
-        You can enqueue the jobs dependents optionally, 
+        You can enqueue the jobs dependents optionally,
         Same pipelining behavior as Queue.enqueue_dependents on whether or not a pipeline is passed in.
         """
         if self.is_canceled:

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -16,10 +16,11 @@ from collections.abc import Iterable
 
 from redis.exceptions import ResponseError
 
-from .compat import as_text, is_python_version, string_types
+from .compat import as_text, string_types
 from .exceptions import TimeoutFormatError
 
 logger = logging.getLogger(__name__)
+
 
 class _Colorizer:
     def __init__(self):
@@ -277,7 +278,7 @@ def get_version(connection):
     This function also correctly handles 4 digit redis server versions.
     """
     try:
-        return tuple(int(i) for i in connection.info("server")["redis_version"].split('.')[:3]) 
+        return tuple(int(i) for i in connection.info("server")["redis_version"].split('.')[:3])
     except ResponseError:  # fakeredis doesn't implement Redis' INFO command
         return (5, 0, 9)
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -36,8 +36,7 @@ from .queue import Queue
 from .registry import FailedJobRegistry, StartedJobRegistry, clean_registries
 from .scheduler import RQScheduler
 from .suspension import is_suspended
-from .timeouts import (JobTimeoutException, HorseMonitorTimeoutException,
-                       UnixSignalDeathPenalty, TimerDeathPenalty)
+from .timeouts import JobTimeoutException, HorseMonitorTimeoutException, UnixSignalDeathPenalty
 from .utils import (backend_class, ensure_list, get_version,
                     make_colorizer, utcformat, utcnow, utcparse)
 from .version import VERSION

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,5 @@ universal = 1
 [flake8]
 max-line-length=120
 ignore=E731
+count=True
+statistics=True

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -222,9 +222,11 @@ def kill_worker(pid, double_kill, interval=0.5):
 
 
 class Serializer:
-    def loads(self): pass
+    def loads(self):
+        pass
 
-    def dumps(self): pass
+    def dumps(self):
+        pass
 
 
 def start_worker(queue_name, conn_kwargs, worker_name, burst):
@@ -238,6 +240,7 @@ def start_worker(queue_name, conn_kwargs, worker_name, burst):
             w = Worker([queue_name], name=worker_name, connection=Redis(**conn_kwargs))
             w.work(burst=burst)
 
+
 def start_worker_process(queue_name, connection=None, worker_name=None, burst=False):
     """
     Use multiprocessing to start a new worker in a separate process.
@@ -247,6 +250,7 @@ def start_worker_process(queue_name, connection=None, worker_name=None, burst=Fa
     p = Process(target=start_worker, args=(queue_name, conn_kwargs, worker_name, burst))
     p.start()
     return p
+
 
 def burst_two_workers(queue, timeout=2, tries=5, pause=0.1):
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -406,7 +406,7 @@ class TestRQCli(RQTestCase):
         runner = CliRunner()
         job = q.enqueue(say_hello)
         runner.invoke(main, ['worker', '-u', self.redis_url,
-                            '--serializer rq.serializer.JSONSerializer'])
+                             '--serializer rq.serializer.JSONSerializer'])
         self.assertIn(job.id, q.job_ids)
 
     def test_cli_enqueue(self):
@@ -439,7 +439,7 @@ class TestRQCli(RQTestCase):
         self.assertTrue(queue.is_empty())
 
         runner = CliRunner()
-        result = runner.invoke(main, ['enqueue', '-u', self.redis_url, '-S', 'rq.serializers.JSONSerializer',  'tests.fixtures.say_hello'])
+        result = runner.invoke(main, ['enqueue', '-u', self.redis_url, '-S', 'rq.serializers.JSONSerializer', 'tests.fixtures.say_hello'])
         self.assert_normal_execution(result)
 
         prefix = 'Enqueued tests.fixtures.say_hello() with job-id \''

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -106,7 +106,7 @@ class TestDecorator(RQTestCase):
 
         bar_job = bar.delay()
 
-        self.assertEqual(foo_job._dependency_ids,[])
+        self.assertEqual(foo_job._dependency_ids, [])
         self.assertIsNone(foo_job._dependency_id)
 
         self.assertEqual(foo_job.dependency, None)
@@ -143,8 +143,8 @@ class TestDecorator(RQTestCase):
         self.assertIsNone(foo_job._dependency_id)
         self.assertIsNone(bar_job._dependency_id)
 
-        self.assertEqual(foo_job._dependency_ids,[])
-        self.assertEqual(bar_job._dependency_ids,[])
+        self.assertEqual(foo_job._dependency_ids, [])
+        self.assertEqual(bar_job._dependency_ids, [])
         self.assertEqual(baz_job._dependency_id, bar_job.id)
         self.assertEqual(baz_job.dependency, bar_job)
         self.assertEqual(baz_job.dependency.id, bar_job.id)
@@ -152,7 +152,7 @@ class TestDecorator(RQTestCase):
     def test_decorator_accepts_on_failure_function_as_argument(self):
         """Ensure that passing in on_failure function to the decorator sets the
         correct on_failure function on the job.
-        """ 
+        """
         # Only functions and builtins are supported as callback
         @job('default', on_failure=Job.fetch)
         def foo():
@@ -167,7 +167,6 @@ class TestDecorator(RQTestCase):
         result_job = Job.fetch(id=result.id, connection=self.testconn)
         self.assertEqual(result_job.failure_callback, print)
 
-
     def test_decorator_accepts_on_success_function_as_argument(self):
         """Ensure that passing in on_failure function to the decorator sets the
         correct on_success function on the job.
@@ -178,7 +177,7 @@ class TestDecorator(RQTestCase):
             return 'Foo'
         with self.assertRaises(ValueError):
             result = foo.delay()
-            
+
         @job('default', on_success=print)
         def hello():
             return 'Hello'

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timedelta, timezone
-from rq.serializers import DefaultSerializer, JSONSerializer
+from rq.serializers import JSONSerializer
 from unittest.mock import patch
 
 from rq import Retry, Queue

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -217,7 +217,7 @@ class TestRegistry(RQTestCase):
         self.assertEqual(self.registry.count, 2)
         self.assertEqual(len(self.registry), 2)
 
-        # Make sure 
+        # Make sure
 
     def test_clean_registries(self):
         """clean_registries() cleans Started and Finished job registries."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,7 +4,6 @@ from multiprocessing import Process
 
 from unittest import mock
 from rq import Queue
-from rq.compat import PY2
 from rq.exceptions import NoSuchJobError
 from rq.job import Job, Retry
 from rq.registry import FinishedJobRegistry, ScheduledJobRegistry
@@ -96,7 +95,7 @@ class TestScheduledJobRegistry(RQTestCase):
         with mock_tz, mock_day, mock_atz:
             registry.schedule(job, datetime(2019, 1, 1))
             self.assertEqual(self.testconn.zscore(registry.key, job.id),
-                                1546300800 + 18000)  # 2019-01-01 UTC in Unix timestamp
+                             1546300800 + 18000)  # 2019-01-01 UTC in Unix timestamp
 
             # second, time.daylight != 0 (in DST)
             # mock the sitatuoin for American/New_York not in DST (UTC - 4)
@@ -317,7 +316,7 @@ class TestWorker(RQTestCase):
 
         p.start()
         queue.enqueue_at(
-            datetime(2019, 1, 1, tzinfo=timezone.utc), 
+            datetime(2019, 1, 1, tzinfo=timezone.utc),
             say_hello, meta={'foo': 'bar'}
         )
         worker.work(burst=False, with_scheduler=True)
@@ -325,6 +324,7 @@ class TestWorker(RQTestCase):
         self.assertIsNotNone(worker.scheduler)
         registry = FinishedJobRegistry(queue=queue)
         self.assertEqual(len(registry), 1)
+
 
 class TestQueue(RQTestCase):
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 import re
 import datetime
-from unittest import mock
 
 from redis import Redis
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -8,7 +8,7 @@ import sys
 import time
 import zlib
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from multiprocessing import Process
 from time import sleep
 
@@ -29,7 +29,7 @@ from tests.fixtures import (
 
 from rq import Queue, SimpleWorker, Worker, get_current_connection
 from rq.compat import as_text, PY2
-from rq.job import Job, JobStatus, Dependency, Retry
+from rq.job import Job, JobStatus, Retry
 from rq.registry import StartedJobRegistry, FailedJobRegistry, FinishedJobRegistry
 from rq.suspension import resume, suspend
 from rq.utils import utcnow


### PR DESCRIPTION
@selwin Here's some lint fixes (about half fixed) as promised, but there's still some outstanding

```
./tests/test_cli.py:442:121: E501 line too long (138 > 120 characters)
./tests/test_cli.py:647:121: E501 line too long (121 > 120 characters)
./tests/test_cli.py:653:121: E501 line too long (130 > 120 characters)
./tests/test_cli.py:659:121: E501 line too long (134 > 120 characters)
./tests/test_cli.py:683:121: E501 line too long (125 > 120 characters)
./tests/test_cli.py:689:121: E501 line too long (132 > 120 characters)
./tests/test_cli.py:695:121: E501 line too long (130 > 120 characters)
./tests/test_cli.py:701:121: E501 line too long (134 > 120 characters)
./tests/test_cli.py:707:121: E501 line too long (131 > 120 characters)
./tests/test_cli.py:713:121: E501 line too long (135 > 120 characters)
./examples/fib.py:5:26: E226 missing whitespace around arithmetic operator
./examples/fib.py:5:42: E226 missing whitespace around arithmetic operator
./rq/registry.py:44:37: W504 line break after binary operator
./rq/job.py:588:121: E501 line too long (138 > 120 characters)
./rq/worker.py:63:13: E741 ambiguous variable name 'l'
./rq/cli/cli.py:203:121: E501 line too long (144 > 120 characters)
2     E226 missing whitespace around arithmetic operator
12    E501 line too long (144 > 120 characters)
1     E741 ambiguous variable name 'l'
1     W504 line break after binary operator
16
```

and I don't think this will move the needle much unless you guys decide to auto-black the entire code base or something along those lines. Most of the lints are whitespace-related which `black` can handle in one fell swoop.

In the projects that I maintain, we have black + linters (configured to ignore all whitespace checks) registered as pre-commit hooks, which are run in CI as well. 

There's a lot of PR's outstanding though, and doing that might introduce merge conflicts with other contributors, so going to leave this decision up to the maintainers. Feel free to disregard/close this if you think its more disruptive than not.