### PR TITLE
pre-warm redis server version cache of job from queue

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -562,6 +562,7 @@ class Queue:
 
         # Add Queue key set
         pipe.sadd(self.redis_queues_keys, self.key)
+        job.redis_server_version = self.get_redis_server_version()
         job.set_status(JobStatus.QUEUED, pipeline=pipe)
 
         job.origin = self.name


### PR DESCRIPTION
`rq.queue.Queue.enqueue_many` is used to enqueue many jobs in one go on `rq` in a bulk operation. 

The issue is that it calls `rq.queue.Queue.enqueue_job` which in turn calls `rq.job.Job.save` which calls `rq.job.Job.get_redis_server_version` which does a round-trip to the server to get the server version. This is cached in `Job`, however when enqueuing 1000 jobs all of these caches are empty. So calling `enqueue_job` on 1000 jobs will do 1000 round-trips to the server to get the server version, which is very slow. 

The patch pre-warms the `Job` cache, causing the round-trip to the server to only happen once.