### PR TITLE
[Chore] Fix test suite

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,6 +10,23 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  test-with-ssl:
+    name: Test all, including SSL tests
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker test image for tox
+      uses: docker/build-push-action@v2
+      with:
+        file: tests/Dockerfile
+        tags: rqtest-image:latest
+        push: false
+    - name: Launch tox for all test scenarii
+      uses: addnab/docker-run-action@v3
+      with:
+        image: rqtest-image:latest
+        run: stunnel & redis-server & RUN_SSL_TESTS=1 tox
+
   test:
     name: Python${{ matrix.python-version }}/Redis${{ matrix.redis-version }}/redis-py${{ matrix.redis-py-version }}
     runs-on: ubuntu-20.04

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ deps=
     sentry-sdk
     codecov
     psutil
+passenv=
+    RUN_SSL_TESTS
+    RUN_SLOW_TESTS_TOO
 
 [testenv:flake8]
 basepython = python3.6


### PR DESCRIPTION
**Problem 1️⃣**
 
Environment variables are not passed to pytest via tox if they are not explicitly registered in the tox configuration
The SSL tests and SLOW tests were not run while using `make test` 

**Problem 2️⃣**

SSL tests were not run by the Github actions since it requires a TLS-enabled Redis instance. To correct this, I use the repository Dockerfile to spin off the complete test suite in Docker, with the correct Redis server. This is a supplementary job to be run by the CI -  it's quite long but we may be able to limit it to only the SSL tests? Happy to discuss

~As expected (I'm based on the `master` branch), the tests fail in the same way than this: https://github.com/rq/rq/issues/1892, but https://github.com/rq/rq/pull/1894 will fix it~

