### PR TITLE
improve the docs on in-flight jobs of killed/lost workers

### DIFF
--- a/docs/docs/results.md
+++ b/docs/docs/results.md
@@ -82,6 +82,8 @@ damage. Just sayin'.
 
 If the worker gets killed while a job is running, it will eventually end up in
 `FailedJobRegistry` because a cleanup task will raise an `AbandonedJobError`.
+Before 0.14 the behavor was the same, but the cleanup task raised a
+`Moved to FailedJobRegistry at` error message instead.
 
 ## Dealing with Job Timeouts
 

--- a/docs/docs/results.md
+++ b/docs/docs/results.md
@@ -78,10 +78,12 @@ chance to finish themselves.
 However, workers can be killed forcefully by `kill -9`, which will not give the
 workers a chance to finish the job gracefully or to put the job on the `failed`
 queue.  Therefore, killing a worker forcefully could potentially lead to
-damage.
+damage. Just sayin'.
 
-Just sayin'.
-
+If the worker was killed while a job was running, the job will stay in a zombie
+like state of being worked on, without ever getting finished. `StartedJobRegistry`
+will eventually move it to `FailedJobRegistry` with an `exc_info` value like
+`Moved to FailedJobRegistry at 2023-02-26 23:53:44.867343`.
 
 ## Dealing with Job Timeouts
 

--- a/docs/docs/results.md
+++ b/docs/docs/results.md
@@ -80,10 +80,8 @@ workers a chance to finish the job gracefully or to put the job on the `failed`
 queue.  Therefore, killing a worker forcefully could potentially lead to
 damage. Just sayin'.
 
-If the worker was killed while a job was running, the job will stay in a zombie
-like state of being worked on, without ever getting finished. `StartedJobRegistry`
-will eventually move it to `FailedJobRegistry` with an `exc_info` value like
-`Moved to FailedJobRegistry at 2023-02-26 23:53:44.867343`.
+If the worker gets killed while a job is running, it will eventually end up in
+`FailedJobRegistry` because a cleanup task will raise an `AbandonedJobError`.
 
 ## Dealing with Job Timeouts
 


### PR DESCRIPTION
When a job gets stuck in WIP state, e.g. because the worker was killed or lost its network connection, the job eventually ends up in `FailedJobRegistry` with an `exc_info` value of `Moved to FailedJobRegistry at 2023-02-2(...)`. As far as I can see, this isn't documented anywhere at the moment. This just adds a small paragraph explaining the behavior.

The whole topic of zombie jobs and `StartedJobRegistry.cleanup` probably deserves a dedicated section in the docs. I am just not sure where exactly to put it?