### PR TITLE
[Results] Allow unserializable return values

### DIFF
--- a/rq/defaults.py
+++ b/rq/defaults.py
@@ -94,3 +94,9 @@ DEFAULT_DEATH_PENALTY_CLASS = 'rq.timeouts.UnixSignalDeathPenalty'
 """ The path for the default Death Penalty class to use.
 Defaults to the `UnixSignalDeathPenalty` class within the `rq.timeouts` module
 """
+
+
+UNSERIALIZABLE_RETURN_VALUE_PAYLOAD = 'Unserializable return value'
+""" The value that we store in the job's _result property or in the Result's return_value
+in case the return value of the actual job is not serializable
+"""

--- a/rq/job.py
+++ b/rq/job.py
@@ -11,7 +11,7 @@ from redis import WatchError
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, Type
 from uuid import uuid4
 
-from .defaults import CALLBACK_TIMEOUT
+from .defaults import CALLBACK_TIMEOUT, UNSERIALIZABLE_RETURN_VALUE_PAYLOAD
 from .timeouts import JobTimeoutException, BaseDeathPenalty
 
 if TYPE_CHECKING:
@@ -887,7 +887,7 @@ class Job:
             try:
                 self._result = self.serializer.loads(result)
             except Exception:
-                self._result = "Unserializable return value"
+                self._result = UNSERIALIZABLE_RETURN_VALUE_PAYLOAD
         self.timeout = parse_timeout(obj.get('timeout')) if obj.get('timeout') else None
         self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None
         self.failure_ttl = int(obj.get('failure_ttl')) if obj.get('failure_ttl') else None

--- a/rq/results.py
+++ b/rq/results.py
@@ -181,7 +181,11 @@ class Result:
         if self.exc_string is not None:
             data['exc_string'] = b64encode(zlib.compress(self.exc_string.encode())).decode()
 
-        serialized = self.serializer.dumps(self.return_value)
+        try:
+            serialized = self.serializer.dumps(self.return_value)
+        except:  # noqa
+            return data
+
         if self.return_value is not None:
             data['return_value'] = b64encode(serialized).decode()
 

--- a/rq/results.py
+++ b/rq/results.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from redis import Redis
 
+from .defaults import UNSERIALIZABLE_RETURN_VALUE_PAYLOAD
 from .utils import decode_redis_hash
 from .job import Job
 from .serializers import resolve_serializer
@@ -184,7 +185,7 @@ class Result:
         try:
             serialized = self.serializer.dumps(self.return_value)
         except:  # noqa
-            return data
+            serialized = self.serializer.dumps(UNSERIALIZABLE_RETURN_VALUE_PAYLOAD)
 
         if self.return_value is not None:
             data['return_value'] = b64encode(serialized).decode()

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -8,6 +8,7 @@ from redis import Redis
 
 from tests import RQTestCase
 
+from rq.defaults import UNSERIALIZABLE_RETURN_VALUE_PAYLOAD
 from rq.job import Job
 from rq.queue import Queue
 from rq.registry import StartedJobRegistry
@@ -248,7 +249,7 @@ class TestScheduledJobRegistry(RQTestCase):
 
         # tempfile.NamedTemporaryFile() is not picklable
         Result.create(job, Result.Type.SUCCESSFUL, ttl=10, return_value=tempfile.NamedTemporaryFile())
-        self.assertIsNone(job.return_value())
+        self.assertEqual(job.return_value(), UNSERIALIZABLE_RETURN_VALUE_PAYLOAD)
         self.assertEqual(Result.count(job), 1)
 
         Result.create(job, Result.Type.SUCCESSFUL, ttl=10, return_value=1)


### PR DESCRIPTION
Hi 👋🏼 

Before RQ 1.12, RQ was actually allowing unserializable results in `job.save()` ([here](https://github.com/rq/rq/blob/master/rq/job.py#L977)):

```python
# note the try/except
try:
    obj['result'] = self.serializer.dumps(self._result)
except:  # noqa
    obj['result'] = "Unserializable return value"
```

RQ 1.12 introduced a breaking change in this regard, as we're now storing the result also in a proper `Result` object to keep multiple results ([here](https://github.com/rq/rq/blob/master/rq/results.py#L184)):

```python
# no try/except block here
serialized = self.serializer.dumps(self.return_value)
```

This PR proposes to be less strict and allow unserializable results (as before).
I'm also adding a test that tries to save a known non-picklable value (`tempfile.NamedTemporaryFile()`) to assess that it doesn't break


Happy to have feedback and adapt the code if needed
Thanks a lot!
