### PR TITLE
Update arguments passed to the Sentinel Object when created from the settings

### DIFF
--- a/docs/docs/connections.md
+++ b/docs/docs/connections.md
@@ -138,7 +138,7 @@ automatic restart option allows workers and RQ to have a fault-tolerant connecti
 ```python
 SENTINEL: {
     'INSTANCES':[('remote.host1.org', 26379), ('remote.host2.org', 26379), ('remote.host3.org', 26379)],
-    'MASTER_NAME': 'master'
+    'MASTER_NAME': 'master',
     'DB': 2,
     'USERNAME': 'redis-user',
     'PASSWORD': 'redis-secret',

--- a/docs/docs/connections.md
+++ b/docs/docs/connections.md
@@ -136,11 +136,21 @@ Using this setting in conjunction with the systemd or docker containers with the
 automatic restart option allows workers and RQ to have a fault-tolerant connection to the redis.
 
 ```python
-SENTINEL: {'INSTANCES':[('remote.host1.org', 26379), ('remote.host2.org', 26379), ('remote.host3.org', 26379)],
-           'SOCKET_TIMEOUT': None,
-           'PASSWORD': 'secret',
-           'DB': 2,
-           'MASTER_NAME': 'master'}
+SENTINEL: {
+    'INSTANCES':[('remote.host1.org', 26379), ('remote.host2.org', 26379), ('remote.host3.org', 26379)],
+    'MASTER_NAME': 'master'
+    'DB': 2,
+    'USERNAME': 'redis-user',
+    'PASSWORD': 'redis-secret',
+    'SOCKET_TIMEOUT': None,
+    'CONNECTION_KWARGS': {  # Eventual addition Redis connection arguments
+        'ssl_ca_path': None,
+    },
+    'SENTINEL_KWARGS': {    # Eventual Sentinels connections arguments
+        'username': 'sentinel-user',
+        'password': 'sentinel-secret',
+    },
+}
 ```
 
 

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -33,21 +33,27 @@ def get_redis_from_config(settings, connection_class=Redis):
     """Returns a StrictRedis instance from a dictionary of settings.
     To use redis sentinel, you must specify a dictionary in the configuration file.
     Example of a dictionary with keys without values:
-    SENTINEL = {'INSTANCES':, 'SOCKET_TIMEOUT':, 'PASSWORD':,'DB':, 'MASTER_NAME':}
+    SENTINEL = {'INSTANCES':, 'SOCKET_TIMEOUT':, 'USERNAME':, 'PASSWORD':, 'DB':, 'MASTER_NAME':, 'SENTINEL_KWARGS':}
     """
     if settings.get('REDIS_URL') is not None:
         return connection_class.from_url(settings['REDIS_URL'])
 
     elif settings.get('SENTINEL') is not None:
         instances = settings['SENTINEL'].get('INSTANCES', [('localhost', 26379)])
-        socket_timeout = settings['SENTINEL'].get('SOCKET_TIMEOUT', None)
-        password = settings['SENTINEL'].get('PASSWORD', None)
-        db = settings['SENTINEL'].get('DB', 0)
         master_name = settings['SENTINEL'].get('MASTER_NAME', 'mymaster')
-        ssl = settings['SENTINEL'].get('SSL', False)
-        arguments = {'password': password, 'ssl': ssl}
+        
+        connection_kwargs = {
+            'db': settings['SENTINEL'].get('DB', 0),
+            'username': settings['SENTINEL'].get('USERNAME', None),
+            'password': settings['SENTINEL'].get('PASSWORD', None),
+            'socket_timeout': settings['SENTINEL'].get('SOCKET_TIMEOUT', None),
+            'ssl': settings['SENTINEL'].get('SSL', False),
+        }
+        connection_kwargs.update(settings['SENTINEL'].get('CONNECTION_KWARGS', {}))
+        sentinel_kwargs = settings['SENTINEL'].get('SENTINEL_KWARGS', {})
+        
         sn = Sentinel(
-            instances, socket_timeout=socket_timeout, password=password, db=db, ssl=ssl, sentinel_kwargs=arguments
+            instances, sentinel_kwargs=sentinel_kwargs, **connection_kwargs
         )
         return sn.master_for(master_name)
 


### PR DESCRIPTION
resolves #1849 

- added `USERNAME` key
- added `CONNECTION_KWARGS` key to allow passing additionals arguments to the Redis connections
- updated the documentation