### PR TITLE
Bugfix: Fix bug when running worker on debug mode

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -983,13 +983,14 @@ class Queue:
         if timeout is not None:  # blocking variant
             if timeout == 0:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
-            logger.debug(f"Starting BLPOP operation for queues {green(queue_keys)} with timeout of {timeout}")
+            colored_queues = [green(queue) for queue in queue_keys]
+            logger.debug(f"Starting BLPOP operation for queues {colored_queues} with timeout of {timeout}")
             result = connection.blpop(queue_keys, timeout)
             if result is None:
-                logger.debug(f"BLPOP Timeout, no jobs found on queues {green(queue_keys)}")
+                logger.debug(f"BLPOP Timeout, no jobs found on queues {colored_queues}")
                 raise DequeueTimeout(timeout, queue_keys)
             queue_key, job_id = result
-            logger.debug(f"Dequeued job {blue(job_id)} from queue {green(queue_key)}")
+            logger.debug(f"Dequeued job {blue(job_id.decode('utf-8'))} from queue {green(queue_key.decode('utf-8'))}")
             return queue_key, job_id
         else:  # non-blocking variant
             for queue_key in queue_keys:


### PR DESCRIPTION
When running on debug mode, some debug logs were
using colorizers on lists, which would raise an unhandled exception on the worker.
The same happened for a debug log that was using colors on a response from Redis (bytes).

To avoid changing the colorizer functions signature, I chose to fix this manually.
In the future we could have more robust logic for the colors (deconstruct lists, convert bytes to string, etc).

Fixes #1786 