### PR TITLE
Fix TimerDeathPenalty not properly handling negative/infinite timeout

### DIFF
--- a/rq/timeouts.py
+++ b/rq/timeouts.py
@@ -110,10 +110,14 @@ class TimerDeathPenalty(BaseDeathPenalty):
 
     def setup_death_penalty(self):
         """Starts the timer."""
+        if self._timeout <= 0:
+            return
         self._timer = self.new_timer()
         self._timer.start()
 
     def cancel_death_penalty(self):
         """Cancels the timer."""
+        if self._timeout <= 0:
+            return
         self._timer.cancel()
         self._timer = None

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -41,4 +41,11 @@ class TestTimeouts(RQTestCase):
         w.work(burst=True)
         self.assertIn(job, failed_job_registry)
         job.refresh()
-        self.assertIn("rq.timeouts.JobTimeoutException", job.exc_info)
+        self.assertIn("rq.timeouts.JobTimeoutException", job.latest_result().exc_string)
+
+        # Test negative timeout doesn't raise JobTimeoutException,
+        # which implies an unintended immediate timeout.
+        job = q.enqueue(thread_friendly_sleep_func, args=(1,), job_timeout=-1)
+        w.work(burst=True)
+        job.refresh()
+        self.assertIn(job, finished_job_registry)

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -41,7 +41,7 @@ class TestTimeouts(RQTestCase):
         w.work(burst=True)
         self.assertIn(job, failed_job_registry)
         job.refresh()
-        self.assertIn("rq.timeouts.JobTimeoutException", job.latest_result().exc_string)
+        self.assertIn("rq.timeouts.JobTimeoutException", job.exc_info)
 
         # Test negative timeout doesn't raise JobTimeoutException,
         # which implies an unintended immediate timeout.


### PR DESCRIPTION
I believe the intended behavior when job timeout is negative is to have infinite timeout. However, `TimerDeathPenalty` immediately times out jobs instead. This PR fixes that behavior and adds a test for that case.

