### PR TITLE
Fix worker TTL not being considered

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -366,7 +366,7 @@ class Worker:
         return self._is_horse
 
     def _get_timeout(self, worker_ttl: Optional[int] = None) -> int:
-        timeout = DEFAULT_WORKER_TTL
+        timeout = getattr(self, "default_worker_ttl", DEFAULT_WORKER_TTL)
         if worker_ttl:
             timeout = worker_ttl
         return max(1, timeout - 15)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1056,6 +1056,14 @@ class TestWorker(RQTestCase):
         connection_kwargs = q.connection.connection_pool.connection_kwargs
         self.assertEqual(connection_kwargs["socket_timeout"], 415)
 
+    def test_worker_ttl_param_resolves_timeout(self):
+        """Ensures the worker_ttl param is being considered in the timeout, takes into account 15 seconds gap (hard coded)"""
+        q = Queue()
+        w = Worker([q])
+        self.assertEqual(w._get_timeout(), 405)
+        w = Worker([q], default_worker_ttl=500)
+        self.assertEqual(w._get_timeout(), 485)
+
     def test_worker_version(self):
         q = Queue()
         w = Worker([q])


### PR DESCRIPTION
The default worker ttl set as a parameter was not being considered after we've concentrated the timeout
calculation into a single place.