### PR TITLE
Support string callbacks in on_success/on_failure

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -138,14 +138,20 @@ class Job:
         job._kwargs = kwargs
 
         if on_success:
-            if not inspect.isfunction(on_success) and not inspect.isbuiltin(on_success):
-                raise ValueError('on_success callback must be a function')
-            job._success_callback_name = '{0}.{1}'.format(on_success.__module__, on_success.__qualname__)
+            if inspect.isfunction(on_success) or inspect.isbuiltin(on_success):
+                job._success_callback_name = '{0}.{1}'.format(on_success.__module__, on_success.__qualname__)
+            elif isinstance(on_success, string_types):
+                job._success_callback_name = as_text(on_success)
+            else:
+                raise ValueError('on_success callback must be a function or a string but got: {0}'.format(on_failure))
 
         if on_failure:
-            if not inspect.isfunction(on_failure) and not inspect.isbuiltin(on_failure):
-                raise ValueError('on_failure callback must be a function')
-            job._failure_callback_name = '{0}.{1}'.format(on_failure.__module__, on_failure.__qualname__)
+            if inspect.isfunction(on_failure) or inspect.isbuiltin(on_failure):
+                job._failure_callback_name = '{0}.{1}'.format(on_failure.__module__, on_failure.__qualname__)
+            elif isinstance(on_failure, string_types):
+                job._failure_callback_name = as_text(on_failure)
+            else:
+                raise ValueError('on_failure callback must be a function or a string but got: {0}'.format(on_failure))
 
         # Extra meta data
         job.description = description or job.get_call_string()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from tests import RQTestCase
-from tests.fixtures import div_by_zero, erroneous_callback, save_exception, save_result, say_hello
+from tests.fixtures import div_by_zero, do_nothing, erroneous_callback, save_exception, save_result, say_hello
 
 from rq import Queue, Worker
 from rq.job import Job, JobStatus, UNEVALUATED
@@ -28,6 +28,9 @@ class QueueCallbackTestCase(RQTestCase):
         job = Job.fetch(id=job.id, connection=self.testconn)
         self.assertEqual(job.success_callback, print)
 
+        job = queue.enqueue(say_hello, on_success="tests.fixtures.do_nothing")
+        self.assertEqual(job.success_callback, do_nothing)
+
     def test_enqueue_with_failure_callback(self):
         """queue.enqueue* methods with on_failure is persisted correctly"""
         queue = Queue(connection=self.testconn)
@@ -45,6 +48,9 @@ class QueueCallbackTestCase(RQTestCase):
 
         job = Job.fetch(id=job.id, connection=self.testconn)
         self.assertEqual(job.failure_callback, print)
+
+        job = queue.enqueue(say_hello, on_failure="tests.fixtures.do_nothing")
+        self.assertEqual(job.failure_callback, do_nothing)
 
 
 class SyncJobCallback(RQTestCase):


### PR DESCRIPTION
`on_success` and `on_failure` callbacks can now take dotted function string in addition to function objects.

Internally this isn't quite different as during serialization phase functions seem to be converted to their dotted path string representation anyway.

Note:
- I've tested functionality locally (and with our projects that use rq)
- Added test and ran tests locally. 

closes https://github.com/rq/rq/issues/1595
