### PR TITLE
Fix log on job stop

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -840,7 +840,7 @@ class Worker:
 
         if job_status is None:  # Job completed and its ttl has expired
             return
-        elif job_status == JobStatus.STOPPED:
+        elif self._stopped_job_id == job.id:
             # Work-horse killed deliberately
             self.log.warning('Job stopped by user, moving job to FailedJobRegistry')
             self.handle_job_failure(


### PR DESCRIPTION
Job status is not yet "stopped" when determining the log to print in `monitor_work_horse`