### PR TITLE
Cache redis version in the connection object

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -303,7 +303,14 @@ def get_version(connection: 'Redis'):
         connection (Redis): The Redis connection.
     """
     try:
-        return tuple(int(i) for i in connection.info("server")["redis_version"].split('.')[:3])
+        # Getting the connection info for each job tanks performance, we can cache it on the connection object
+        if not getattr(connection, "__rq_redis_server_version", None):
+            setattr(
+                connection,
+                "__rq_redis_server_version",
+                tuple(int(i) for i in connection.info("server")["redis_version"].split('.')[:3])
+            )
+        return getattr(connection, "__rq_redis_server_version")
     except ResponseError:  # fakeredis doesn't implement Redis' INFO command
         return (5, 0, 9)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import re
 import datetime
+from unittest.mock import Mock
 
 from redis import Redis
 
@@ -84,6 +85,15 @@ class TestUtils(RQTestCase):
             def info(*args):
                 return {'redis_version': '3.0.7.9'}
         self.assertEqual(get_version(DummyRedis()), (3, 0, 7))
+
+    def test_get_redis_version_gets_cached(self):
+        """Ensure get_version works properly"""
+        # Parses 3 digit version numbers correctly
+        redis = Mock(spec=['info'])
+        redis.info = Mock(return_value={'redis_version': '4.0.8'})
+        self.assertEqual(get_version(redis), (4, 0, 8))
+        self.assertEqual(get_version(redis), (4, 0, 8))
+        redis.info.assert_called_once()
 
     def test_ceildiv_even(self):
         """When a number is evenly divisible by another ceildiv returns the quotient"""


### PR DESCRIPTION
Hi there, long time `rq` user here.

I was recently running some annual disaster recovery tests in our infra. These tests involve enqueuing hundreds of thousands of objects in our `rq` and then running scripts to evict duplicated jobs. To my surprise, enqueuing the objects would take about a day or so, while last years test took a few seconds.

Upon further inspection and profiling it became aparent that the reason for the low performance was a `get_redis_server_version` call for every job. And caching or hard-coding that value would help the performance issue.

Here's a proposal to sneakily store the server version on the connection object, this would make enqueue calls fast again as long as they are made from the same connection.
