### PR TITLE
add deprecation warnings to connection functions

### DIFF
--- a/rq/connections.py
+++ b/rq/connections.py
@@ -1,6 +1,7 @@
+import warnings
 from contextlib import contextmanager
 from typing import Optional
-import warnings
+
 from redis import Redis
 
 from .local import LocalStack, release_local
@@ -31,7 +32,8 @@ def Connection(connection: Optional['Redis'] = None):  # noqa
         connection (Optional[Redis], optional): A Redis Connection instance. Defaults to None.
     """
     warnings.warn(
-        "The Conneciton context manager is deprecated. Use the `connection` parameter instead.", DeprecationWarning
+        "The Conneciton context manager is deprecated. Use the `connection` parameter instead.",
+        DeprecationWarning,
     )
     if connection is None:
         connection = Redis()
@@ -41,7 +43,8 @@ def Connection(connection: Optional['Redis'] = None):  # noqa
     finally:
         popped = pop_connection()
         assert popped == connection, (
-            'Unexpected Redis connection was popped off the stack. ' 'Check your Redis connection setup.'
+            'Unexpected Redis connection was popped off the stack. '
+            'Check your Redis connection setup.'
         )
 
 
@@ -52,6 +55,10 @@ def push_connection(redis: 'Redis'):
     Args:
         redis (Redis): A Redis connection
     """
+    warnings.warn(
+        "The `push_connection` function is deprecated. Pass the `connection` explicitly instead.",
+        DeprecationWarning,
+    )
     _connection_stack.push(redis)
 
 
@@ -62,6 +69,10 @@ def pop_connection() -> 'Redis':
     Returns:
         redis (Redis): A Redis connection
     """
+    warnings.warn(
+        "The `pop_connection` function is deprecated. Pass the `connection` explicitly instead.",
+        DeprecationWarning,
+    )
     return _connection_stack.pop()
 
 
@@ -73,7 +84,13 @@ def use_connection(redis: Optional['Redis'] = None):
     Args:
         redis (Optional[Redis], optional): A Redis Connection. Defaults to None.
     """
-    assert len(_connection_stack) <= 1, 'You should not mix Connection contexts with use_connection()'
+    warnings.warn(
+        "The `use_connection` function is deprecated. Pass the `connection` explicitly instead.",
+        DeprecationWarning,
+    )
+    assert (
+        len(_connection_stack) <= 1
+    ), 'You should not mix Connection contexts with use_connection()'
     release_local(_connection_stack)
 
     if redis is None:
@@ -89,6 +106,10 @@ def get_current_connection() -> 'Redis':
     Returns:
         Redis: A Redis Connection
     """
+    warnings.warn(
+        "The `get_current_connection` function is deprecated. Pass the `connection` explicitly instead.",
+        DeprecationWarning,
+    )
     return _connection_stack.top
 
 
@@ -106,7 +127,10 @@ def resolve_connection(connection: Optional['Redis'] = None) -> 'Redis':
     Returns:
         Redis: A Redis Connection
     """
-
+    warnings.warn(
+        "The `resolve_connection` function is deprecated. Pass the `connection` explicitly instead.",
+        DeprecationWarning,
+    )
     if connection is not None:
         return connection
 
@@ -118,4 +142,10 @@ def resolve_connection(connection: Optional['Redis'] = None) -> 'Redis':
 
 _connection_stack = LocalStack()
 
-__all__ = ['Connection', 'get_current_connection', 'push_connection', 'pop_connection', 'use_connection']
+__all__ = [
+    'Connection',
+    'get_current_connection',
+    'push_connection',
+    'pop_connection',
+    'use_connection',
+]


### PR DESCRIPTION
Most of the functions on the `connections` module are used to interact with a Redis connection implicitly through the LocalStack: `push/pop/use/resolve_connection`.

The connection ideally should be handled explicitly and the `with Connection` already has a deprecation warning. This adds deprecation warnings to those functions. After these are deprecated, we would be able to delete the `local.py` entirely, and only handle connections explicitly.