### PR TITLE
Added job details to "rq info" command

### DIFF
--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -27,7 +27,7 @@ listen = ['high', 'default', 'low']
 redis_url = os.getenv('REDIS_URL')
 if not redis_url:
     raise RuntimeError("Set up Heroku Data For Redis first, \
-    make sure the its config var is named 'REDIS_URL'.")
+    make sure its config var is named 'REDIS_URL'.")
     
 conn = redis.from_url(redis_url)
 

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -124,9 +124,13 @@ def show_queues(queues, raw, by_queue, queue_class, worker_class):
         count = counts[q]
         if not raw:
             chart = green('|' + '█' * int(ratio * count))
-            line = '%-12s %s %d' % (q.name, chart, count)
+            line = '%-12s %s %d, %d executing, %d finished, %d failed' \
+                    % (q.name, chart, count, q.started_job_registry.count,  \
+                       q.finished_job_registry.count, q.failed_job_registry.count)
         else:
-            line = 'queue %s %d' % (q.name, count)
+            line = 'queue %s %d, %d executing, %d finished, %d failed' \
+                    % (q.name, count, q.started_job_registry.count, \
+                    q.finished_job_registry.count, q.failed_job_registry.count)
         click.echo(line)
 
         num_jobs += count
@@ -151,9 +155,15 @@ def show_workers(queues, raw, by_queue, queue_class, worker_class):
             queue_names = ', '.join(worker.queue_names())
             name = '%s (%s %s %s)' % (worker.name, worker.hostname, worker.ip_address, worker.pid)
             if not raw:
-                click.echo('%s: %s %s' % (name, state_symbol(worker.get_state()), queue_names))
+                line = '%s: %s %s. jobs: %d finished, %d failed' \
+                        % (name, state_symbol(worker.get_state()), queue_names, \
+                           worker.successful_job_count, worker.failed_job_count)
+                click.echo(line)
             else:
-                click.echo('worker %s %s %s' % (name, worker.get_state(), queue_names))
+                line = 'worker %s %s %s. jobs: %d finished, %d failed' \
+                       % (name, worker.get_state(), queue_names,\
+                        worker.successful_job_count, worker.failed_job_count)
+                click.echo(line)
 
     else:
         # Display workers by queue


### PR DESCRIPTION
Each queue and each worker has info about finished/failed jobs
Didn't add ' [num of jobs] executing ' to worker bc it ias the same as 'busy'

```
default      |██████████████ 35, 2 executing, 0 finished, 0 failed
1 queues, 35 jobs total


1a0a9f8ae1364fb4b13bbb7763a4fc74 (None None None): busy . jobs: 0 finished, 1 failed
0bdc85d1b78842a497aef2e7f71b147c (TiH-MacBook-Pro.local [::1]:50568 21446): busy default, high, low. jobs: 0 finished, 0 failed
2 workers, 1 queues```