### PR TITLE
Fix - TypeError - accessing None when dequeued result is None (when timeout=None, e.g. in burst mode)

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -760,10 +760,9 @@ class Worker:
                     job_class=self.job_class,
                     serializer=self.serializer,
                 )
-                self.log.debug(f"Dequeued job {result[1]} from {result[0]}")
                 if result is not None:
-
                     job, queue = result
+                    self.log.debug(f"Dequeued job {job} from {queue}")
                     job.redis_server_version = self.get_redis_server_version()
                     if self.log_job_description:
                         self.log.info('%s: %s (%s)', green(queue.name), blue(job.description), job.id)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -640,8 +640,7 @@ class TestWorker(RQTestCase):
         w = Worker([q])
 
         # Put it on the queue with a timeout value
-        res = w.dequeue_job_and_maintain_ttl(None)
-        assert res is None
+        assert self.assertIsNone(w.dequeue_job_and_maintain_ttl(None))
 
     def test_worker_sets_result_ttl(self):
         """Ensure that Worker properly sets result_ttl for individual jobs."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -634,6 +634,15 @@ class TestWorker(RQTestCase):
         res.refresh()
         self.assertIn('JobTimeoutException', as_text(res.exc_info))
 
+    def test_dequeue_job_and_maintain_ttl_non_blocking(self):
+        """Not passing a timeout should return immediately with None as a result"""
+        q = Queue()
+        w = Worker([q])
+
+        # Put it on the queue with a timeout value
+        res = w.dequeue_job_and_maintain_ttl(None)
+        assert res is None
+
     def test_worker_sets_result_ttl(self):
         """Ensure that Worker properly sets result_ttl for individual jobs."""
         q = Queue()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -640,7 +640,7 @@ class TestWorker(RQTestCase):
         w = Worker([q])
 
         # Put it on the queue with a timeout value
-        assert self.assertIsNone(w.dequeue_job_and_maintain_ttl(None))
+        self.assertIsNone(w.dequeue_job_and_maintain_ttl(None))
 
     def test_worker_sets_result_ttl(self):
         """Ensure that Worker properly sets result_ttl for individual jobs."""


### PR DESCRIPTION
result might be None if burst=True for example

added a test (failing before the fix)

(This was introduced in #1752)