### PR TITLE
Add py.typed for PEP561 compliance

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
                 'jobs, and processing them.',
     long_description=__doc__,
     packages=find_packages(exclude=['tests', 'tests.*']),
+    package_data = {"rq": ["py.typed"]},
     include_package_data=True,
     zip_safe=False,
     platforms='any',


### PR DESCRIPTION
This allows external projects that use type checkers themselves to read the typing information that RQ contains.

Without this file, compliant type-checkers will skip type checks for project code that calls RQ.

Fixes #1881

Note: this PR should be backwards compatible to pretty much any branch, so if there are more versions maintained than just master branch, applying the same patch to them would allow older versions to type check without upgrading to the latest version of RQ.

## Test Plan
1. Create test file `example.py`:
```lang=py
from redis import Redis
from rq import Queue

q = Queue(connection=Redis())
result = q.enqueue(sum, [1,2,3,4,5])
```
2. (optional: create virtual environment first) Install dependencies
    `pip install mypy redis types-redis rq`
3. Run MyPy `mypy example.py`
    Should observe MyPy `import` error.
4. Build new version of RQ `python3 setup.py bdist_wheel`
5. Install new version of RQ `pip install ./path/to/rq/dist/rq-1.13.0-py2.py3-none-any.whl`
6. Re-run MyPy (step 3)
    Observe no errors