### PR TITLE
Moves the `compact` helper to `utils`

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -19,7 +19,7 @@ from .defaults import DEFAULT_RESULT_TTL
 from .exceptions import DequeueTimeout, NoSuchJobError
 from .job import Job, JobStatus
 from .serializers import resolve_serializer
-from .utils import backend_class, get_version, import_attribute, make_colorizer, parse_timeout, utcnow
+from .utils import backend_class, get_version, import_attribute, make_colorizer, parse_timeout, utcnow, compact
 
 
 green = make_colorizer('darkgreen')
@@ -28,9 +28,6 @@ blue = make_colorizer('darkblue')
 
 logger = logging.getLogger("rq.queue")
 
-
-def compact(lst):
-    return [item for item in lst if item is not None]
 
 
 class EnqueueData(namedtuple('EnqueueData', ["func", "args", "kwargs", "timeout",

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -125,6 +125,18 @@ class ColorizingStreamHandler(logging.StreamHandler):
         return message
 
 
+def compact(lst: list[t.Any]) -> list[t.Any]:
+    """Excludes `None` values from a list-like object.
+
+    Args:
+        lst (list): A list (or list-like) oject
+
+    Returns:
+        object (list): The list without None values
+    """    
+    return [item for item in lst if item is not None]
+
+
 def as_text(v):
     if v is None:
         return None

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -125,7 +125,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
         return message
 
 
-def compact(lst: list[t.Any]) -> list[t.Any]:
+def compact(lst: t.List[t.Any]) -> t.List[t.Any]:
     """Excludes `None` values from a list-like object.
 
     Args:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -45,7 +45,7 @@ from .scheduler import RQScheduler
 from .suspension import is_suspended
 from .timeouts import JobTimeoutException, HorseMonitorTimeoutException, UnixSignalDeathPenalty
 from .utils import (backend_class, ensure_list, get_version,
-                    make_colorizer, utcformat, utcnow, utcparse)
+                    make_colorizer, utcformat, utcnow, utcparse, compact)
 from .version import VERSION
 from .worker_registration import clean_worker_registry, get_keys
 from .serializers import resolve_serializer
@@ -66,9 +66,6 @@ logger = logging.getLogger("rq.worker")
 class StopRequested(Exception):
     pass
 
-
-def compact(a_list):
-    return [x for x in a_list if x is not None]
 
 
 _signames = dict((getattr(signal, signame), signame)


### PR DESCRIPTION
There is a helper funcion that excludes `None` values from a list. This was being declared both in the Queue and in the worker. This centralizes this helper in the `utils` Importing