### PR TITLE
Enhance debug logs

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -720,7 +720,7 @@ class Queue:
                 logger.debug(f"BLPOP Timeout, no jobs found on queues {green(queue_keys)}")
                 raise DequeueTimeout(timeout, queue_keys)
             queue_key, job_id = result
-            logger.debug(f"Found job {blue(job_id)} on queue {green(queue_key)}")
+            logger.debug(f"Dequeued job {blue(job_id)} from queue {green(queue_key)}")
             return queue_key, job_id
         else:  # non-blocking variant
             for queue_key in queue_keys:

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -79,7 +79,7 @@ class Queue:
         return cls(name, connection=connection, job_class=job_class, serializer=serializer)
 
     def __init__(self, name='default', default_timeout=None, connection: t.Optional['Redis'] = None,
-                 is_async=True, job_class=None, serializer=None, debug=False, **kwargs):
+                 is_async=True, job_class=None, serializer=None, **kwargs):
         self.connection = resolve_connection(connection)
         prefix = self.redis_queue_namespace_prefix
         self.name = name
@@ -87,7 +87,6 @@ class Queue:
         self._default_timeout = parse_timeout(default_timeout) or self.DEFAULT_TIMEOUT
         self._is_async = is_async
         self.log = logger
-        self.debug_mode = debug
 
         if 'async' in kwargs:
             self._is_async = kwargs['async']
@@ -306,9 +305,6 @@ class Queue:
     def push_job_id(self, job_id: str, pipeline: t.Optional['Pipeline'] = None, at_front=False):
         """Pushes a job ID on the corresponding Redis queue.
         'at_front' allows you to push the job onto the front instead of the back of the queue"""
-        self.log.debug(f"Pushing job {blue(job_id)} into the queue {green(self.name)}.")
-        if self.debug_mode:
-            self.log.debug(f"Current job count for queue {green(self.name)} is {self.count}.")
         connection = pipeline if pipeline is not None else self.connection
         if at_front:
             result = connection.lpush(self.key, job_id)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -2,6 +2,7 @@ import uuid
 import sys
 import warnings
 import typing as t
+import logging
 from collections import namedtuple
 from datetime import datetime, timezone
 
@@ -17,7 +18,14 @@ from .defaults import DEFAULT_RESULT_TTL
 from .exceptions import DequeueTimeout, NoSuchJobError
 from .job import Job, JobStatus
 from .serializers import resolve_serializer
-from .utils import backend_class, get_version, import_attribute, parse_timeout, utcnow
+from .utils import backend_class, get_version, import_attribute, make_colorizer, parse_timeout, utcnow
+
+
+green = make_colorizer('darkgreen')
+yellow = make_colorizer('darkyellow')
+blue = make_colorizer('darkblue')
+
+logger = logging.getLogger("rq.queue")
 
 
 def compact(lst):
@@ -78,6 +86,7 @@ class Queue:
         self._key = '{0}{1}'.format(prefix, name)
         self._default_timeout = parse_timeout(default_timeout) or self.DEFAULT_TIMEOUT
         self._is_async = is_async
+        self.log = logger
 
         if 'async' in kwargs:
             self._is_async = kwargs['async']
@@ -204,8 +213,13 @@ class Queue:
             end = offset + (length - 1)
         else:
             end = length
-        return [as_text(job_id) for job_id in
-                self.connection.lrange(self.key, start, end)]
+        job_ids = [
+            as_text(job_id)
+            for job_id
+            in self.connection.lrange(self.key, start, end)
+        ]
+        self.log.debug(f"Getting jobs for queue {green(self.name)}: {len(job_ids)} found.")
+        return job_ids
 
     def get_jobs(self, offset: int = 0, length: int = -1):
         """Returns a slice of jobs in the queue."""
@@ -291,11 +305,13 @@ class Queue:
     def push_job_id(self, job_id: str, pipeline: t.Optional['Pipeline'] = None, at_front=False):
         """Pushes a job ID on the corresponding Redis queue.
         'at_front' allows you to push the job onto the front instead of the back of the queue"""
+        self.log.debug(f"Pushing job {blue(job_id)} into the queue {green(self.name)}, current job count {self.count}")
         connection = pipeline if pipeline is not None else self.connection
         if at_front:
-            connection.lpush(self.key, job_id)
+            result = connection.lpush(self.key, job_id)
         else:
