### PR TITLE
Use job.return_value() instead of job.result when processing callbacks

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -743,6 +743,14 @@ class Job:
             self._cached_result = None
 
         if not self.supports_redis_streams:
+            if self._result is not None:
+                return self._result
+
+            rv = self.connection.hget(self.key, 'result')
+            if rv is not None:
+                # cache the result
+                self._result = self.serializer.loads(rv)
+                return self._result
             return None
 
         if not self._cached_result:

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1035,10 +1035,10 @@ class Queue:
                 pipeline.execute()
 
             if job.failure_callback:
-                job.failure_callback(job, self.connection, *sys.exc_info())
+                job.failure_callback(job, self.connection, *sys.exc_info())  # type: ignore
         else:
             if job.success_callback:
-                job.success_callback(job, self.connection, job.result)
+                job.success_callback(job, self.connection, job.return_value())  # type: ignore
 
         return job
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -90,7 +90,7 @@ class WorkerCallbackTestCase(RQTestCase):
         self.assertEqual(job.get_status(), JobStatus.FINISHED)
         self.assertEqual(
             self.testconn.get('success_callback:%s' % job.id).decode(),
-            job.result
+            job.return_value()
         )
 
         job = queue.enqueue(div_by_zero, on_success=save_result)


### PR DESCRIPTION
Fixes https://github.com/rq/rq/issues/1797