### PR TITLE
Catch serializer TypeError Exception

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -912,7 +912,11 @@ class Job:
         self.allow_dependency_failures = bool(int(allow_failures)) if allow_failures else None
         self.enqueue_at_front = bool(int(obj['enqueue_at_front'])) if 'enqueue_at_front' in obj else None
         self.ttl = int(obj.get('ttl')) if obj.get('ttl') else None
-        self.meta = self.serializer.loads(obj.get('meta')) if obj.get('meta') else {}
+        try:
+            self.meta = self.serializer.loads(obj.get('meta')) if obj.get('meta') else {}
+        except TypeError:
+            # TypeError: InvalidChunkLength.__init__() missing 1 required positional argument: 'length'
+            self.meta = {'unserialized': obj.get('meta', {})}
 
         self.retries_left = int(obj.get('retries_left')) if obj.get('retries_left') else None
         if obj.get('retry_intervals'):

--- a/rq/job.py
+++ b/rq/job.py
@@ -914,8 +914,7 @@ class Job:
         self.ttl = int(obj.get('ttl')) if obj.get('ttl') else None
         try:
             self.meta = self.serializer.loads(obj.get('meta')) if obj.get('meta') else {}
-        except TypeError:
-            # TypeError: InvalidChunkLength.__init__() missing 1 required positional argument: 'length'
+        except Exception:  # depends on the serializer
             self.meta = {'unserialized': obj.get('meta', {})}
 
         self.retries_left = int(obj.get('retries_left')) if obj.get('retries_left') else None


### PR DESCRIPTION
@selwin I came into a rare error where a job meta is stored on job_failure, but it crashes the worker when loading the job (the worker fails completely)

Please let me know how to go about it. In the meantime, I'm using this branch...