### PR TITLE
removed import error warning and changed function doc

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -182,10 +182,7 @@ def import_attribute(name: str) -> Callable[..., Any]:
     E.g.: package_a.package_b.module_a.ClassA.my_static_method
 
     Thus we remove the bits from the end of the name until we can import it
-    Sometimes the failure during importing is due to a genuine coding error in the imported module
-    In this case, the exception is logged as a warning for ease of debugging.
-    The above logic will apply anyways regardless of the cause of the import error.
-
+    
     Args:
         name (str): The name (reference) to the path.
 
@@ -204,7 +201,6 @@ def import_attribute(name: str) -> Callable[..., Any]:
             module = importlib.import_module(module_name)
             break
         except ImportError:
-            logger.warning("Import error for '%s'" % module_name, exc_info=True)
             attribute_bits.insert(0, module_name_bits.pop())
 
     if module is None:


### PR DESCRIPTION
With reference to: https://github.com/rq/rq/discussions/1828

I decided to completely remove the logger line instead of changing it to `debug`, because in all cases during my observation, there was nothing happening that was worthy of a log. 

In case of a class method, the function moves through each component of the dotted path (raising and catching `ImportError`s as needed) till it found a module to import, which is the expected behavior.