### PR TITLE
Persist worker_name after job is finished

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     permissions:
       # required for all workflows

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.2.0
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -56,7 +56,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.2.0
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     if: github.repository == 'rq/rq'
     name: Python${{ matrix.python-version }}/Redis${{ matrix.redis-version }}/redis-py${{ matrix.redis-py-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8.3", "3.9", "3.10"]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   push:
     if: github.repository == 'rq/rq'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v4.2.0
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build:
     name: Python${{ matrix.python-version }}/Redis${{ matrix.redis-version }}/redis-py${{ matrix.redis-py-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8.3", "3.9", "3.10"]

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.2.0
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1059,8 +1059,6 @@ class Worker:
                     if result_ttl != 0:
                         self.log.debug('Setting job %s status to finished', job.id)
                         job.set_status(JobStatus.FINISHED, pipeline=pipeline)
-                        # Don't clobber the user's meta dictionary!
-                        job.save(pipeline=pipeline, include_meta=False)
                         # Result should be saved in job hash only if server
                         # doesn't support Redis streams
                         include_result = not self.supports_redis_streams

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -971,7 +971,6 @@ class Worker:
                     job_class=self.job_class,
                     serializer=self.serializer
                 )
-            job.worker_name = None
 
             # check whether a job was stopped intentionally and set the job
             # status appropriately if it was this job.
@@ -1045,7 +1044,6 @@ class Worker:
                     if result_ttl != 0:
                         self.log.debug('Setting job %s status to finished', job.id)
                         job.set_status(JobStatus.FINISHED, pipeline=pipeline)
-                        job.worker_name = None
                         # Don't clobber the user's meta dictionary!
                         job.save(pipeline=pipeline, include_meta=False)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -379,7 +379,6 @@ class TestWorker(RQTestCase):
         # Check the job
         job = Job.fetch(job.id)
         self.assertEqual(job.origin, q.name)
-        self.assertIsNone(job.worker_name)  # Worker name is cleared after failures
 
         # Should be the original enqueued_at date, not the date of enqueueing
         # to the failed queue


### PR DESCRIPTION
Persisting the worker_name on the job object in Redis would allow for debugging and analyzing logs from the worker