### PR TITLE
New dequeue strategy

### DIFF
--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -69,7 +69,7 @@ In addition to `--burst`, `rq worker` also accepts these arguments:
 * `--date-format`: Datetime format for the worker logs, defaults to `'%H:%M:%S'`
 * `--disable-job-desc-logging`: Turn off job description logging.
 * `--max-jobs`: Maximum number of jobs to execute.
-* `--dequeue-strategy`: The strategy to dequeue jobs from multiple queues (one of `order`, `random` or `roundrobin`,  defaults to `order`)
+* `--dequeue-strategy`: The strategy to dequeue jobs from multiple queues (one of `default`, `random` or `round_robin`,  defaults to `default`)
 
 _New in version 1.8.0._
 * `--serializer`: Path to serializer object (e.g "rq.serializers.DefaultSerializer" or "rq.serializers.JSONSerializer")
@@ -324,7 +324,7 @@ To choose the strategy that should be used, `rq` provides the `--dequeue-strateg
 In certain circumstances it can be useful that a when a worker is listening to multiple queues, 
 say `q1`,`q2`,`q3`, the jobs are dequeued using a Round Robin strategy. That is, the 1st
 dequeued job is taken from `q1`, the 2nd from `q2`, the 3rd from `q3`, the 4th
-from `q1`, the 5th from `q2` and so on. To implement this strategy use `-ds roundrobin` argument.
+from `q1`, the 5th from `q2` and so on. To implement this strategy use `-ds round_robin` argument.
 
 In other circumstances, it can be useful to pull jobs from the different queues randomly.
 To implement this strategy use `-ds random` argument.

--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -69,6 +69,7 @@ In addition to `--burst`, `rq worker` also accepts these arguments:
 * `--date-format`: Datetime format for the worker logs, defaults to `'%H:%M:%S'`
 * `--disable-job-desc-logging`: Turn off job description logging.
 * `--max-jobs`: Maximum number of jobs to execute.
+* `--dequeue-strategy`: The strategy to dequeue jobs from multiple queues (one of `order`, `random` or `roundrobin`,  defaults to `order`)
 
 _New in version 1.8.0._
 * `--serializer`: Path to serializer object (e.g "rq.serializers.DefaultSerializer" or "rq.serializers.JSONSerializer")
@@ -322,14 +323,15 @@ it will be selected before any other in queues with lower priority.
 In certain circumstances it can be useful that a when a worker is listening to multiple queues, 
 say `q1`,`q2`,`q3`, the jobs are dequeued using a Round Robin strategy. That is, the 1st
 dequeued job is taken from `q1`, the 2nd from `q2`, the 3rd from `q3`, the 4th
-from `q1`, the 5th from `q2` and so on. The custom worker class `rq.worker.RoundRobinWorker`
-implements this strategy. 
+from `q1`, the 5th from `q2` and so on. To implement this strategy use `--dequeue-strategy roundrobin` argument.
 
 In some other circumstances, when a worker is listening to multiple queues, it can be useful
-to pull jobs from the different queues randomly. The custom class `rq.worker.RandomWorker`
-implements this strategy. In fact, whenever a job is pulled from any queue, the list of queues is
+to pull jobs from the different queues randomly.  To implement this strategy use `--dequeue-strategy random` argument.
+In fact, whenever a job is pulled from any queue, the list of queues is
 shuffled, so that no queue has more priority than the other ones.
 
+Deprecation Warning: Those strategies were formely being implemented by using the custom classes `rq.worker.RoundRobinWorker`
+and `rq.worker.RandomWorker`. Those worker classes are deprecated and will be removed from future versions.
 
 ## Custom Job and Queue Classes
 

--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -318,20 +318,21 @@ $ rq worker -w 'path.to.GeventWorker'
 
 The default worker considers the order of queues as their priority order, 
 and if a task is pending in a higher priority queue 
-it will be selected before any other in queues with lower priority.
+it will be selected before any other in queues with lower priority (the `default` behavior).
+To choose the strategy that should be used, `rq` provides the `--dequeue-strategy / -ds` option.
 
 In certain circumstances it can be useful that a when a worker is listening to multiple queues, 
 say `q1`,`q2`,`q3`, the jobs are dequeued using a Round Robin strategy. That is, the 1st
 dequeued job is taken from `q1`, the 2nd from `q2`, the 3rd from `q3`, the 4th
-from `q1`, the 5th from `q2` and so on. To implement this strategy use `--dequeue-strategy roundrobin` argument.
+from `q1`, the 5th from `q2` and so on. To implement this strategy use `-ds roundrobin` argument.
 
-In some other circumstances, when a worker is listening to multiple queues, it can be useful
-to pull jobs from the different queues randomly.  To implement this strategy use `--dequeue-strategy random` argument.
-In fact, whenever a job is pulled from any queue, the list of queues is
+In other circumstances, it can be useful to pull jobs from the different queues randomly.
+To implement this strategy use `-ds random` argument.
+In fact, whenever a job is pulled from any queue with the `random` strategy, the list of queues is
 shuffled, so that no queue has more priority than the other ones.
 
 Deprecation Warning: Those strategies were formely being implemented by using the custom classes `rq.worker.RoundRobinWorker`
-and `rq.worker.RandomWorker`. Those worker classes are deprecated and will be removed from future versions.
+and `rq.worker.RandomWorker`. As the `--dequeue-strategy` argument allows for this option to be used with any worker, those worker classes are deprecated and will be removed from future versions. 
 
 ## Custom Job and Queue Classes
 

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -262,9 +262,7 @@ def worker(
             fp.write(str(os.getpid()))
 
     worker_name = cli_config.worker_class.__qualname__
-    is_roundrobin_worker = worker_name == "RoundRobinWorker"
-    is_random_worker = worker_name == "RandomWorker"
-    if is_roundrobin_worker or is_random_worker:
+    if worker_name in ["RoundRobinWorker", "RandomWorker"]:
         strategy_alternative = "random" if worker_name == "RandomWorker" else "roundrobin"
         msg = f"WARNING: The {worker_name} is deprecated. Use the --dequeue-strategy / -ds option with the {strategy_alternative} argument to set the strategy."
         warnings.warn(msg, DeprecationWarning)

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -263,13 +263,13 @@ def worker(
 
     worker_name = cli_config.worker_class.__qualname__
     if worker_name in ["RoundRobinWorker", "RandomWorker"]:
-        strategy_alternative = "random" if worker_name == "RandomWorker" else "roundrobin"
+        strategy_alternative = "random" if worker_name == "RandomWorker" else "round_robin"
         msg = f"WARNING: The {worker_name} is deprecated. Use the --dequeue-strategy / -ds option with the {strategy_alternative} argument to set the strategy."
         warnings.warn(msg, DeprecationWarning)
         click.secho(msg, fg='yellow')
 
-    if dequeue_strategy not in ["default", "random", "roundrobin"]:
-        click.secho("ERROR: Dequeue Strategy can only be one of `default`, `random` or `roundrobin`.", err=True, fg='red')
+    if dequeue_strategy not in ("default", "random", "round_robin"):
+        click.secho("ERROR: Dequeue Strategy can only be one of `default`, `random` or `round_robin`.", err=True, fg='red')
         sys.exit(1)
 
     setup_loghandlers_from_args(verbose, quiet, date_format, log_format)

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -175,7 +175,6 @@ def info(cli_config, interval, raw, only_queues, only_workers, by_queue, queues,
 
     try:
         with Connection(cli_config.connection):
-
             if queues:
                 qs = list(map(cli_config.queue_class, queues))
             else:
@@ -220,7 +219,9 @@ def info(cli_config, interval, raw, only_queues, only_workers, by_queue, queues,
 @click.option('--max-jobs', type=int, default=None, help='Maximum number of jobs to execute')
 @click.option('--with-scheduler', '-s', is_flag=True, help='Run worker with scheduler')
 @click.option('--serializer', '-S', default=None, help='Run worker with custom serializer')
-@click.option('--dequeue-strategy', '-ds', default="order", help='Sets a custom stratey to dequeue from multiple queues')
+@click.option(
+    '--dequeue-strategy', '-ds', default="order", help='Sets a custom stratey to dequeue from multiple queues'
+)
 @click.argument('queues', nargs=-1)
 @pass_cli_config
 def worker(
@@ -247,7 +248,7 @@ def worker(
     date_format,
     serializer,
     dequeue_strategy,
-    **options
+    **options,
 ):
     """Starts an RQ worker."""
     settings = read_config_file(cli_config.config) if cli_config.config else {}
@@ -266,7 +267,8 @@ def worker(
     is_random_worker = cli_config.worker_class == "rq.worker.RandomWorker"
     if is_roundrobin_worker or is_random_worker:
         warnings.warn(
-            "The %s worker is deprecated. Use the `dequeue_strategy` argument to set the strategy.", DeprecationWarning
+            f"The {cli_config.worker_class} worker is deprecated. Use the `dequeue_strategy` argument to set the strategy.",
+            DeprecationWarning,
         )
 
     setup_loghandlers_from_args(verbose, quiet, date_format, log_format)
@@ -300,7 +302,7 @@ def worker(
             disable_default_exception_handler=disable_default_exception_handler,
             log_job_description=not disable_job_desc_logging,
             serializer=serializer,
-            dequeue_strategy=dequeue_strategy
+            dequeue_strategy=dequeue_strategy,
         )
 
         # Should we configure Sentry?
@@ -402,7 +404,7 @@ def enqueue(
     serializer,
     function,
     arguments,
-    **options
+    **options,
 ):
     """Enqueues a job from the command line"""
     args, kwargs = parse_function_args(arguments)

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -302,8 +302,7 @@ def worker(
             exception_handlers=exception_handlers or None,
             disable_default_exception_handler=disable_default_exception_handler,
             log_job_description=not disable_job_desc_logging,
-            serializer=serializer,
-            dequeue_strategy=dequeue_strategy,
+            serializer=serializer
         )
 
         # Should we configure Sentry?
@@ -324,6 +323,7 @@ def worker(
             log_format=log_format,
             max_jobs=max_jobs,
             with_scheduler=with_scheduler,
+            dequeue_strategy=dequeue_strategy
         )
     except ConnectionError as e:
         print(e)

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -100,7 +100,6 @@ def state_symbol(state):
 
 
 def show_queues(queues, raw, by_queue, queue_class, worker_class):
-
     num_jobs = 0
     termwidth = get_terminal_size().columns
     chartwidth = min(20, termwidth - 20)
@@ -141,7 +140,6 @@ def show_workers(queues, raw, by_queue, queue_class, worker_class):
             workers.add(worker)
 
     if not by_queue:
-
         for worker in workers:
             queue_names = ', '.join(worker.queue_names())
             name = '%s (%s %s %s)' % (worker.name, worker.hostname, worker.ip_address, worker.pid)

--- a/rq/job.py
+++ b/rq/job.py
@@ -1317,9 +1317,8 @@ class Job:
         # for backward compatibility
         if self.supports_redis_streams:
             from .results import Result
-            Result.create(
-                self, Result.Type.SUCCESSFUL, return_value=self._result, ttl=result_ttl, pipeline=pipeline
-            )
+
+            Result.create(self, Result.Type.SUCCESSFUL, return_value=self._result, ttl=result_ttl, pipeline=pipeline)
 
         if result_ttl != 0:
             finished_job_registry = self.finished_job_registry
@@ -1339,6 +1338,7 @@ class Job:
         )
         if self.supports_redis_streams:
             from .results import Result
+
             Result.create_failure(self, self.failure_ttl, exc_string=exc_string, pipeline=pipeline)
 
     def get_retry_interval(self) -> int:

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -771,7 +771,7 @@ class Queue:
             Job: _description_
         """
         job.perform()
-        result_ttl = job.get_result_ttl(default_ttl=DEFAULT_RESULT_TTL) 
+        result_ttl = job.get_result_ttl(default_ttl=DEFAULT_RESULT_TTL)
         with self.connection.pipeline() as pipeline:
             job._handle_success(result_ttl=result_ttl, pipeline=pipeline)
             job.cleanup(result_ttl, pipeline=pipeline)
@@ -1062,7 +1062,6 @@ class Queue:
         dependents_key = job.dependents_key
 
         while True:
-
             try:
                 # if a pipeline is passed, the caller is responsible for calling WATCH
                 # to ensure all jobs are enqueued

--- a/rq/results.py
+++ b/rq/results.py
@@ -85,7 +85,7 @@ class Result(object):
         # response = job.connection.zrange(cls.get_key(job.id), 0, 10, desc=True, withscores=True)
         response = job.connection.xrevrange(cls.get_key(job.id), '+', '-')
         results = []
-        for (result_id, payload) in response:
+        for result_id, payload in response:
             results.append(
                 cls.restore(job.id, result_id.decode(), payload, connection=job.connection, serializer=serializer)
             )

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -27,7 +27,7 @@ from .exceptions import TimeoutFormatError
 logger = logging.getLogger(__name__)
 
 
-class DequeueStrategy(Enum):
+class DequeueStrategy(str, Enum):
     DEFAULT = "default"
     ROUNDROBIN = "roundrobin"
     RANDOM = "random"

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -12,6 +12,7 @@ import logging
 import numbers
 import sys
 import datetime as dt
+from enum import Enum
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Dict, List, Optional, Any, Callable, Tuple, Union
 
@@ -24,6 +25,12 @@ from redis.exceptions import ResponseError
 from .exceptions import TimeoutFormatError
 
 logger = logging.getLogger(__name__)
+
+
+class DequeueStrategy(str, Enum):
+    Order = "default"
+    RoundRobin = "roundrobin"
+    Random = "random"
 
 
 class _Colorizer:

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -27,10 +27,10 @@ from .exceptions import TimeoutFormatError
 logger = logging.getLogger(__name__)
 
 
-class DequeueStrategy(str, Enum):
-    Order = "order"
-    RoundRobin = "roundrobin"
-    Random = "random"
+class DequeueStrategy(Enum):
+    DEFAULT = "default"
+    ROUNDROBIN = "roundrobin"
+    RANDOM = "random"
 
 
 class _Colorizer:

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -103,7 +103,6 @@ def make_colorizer(color: str):
 
 
 class ColorizingStreamHandler(logging.StreamHandler):
-
     levels = {
         logging.WARNING: make_colorizer('darkyellow'),
         logging.ERROR: make_colorizer('darkred'),

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -12,7 +12,6 @@ import logging
 import numbers
 import sys
 import datetime as dt
-from enum import Enum
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Dict, List, Optional, Any, Callable, Tuple, Union
 
@@ -25,12 +24,6 @@ from redis.exceptions import ResponseError
 from .exceptions import TimeoutFormatError
 
 logger = logging.getLogger(__name__)
-
-
-class DequeueStrategy(str, Enum):
-    DEFAULT = "default"
-    ROUNDROBIN = "roundrobin"
-    RANDOM = "random"
 
 
 class _Colorizer:

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class DequeueStrategy(str, Enum):
-    Order = "default"
+    Order = "order"
     RoundRobin = "roundrobin"
     Random = "random"
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -97,7 +97,7 @@ def signal_name(signum):
 
 class DequeueStrategy(str, Enum):
     DEFAULT = "default"
-    ROUNDROBIN = "roundrobin"
+    ROUND_ROBIN = "round_robin"
     RANDOM = "random"
 
 
@@ -692,7 +692,7 @@ class Worker:
         if self._dequeue_strategy is None:
             self._dequeue_strategy = DequeueStrategy.DEFAULT
 
-        if self._dequeue_strategy not in ["default", "random", "roundrobin"]:
+        if self._dequeue_strategy not in ["default", "random", "round_robin"]:
             self.log.warning(
                 "Dequeue strategy %s is not allowed. Use one of `default`, `random` or `rounbrobin`. Using defalt ordering.",
                 self._dequeue_strategy,
@@ -700,7 +700,7 @@ class Worker:
             return
         if self._dequeue_strategy == DequeueStrategy.DEFAULT:
             return
-        if self._dequeue_strategy == DequeueStrategy.ROUNDROBIN:
+        if self._dequeue_strategy == DequeueStrategy.ROUND_ROBIN:
             pos = self._ordered_queues.index(reference_queue)
             self._ordered_queues = self._ordered_queues[pos + 1:] + self._ordered_queues[: pos + 1]
             return

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -693,7 +693,7 @@ class Worker:
 
         if self._dequeue_strategy not in ("default", "random", "round_robin"):
             raise ValueError(
-                f"Dequeue strategy {self._dequeue_strategy} is not allowed. Use one of `default`, `random` or `round_robin`. Using defalt ordering."
+                f"Dequeue strategy {self._dequeue_strategy} is not allowed. Use `default`, `random` or `round_robin`."
             )
         if self._dequeue_strategy == DequeueStrategy.DEFAULT:
             return

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -292,7 +292,7 @@ class Worker:
         self.scheduler: Optional[RQScheduler] = None
         self.pubsub = None
         self.pubsub_thread = None
-        self._dequeue_strategy = dequeue_strategy
+        self._dequeue_strategy: DequeueStrategy = dequeue_strategy
 
         self.disable_default_exception_handler = disable_default_exception_handler
 
@@ -681,7 +681,7 @@ class Worker:
             self.pubsub.unsubscribe()
             self.pubsub.close()
 
-    def reorder_queues(self, reference_queue: 'Queue'):
+    def reorder_queues(self, reference_queue: Optional['Queue'] = None):
         """Reorder the queues according to the strategy.
         As this can be defined both in the `Worker` initialization or in the `work` method,
         it doesn't take the strategy directly, but rather uses the private `_dequeue_strategy` attribute.
@@ -689,10 +689,13 @@ class Worker:
         Args:
             reference_queue (Union[Queue, str]): The queues to reorder
         """
+        if not reference_queue:
+            return
+
         if self._dequeue_strategy is None:
             self._dequeue_strategy = DequeueStrategy.DEFAULT
 
-        if self._dequeue_strategy not in ["default", "random", "round_robin"]:
+        if self._dequeue_strategy not in ("default", "random", "round_robin"):
             self.log.warning(
                 "Dequeue strategy %s is not allowed. Use one of `default`, `random` or `rounbrobin`. Using defalt ordering.",
                 self._dequeue_strategy,

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -709,8 +709,7 @@ class Worker:
         self,
         logging_level: str = "INFO",
         date_format: str = DEFAULT_LOGGING_DATE_FORMAT,
-        log_format: str = DEFAULT_LOGGING_FORMAT,
-        dequeue_strategy: DequeueStrategy = DequeueStrategy.DEFAULT,
+        log_format: str = DEFAULT_LOGGING_FORMAT
     ):
         """Bootstraps the worker.
         Runs the basic tasks that should run when the worker actually starts working.
@@ -728,7 +727,6 @@ class Worker:
         self.subscribe()
         self.set_state(WorkerStatus.STARTED)
         qnames = self.queue_names()
-        self._dequeue_strategy = dequeue_strategy
         self.log.info('*** Listening on %s...', green(', '.join(qnames)))
 
     def _start_scheduler(
@@ -792,11 +790,13 @@ class Worker:
             log_format (str, optional): Log Format. Defaults to DEFAULT_LOGGING_FORMAT.
             max_jobs (Optional[int], optional): Max number of jobs. Defaults to None.
             with_scheduler (bool, optional): Whether to run the scheduler in a separate process. Defaults to False.
+            dequeue_strategy (DequeueStrategy, optional): Which strategy to use to dequeue jobs. Defaults to DequeueStrategy.DEFAULT
 
         Returns:
             worked (bool): Will return True if any job was processed, False otherwise.
         """
-        self.bootstrap(logging_level, date_format, log_format, dequeue_strategy)
+        self.bootstrap(logging_level, date_format, log_format)
+        self._dequeue_strategy = dequeue_strategy
         completed_jobs = 0
         if with_scheduler:
             self._start_scheduler(burst, logging_level, date_format, log_format)

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -694,7 +694,7 @@ class Worker:
 
         if self._dequeue_strategy not in ("default", "random", "round_robin"):
             self.log.warning(
-                "Dequeue strategy %s is not allowed. Use one of `default`, `random` or `rounbrobin`. Using defalt ordering.",
+                "Dequeue strategy %s is not allowed. Use one of `default`, `random` or `round_robin`. Using defalt ordering.",
                 self._dequeue_strategy,
             )
             return

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -681,7 +681,7 @@ class Worker:
             self.pubsub.unsubscribe()
             self.pubsub.close()
 
-    def reorder_queues(self, reference_queue: Optional['Queue'] = None):
+    def reorder_queues(self, reference_queue: 'Queue'):
         """Reorder the queues according to the strategy.
         As this can be defined both in the `Worker` initialization or in the `work` method,
         it doesn't take the strategy directly, but rather uses the private `_dequeue_strategy` attribute.
@@ -689,9 +689,6 @@ class Worker:
         Args:
             reference_queue (Union[Queue, str]): The queues to reorder
         """
-        if not reference_queue:
-            return
-
         if self._dequeue_strategy is None:
             self._dequeue_strategy = DequeueStrategy.DEFAULT
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -244,7 +244,6 @@ class Worker:
         disable_default_exception_handler: bool = False,
         prepare_for_work: bool = True,
         serializer=None,
-        dequeue_strategy=DequeueStrategy.DEFAULT,
         work_horse_killed_handler: Optional[Callable[[Job, int, int, resource.struct_rusage], None]] = None
     ):  # noqa
         self.default_result_ttl = default_result_ttl
@@ -292,7 +291,7 @@ class Worker:
         self.scheduler: Optional[RQScheduler] = None
         self.pubsub = None
         self.pubsub_thread = None
-        self._dequeue_strategy: DequeueStrategy = dequeue_strategy
+        self._dequeue_strategy: DequeueStrategy = DequeueStrategy.DEFAULT
 
         self.disable_default_exception_handler = disable_default_exception_handler
 
@@ -693,11 +692,9 @@ class Worker:
             self._dequeue_strategy = DequeueStrategy.DEFAULT
 
         if self._dequeue_strategy not in ("default", "random", "round_robin"):
-            self.log.warning(
-                "Dequeue strategy %s is not allowed. Use one of `default`, `random` or `round_robin`. Using defalt ordering.",
-                self._dequeue_strategy,
+            raise ValueError(
+                f"Dequeue strategy {self._dequeue_strategy} is not allowed. Use one of `default`, `random` or `round_robin`. Using defalt ordering."
             )
-            return
         if self._dequeue_strategy == DequeueStrategy.DEFAULT:
             return
         if self._dequeue_strategy == DequeueStrategy.ROUND_ROBIN:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -221,9 +221,8 @@ class Worker:
         disable_default_exception_handler: bool = False,
         prepare_for_work: bool = True,
         serializer=None,
-        dequeue_strategy=DequeueStrategy.Order
+        dequeue_strategy=DequeueStrategy.Order,
     ):  # noqa
-
         self.default_result_ttl = default_result_ttl
         self.worker_ttl = default_worker_ttl
         self.job_monitoring_interval = job_monitoring_interval
@@ -574,7 +573,6 @@ class Worker:
         notified = False
 
         while not self._stop_requested and is_suspended(self.connection, self):
-
             if burst:
                 self.log.info('Suspended in burst mode, exiting')
                 self.log.info('Note: There could still be unfinished jobs on the queue')
@@ -629,7 +627,10 @@ class Worker:
             reference_queue (Queue): The queues to reorder
         """
         if self._dequeue_strategy not in ["order", "random", "roundrobin"]:
-            self.log.warning("Dequeue strategy %s is not allowed. Use on of `order`, `random` or `rounbrobin` Defaulting to `order`.", self._dequeue_strategy)
+            self.log.warning(
+                "Dequeue strategy %s is not allowed. Use on of `order`, `random` or `rounbrobin` Defaulting to `order`.",
+                self._dequeue_strategy,
+            )
             return
         if self._dequeue_strategy == DequeueStrategy.Order:
             return
@@ -649,7 +650,7 @@ class Worker:
         log_format=DEFAULT_LOGGING_FORMAT,
         max_jobs=None,
         with_scheduler: bool = False,
-        dequeue_strategy: DequeueStrategy = DequeueStrategy.Order
+        dequeue_strategy: DequeueStrategy = DequeueStrategy.Order,
     ):
         """Starts the work loop.
 
@@ -736,7 +737,6 @@ class Worker:
                     break
         finally:
             if not self.is_horse:
-
                 if self.scheduler:
                     self.stop_scheduler()
 
@@ -763,7 +763,6 @@ class Worker:
         self.log.debug('*** Listening on %s...', green(qnames))
         connection_wait_time = 1.0
         while True:
-
             try:
                 self.heartbeat()
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -53,7 +53,7 @@ from .scheduler import RQScheduler
 from .serializers import resolve_serializer
 from .suspension import is_suspended
 from .timeouts import JobTimeoutException, HorseMonitorTimeoutException, UnixSignalDeathPenalty
-from .utils import DequeueStrategy, backend_class, ensure_list, get_version, make_colorizer, utcformat, utcnow, utcparse, compact, as_text
+from .utils import backend_class, ensure_list, get_version, make_colorizer, utcformat, utcnow, utcparse, compact, as_text
 from .version import VERSION
 from .serializers import resolve_serializer
 
@@ -93,6 +93,12 @@ def signal_name(signum):
         return 'SIG_UNKNOWN'
     except ValueError:
         return 'SIG_UNKNOWN'
+
+
+class DequeueStrategy(str, Enum):
+    DEFAULT = "default"
+    ROUNDROBIN = "roundrobin"
+    RANDOM = "random"
 
 
 class WorkerStatus(str, Enum):

--- a/rq/worker_registration.py
+++ b/rq/worker_registration.py
@@ -86,7 +86,6 @@ def clean_worker_registry(queue: 'Queue'):
     keys = list(get_keys(queue))
 
     with queue.connection.pipeline() as pipeline:
-
         for key in keys:
             pipeline.exists(key)
         results = pipeline.execute()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -333,7 +333,7 @@ class TestRQCli(RQTestCase):
         result = runner.invoke(main, args)
         self.assert_normal_execution(result)
 
-        args = ['worker', '-u', self.redis_url, '-b', '--dequeue-strategy', 'roundrobin']
+        args = ['worker', '-u', self.redis_url, '-b', '--dequeue-strategy', 'round_robin']
         result = runner.invoke(main, args)
         self.assert_normal_execution(result)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -326,6 +326,21 @@ class TestRQCli(RQTestCase):
         result = runner.invoke(main, args + ['--quiet', '--verbose'])
         self.assertNotEqual(result.exit_code, 0)
 
+    def test_worker_dequeue_strategy(self):
+        """--quiet and --verbose logging options are supported"""
+        runner = CliRunner()
+        args = ['worker', '-u', self.redis_url, '-b', '--dequeue-strategy', 'random']
+        result = runner.invoke(main, args)
+        self.assert_normal_execution(result)
+
+        args = ['worker', '-u', self.redis_url, '-b', '--dequeue-strategy', 'roundrobin']
+        result = runner.invoke(main, args)
+        self.assert_normal_execution(result)
+
+        args = ['worker', '-u', self.redis_url, '-b', '--dequeue-strategy', 'wrong']
+        result = runner.invoke(main, args)
+        self.assertEqual(result.exit_code, 1)
+
     def test_exception_handlers(self):
         """rq worker -u <url> -b --exception-handler <handler>"""
         connection = Redis.from_url(self.redis_url)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1141,7 +1141,7 @@ class TestWorker(RQTestCase):
                 qs[i].enqueue(say_pid, job_id='q%d_%d' % (i, j))
 
         w = Worker(qs)
-        w.work(burst=True, dequeue_strategy="roundrobin")
+        w.work(burst=True, dequeue_strategy="round_robin")
 
         start_times = []
         for i in range(5):


### PR DESCRIPTION
This implements a new parameter `dequeue_strategy` that should replace the `RoundRobinWorker` and `RandomWorker`.
It adds the parameter to (1) the `work()` method, (2) the `Worker` constructor and (3) to the CLI. It also adds deprecation warnings to the workers: I chose to do this through the CLI to avoid having to have a `__init__` method on the workers, and to avoid showing this warning only when the workers hits the `reorder_queue` method - that way we can have the warning as soon as possible.

Fixes #1805 