### PR TITLE
Fix - Use worker TTL for timeout

### DIFF
--- a/rq/contrib/legacy.py
+++ b/rq/contrib/legacy.py
@@ -19,6 +19,6 @@ def cleanup_ghosts(conn=None):
     conn = conn if conn else get_current_connection()
     for worker in Worker.all(connection=conn):
         if conn.ttl(worker.key) == -1:
-            ttl = worker.default_worker_ttl
+            ttl = worker.worker_ttl
             conn.expire(worker.key, ttl)
             logger.info('Marked ghosted worker {0} to expire in {1} seconds.'.format(worker.name, ttl))

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -227,7 +227,11 @@ class Worker:
         serializer=None,
     ):  # noqa
 
-        connection = self._set_connection(connection, default_worker_ttl)
+        self.default_result_ttl = default_result_ttl
+        self.default_worker_ttl = default_worker_ttl
+        self.job_monitoring_interval = job_monitoring_interval
+
+        connection = self._set_connection(connection)
         self.connection = connection
         self.redis_server_version = None
 
@@ -249,10 +253,6 @@ class Worker:
         self.validate_queues()
         self._ordered_queues = self.queues[:]
         self._exc_handlers: List[Callable] = []
-
-        self.default_result_ttl = default_result_ttl
-        self.default_worker_ttl = default_worker_ttl
-        self.job_monitoring_interval = job_monitoring_interval
 
         self._state: str = 'starting'
         self._is_horse: bool = False
@@ -300,20 +300,19 @@ class Worker:
         elif exception_handlers is not None:
             self.push_exc_handler(exception_handlers)
 
-    def _set_connection(self, connection: Optional['Redis'], default_worker_ttl: int) -> 'Redis':
+    def _set_connection(self, connection: Optional['Redis']) -> 'Redis':
         """Configures the Redis connection to have a socket timeout.
         This should timouet the connection in case any specific command hangs at any given time (eg. BLPOP).
         If the connection provided already has a `socket_timeout` defined, skips.
 
         Args:
             connection (Optional[Redis]): The Redis Connection.
-            default_worker_ttl (int): The Default Worker TTL
         """
         if connection is None:
             connection = get_current_connection()
         current_socket_timeout = connection.connection_pool.connection_kwargs.get("socket_timeout")
         if current_socket_timeout is None:
-            timeout = self._get_timeout(default_worker_ttl) + 10
+            timeout = self.timeout + 10
             timeout_config = {"socket_timeout": timeout}
             connection.connection_pool.connection_kwargs.update(timeout_config)
         return connection
@@ -365,11 +364,9 @@ class Worker:
         """Returns whether or not this is the worker or the work horse."""
         return self._is_horse
 
-    def _get_timeout(self, worker_ttl: Optional[int] = None) -> int:
-        timeout = DEFAULT_WORKER_TTL
-        if worker_ttl:
-            timeout = worker_ttl
-        return max(1, timeout - 15)
+    @property
+    def timeout(self) -> int:
+        return max(1, self.default_worker_ttl - 15)
 
     def procline(self, message):
         """Changes the current procname for the process.
@@ -684,7 +681,7 @@ class Worker:
                         self.log.info('Worker %s: stopping on request', self.key)
                         break
 
-                    timeout = None if burst else self._get_timeout()
+                    timeout = None if burst else self.timeout
                     result = self.dequeue_job_and_maintain_ttl(timeout)
                     if result is None:
                         if burst:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -365,7 +365,7 @@ class Worker:
 
     @property
     def connection_timeout(self) -> int:
-        return max(1, self.worker_ttl - 15) + 10
+        return self.dequeue_timeout + 10
 
     def procline(self, message):
         """Changes the current procname for the process.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -609,7 +609,7 @@ class TestWorker(RQTestCase):
 
     @slow  # noqa
     def test_timeouts(self):
-        """Worker kills jobs after timeout."""
+        """Worker kills jobs after dequeue_timeout."""
         sentinel_file = '/tmp/.rq_sentinel'
 
         q = Queue()
@@ -638,9 +638,9 @@ class TestWorker(RQTestCase):
         """Ensures the worker_ttl param is being considered in the timeout, takes into account 15 seconds gap (hard coded)"""
         q = Queue()
         w = Worker([q])
-        self.assertEqual(w.timeout, 405)
+        self.assertEqual(w.dequeue_timeout, 405)
         w = Worker([q], default_worker_ttl=500)
-        self.assertEqual(w.timeout, 485)
+        self.assertEqual(w.dequeue_timeout, 485)
 
     def test_worker_sets_result_ttl(self):
         """Ensure that Worker properly sets result_ttl for individual jobs."""
@@ -756,7 +756,7 @@ class TestWorker(RQTestCase):
                          'PID mismatch, fork() is not supposed to happen here')
 
     def test_simpleworker_heartbeat_ttl(self):
-        """SimpleWorker's key must last longer than job.timeout when working"""
+        """SimpleWorker's key must last longer than job.dequeue_timeout when working"""
         queue = Queue('foo')
 
         worker = SimpleWorker([queue])

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -634,6 +634,14 @@ class TestWorker(RQTestCase):
         res.refresh()
         self.assertIn('JobTimeoutException', as_text(res.exc_info))
 
+    def test_worker_ttl_param_resolves_timeout(self):
+        """Ensures the worker_ttl param is being considered in the timeout, takes into account 15 seconds gap (hard coded)"""
+        q = Queue()
+        w = Worker([q])
+        self.assertEqual(w.timeout, 405)
+        w = Worker([q], default_worker_ttl=500)
+        self.assertEqual(w.timeout, 485)
+
     def test_worker_sets_result_ttl(self):
         """Ensure that Worker properly sets result_ttl for individual jobs."""
         q = Queue()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -647,8 +647,10 @@ class TestWorker(RQTestCase):
         q = Queue()
         w = Worker([q])
         self.assertEqual(w.dequeue_timeout, 405)
+        self.assertEqual(w.connection_timeout, 415)
         w = Worker([q], default_worker_ttl=500)
         self.assertEqual(w.dequeue_timeout, 485)
+        self.assertEqual(w.connection_timeout, 495)
 
     def test_worker_sets_result_ttl(self):
         """Ensure that Worker properly sets result_ttl for individual jobs."""


### PR DESCRIPTION
Worker ttl was ignored.
BTW, do we have a better name for `timeout`? It was names `_get_timeout` before, but maybe something more specific can help with readability