### PR TITLE
[Hotfix] Fix SSL connection for scheduler

### DIFF
--- a/rq/connections.py
+++ b/rq/connections.py
@@ -118,23 +118,10 @@ def resolve_connection(connection: Optional['Redis'] = None) -> 'Redis':
 
 
 def parse_connection(connection: Redis) -> Tuple[Type[Redis], Type[RedisConnection], dict]:
-    connection_kwargs = connection.connection_pool.connection_kwargs.copy()
-    # Redis does not accept parser_class argument which is sometimes present
-    # on connection_pool kwargs, for example when hiredis is used
-    connection_kwargs.pop('parser_class', None)
+    connection_pool_kwargs = connection.connection_pool.connection_kwargs.copy()
     connection_pool_class = connection.connection_pool.connection_class
-    if issubclass(connection_pool_class, SSLConnection):
-        connection_kwargs['ssl'] = True
-    if issubclass(connection_pool_class, UnixDomainSocketConnection):
-        # The connection keyword arguments are obtained from
-        # `UnixDomainSocketConnection`, which expects `path`, but passed to
-        # `redis.client.Redis`, which expects `unix_socket_path`, renaming
-        # the key is necessary.
-        # `path` is not left in the dictionary as that keyword argument is
-        # not expected by `redis.client.Redis` and would raise an exception.
-        connection_kwargs['unix_socket_path'] = connection_kwargs.pop('path')
 
-    return connection.__class__, connection_pool_class, connection_kwargs
+    return connection.__class__, connection_pool_class, connection_pool_kwargs
 
 
 _connection_stack = LocalStack()

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -50,7 +50,7 @@ class RQScheduler:
         self._acquired_locks: Set[str] = set()
         self._scheduled_job_registries: List[ScheduledJobRegistry] = []
         self.lock_acquisition_time = None
-        self._connection_class, self._pool_class, self._connection_kwargs = parse_connection(connection)
+        self._connection_class, self._pool_class, self._pool_kwargs = parse_connection(connection)
         self.serializer = resolve_serializer(serializer)
 
         self._connection = None
@@ -71,7 +71,7 @@ class RQScheduler:
         if self._connection:
             return self._connection
         self._connection = self._connection_class(
-            connection_pool=ConnectionPool(connection_class=self._pool_class, **self._connection_kwargs)
+            connection_pool=ConnectionPool(connection_class=self._pool_class, **self._pool_kwargs)
         )
         return self._connection
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -36,12 +36,3 @@ class TestConnectionInheritance(RQTestCase):
         job2 = q2.enqueue(do_nothing)
         self.assertEqual(q1.connection, job1.connection)
         self.assertEqual(q2.connection, job2.connection)
-
-    def test_parse_connection(self):
-        """Test parsing `ssl` and UnixDomainSocketConnection"""
-        _, _, kwargs = parse_connection(Redis(ssl=True))
-        self.assertTrue(kwargs['ssl'])
-        path = '/tmp/redis.sock'
-        pool = ConnectionPool(connection_class=UnixDomainSocketConnection, path=path)
-        _, _, kwargs = parse_connection(Redis(connection_pool=pool))
-        self.assertTrue(kwargs['unix_socket_path'], path)

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -8,6 +8,7 @@ from rq.job import JobStatus
 from tests import TestCase
 from tests.fixtures import CustomJob, _send_shutdown_command, long_running_job, say_hello
 
+from rq.connections import parse_connection
 from rq.queue import Queue
 from rq.serializers import JSONSerializer
 from rq.worker import SimpleWorker
@@ -108,8 +109,10 @@ class TestWorkerPool(TestCase):
         """Ensure run_worker() properly spawns a Worker"""
         queue = Queue('foo', connection=self.connection)
         queue.enqueue(say_hello)
+
+        connection_class, pool_class, pool_kwargs = parse_connection(self.connection)
         run_worker(
-            'test-worker', ['foo'], self.connection.__class__, self.connection.connection_pool.connection_kwargs.copy()
+            'test-worker', ['foo'], connection_class, pool_class, pool_kwargs
         )
         # Worker should have processed the job
         self.assertEqual(len(queue), 0)


### PR DESCRIPTION
It seems that we were unnecessarily [changing the connection pool kwargs](https://github.com/tchapi/rq/blob/5bf8239ea2a8378a6d0e344fcf80aaa07bcb37f3/rq/connections.py#L126-L135) because we were trying to pass them to a Client instead of a ConnectionPool:

```python
if issubclass(connection_pool_class, SSLConnection):
    connection_kwargs['ssl'] = True
if issubclass(connection_pool_class, UnixDomainSocketConnection):
    # The connection keyword arguments are obtained from
    # `UnixDomainSocketConnection`, which expects `path`, but passed to
    # `redis.client.Redis`, which expects `unix_socket_path`, renaming
    # the key is necessary.
    # `path` is not left in the dictionary as that keyword argument is
    # not expected by `redis.client.Redis` and would raise an exception.
    connection_kwargs['unix_socket_path'] = connection_kwargs.pop('path')
```

Now that we're correctly using a ConnectionPool (since #1885), we don't need those changes anymore