### PR TITLE
Bugfix: sets `exc_info` when working with `is_async=False`

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1,3 +1,4 @@
+import traceback
 import uuid
 import sys
 import warnings
@@ -855,6 +856,8 @@ class Queue:
             job.set_status(JobStatus.FAILED)
             if job.failure_callback:
                 job.failure_callback(job, self.connection, *sys.exc_info())
+            exc_info = sys.exc_info()
+            job._exc_info = ''.join(traceback.format_exception(*exc_info))
         else:
             if job.success_callback:
                 job.success_callback(job, self.connection, job.result)


### PR DESCRIPTION
Fix #1633. Currently `exc_info` is only being set by the worker on the `handle_job_failure` method. This adds the `exc_info` to the queue, when running a sync job.