-            connection.rpush(self.key, job_id)
+            result = connection.rpush(self.key, job_id)
+        self.log.debug(f"Pushed job {blue(job_id)} into the queue {green(self.name)}, total job count after pushing job: {result}")
 
     def create_job(self, func: t.Callable[..., t.Any], args=None, kwargs=None, timeout=None,
                    result_ttl=None, ttl=None, failure_ttl=None,
@@ -699,10 +715,13 @@ class Queue:
         if timeout is not None:  # blocking variant
             if timeout == 0:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
+            logger.debug(f"Starting blocking pop operation for queues {green(queue_keys)} with timeout of {timeout}")
             result = connection.blpop(queue_keys, timeout)
             if result is None:
+                logger.debug(f"BLPOP Timeout, no jobs found on queues {green(queue_keys)}")
                 raise DequeueTimeout(timeout, queue_keys)
             queue_key, job_id = result
+            logger.debug(f"Found job {blue(job_id)} on queue {green(queue_key)}")
             return queue_key, job_id
         else:  # non-blocking variant
             for queue_key in queue_keys:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -60,7 +60,7 @@ green = make_colorizer('darkgreen')
 yellow = make_colorizer('darkyellow')
 blue = make_colorizer('darkblue')
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("rq.worker")
 
 
 class StopRequested(Exception):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -952,12 +952,10 @@ class Worker:
         with self.connection.pipeline() as pipeline:
             self.set_current_job_id(job.id, pipeline=pipeline)
             self.set_current_job_working_time(0, pipeline=pipeline)
-            self.log.debug(f"Set Current Job ID & Working Time")
 
             heartbeat_ttl = self.get_heartbeat_ttl(job)
             self.heartbeat(heartbeat_ttl, pipeline=pipeline)
             job.heartbeat(utcnow(), heartbeat_ttl, pipeline=pipeline)
-            self.log.debug(f"Heartbeat set with TTL of {heartbeat_ttl}")
 
             job.prepare_for_execution(self.name, pipeline=pipeline)
             pipeline.execute()

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1096,7 +1096,7 @@ class Worker:
 
     def execute_failure_callback(self, job):
         """Executes failure_callback with timeout"""
-        self.log.debug(f"Running Failure Callbacks for {job.id}")
+        self.log.debug(f"Running failure callbacks for {job.id}")
         job.heartbeat(utcnow(), CALLBACK_TIMEOUT)
         with self.death_penalty_class(CALLBACK_TIMEOUT, JobTimeoutException, job_id=job.id):
             job.failure_callback(job, self.connection, *sys.exc_info())

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -695,7 +695,7 @@ class Worker:
                                                       connection=self.connection,
                                                       job_class=self.job_class,
                                                       serializer=self.serializer)
-                self.log.debug(f"Dequed job ID {result[1]} on queue {result[0]}")
+                self.log.debug(f"Dequeued job ID {result[1]} on queue {result[0]}")
                 if result is not None:
 
                     job, queue = result

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -957,7 +957,7 @@ class Worker:
             heartbeat_ttl = self.get_heartbeat_ttl(job)
             self.heartbeat(heartbeat_ttl, pipeline=pipeline)
             job.heartbeat(utcnow(), heartbeat_ttl, pipeline=pipeline)
-            self.log.debug(f"Got Heartbeat. Current TTL is {heartbeat_ttl}")
+            self.log.debug(f"Heartbeat set with TTL of {heartbeat_ttl}")
 
             job.prepare_for_execution(self.name, pipeline=pipeline)
             pipeline.execute()

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -690,10 +690,12 @@ class Worker:
                 if self.should_run_maintenance_tasks:
                     self.run_maintenance_tasks()
 
+                self.log.debug(f"Dequeing jobs on queues {self._ordered_queues} and timeout {timeout}")
                 result = self.queue_class.dequeue_any(self._ordered_queues, timeout,
                                                       connection=self.connection,
                                                       job_class=self.job_class,
                                                       serializer=self.serializer)
+                self.log.debug(f"Dequed job ID {result[1]} on queue {result[0]}")
                 if result is not None:
 
                     job, queue = result


### PR DESCRIPTION
There were reports where a worker wouldn't fetch new jobs.
Since one possible cause is the infinite hanging of the `BLPOP` command,
this adds a couple of logs surrounding the `dequeue_any` function,
that interacts with Redis using `BLPOP`,