### PR TITLE
[Fix] Allow custom connection pool class for the scheduler

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,6 @@
 import os
+import redis
+
 from datetime import datetime, timedelta, timezone
 from multiprocessing import Process
 from unittest import mock
@@ -14,6 +16,17 @@ from rq.utils import current_timestamp
 from rq.worker import Worker
 from tests import RQTestCase, find_empty_redis_database, ssl_test
 from .fixtures import kill_worker, say_hello
+
+
+class CustomRedisConnection(redis.Connection):
+    """Custom redis connection with a custom arg, used in test_custom_connection_pool"""
+
+    def __init__(self, *args, custom_arg=None, **kwargs):
+        self.custom_arg = custom_arg
+        super().__init__(*args, **kwargs)
+
+    def get_custom_arg(self):
+        return self.custom_arg
 
 
 class TestScheduledJobRegistry(RQTestCase):
@@ -431,3 +444,34 @@ class TestQueue(RQTestCase):
         job = queue.enqueue_in(timedelta(seconds=30), say_hello, retry=Retry(3, [2]))
         self.assertEqual(job.retries_left, 3)
         self.assertEqual(job.retry_intervals, [2])
+
+    def test_custom_connection_pool(self):
+        """Connection pool customizing. Ensure that we can properly set a
+        custom connection pool class and pass extra arguments"""
+        custom_conn = redis.Redis(
+            connection_pool=redis.ConnectionPool(
+                connection_class=CustomRedisConnection,
+                db=4,
+                custom_arg="foo",
+            )
+        )
+
+        queue = Queue(connection=custom_conn)
+        scheduler = RQScheduler([queue], connection=custom_conn)
+
+        scheduler_connection = scheduler.connection.connection_pool.get_connection('info')
+
+        self.assertEqual(scheduler_connection.__class__, CustomRedisConnection)
+        self.assertEqual(scheduler_connection.get_custom_arg(), "foo")
+
+    def test_no_custom_connection_pool(self):
+        """Connection pool customizing must not interfere if we're using a standard
+        connection (non-pooled)"""
+        standard_conn = redis.Redis(db=5)
+
+        queue = Queue(connection=standard_conn)
+        scheduler = RQScheduler([queue], connection=standard_conn)
+
+        scheduler_connection = scheduler.connection.connection_pool.get_connection('info')
+
+        self.assertEqual(scheduler_connection.__class__, redis.Connection)


### PR DESCRIPTION
Following https://github.com/rq/rq/issues/1879, I'm proposing a change to allow passing a **custom connection class to the scheduler**;

To date, we can pass a custom connection to a worker with:

```python
my_custom_conn = redis.Redis(
    connection_pool=redis.ConnectionPool(
        connection_class=CustomRedisConnection,
        custom_arg="foo",
    )
)
worker = Worker(connection=my_custom_conn)
worker.work()
```

but doing so while enabling the scheduler will raise:
```python
worker.work(with_scheduler=True)
# raises:
# TypeError: Redis.__init__() got an unexpected 
# keyword argument 'custom_arg'
```


Passing extra arguments to the connection pool class is a standard feature in redis-py, as per the [documentation](https://redis.readthedocs.io/en/stable/connections.html#redis.connection.ConnectionPool).

I added 2 tests to verify that the custom connection class is indeed used, and that it does not interfere with the actual behavior (ie, using a standard `Redis` client).

_meta: I haven't found in the repo anything about the code standards / formatting / etc — feel free to point me to your contributing guidelines if needed_

Best regards,