### PR TITLE
Stop calling deprecated function `resolve_connection`

### DIFF
--- a/rq/connections.py
+++ b/rq/connections.py
@@ -1,8 +1,8 @@
 import warnings
 from contextlib import contextmanager
-from typing import Any, Optional, Tuple, Type
+from typing import Optional, Tuple, Type
 
-from redis import Connection as RedisConnection, Redis, SSLConnection, UnixDomainSocketConnection
+from redis import Connection as RedisConnection, Redis
 
 from .local import LocalStack
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -532,9 +532,10 @@ class Job:
         Returns:
             job_exists (bool): Whether the Job exists
         """
-        conn = resolve_connection(connection)
+        if not connection:
+            connection = resolve_connection()
         job_key = cls.key_for(job_id)
-        job_exists = conn.exists(job_key)
+        job_exists = connection.exists(job_key)
         return bool(job_exists)
 
     @classmethod
@@ -587,7 +588,10 @@ class Job:
         return jobs
 
     def __init__(self, id: Optional[str] = None, connection: Optional['Redis'] = None, serializer=None):
-        self.connection = resolve_connection(connection)
+        if connection:
+            self.connection = connection
+        else:
+            self.connection = resolve_connection()
         self._id = id
         self.created_at = utcnow()
         self._data = UNEVALUATED

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -22,7 +22,7 @@ from .connections import resolve_connection
 from .defaults import DEFAULT_RESULT_TTL
 from .exceptions import DequeueTimeout, NoSuchJobError
 from .job import Job, JobStatus
-from .logutils import blue, green, yellow
+from .logutils import blue, green
 from .types import FunctionReferenceType, JobDependencyType
 from .serializers import resolve_serializer
 from .utils import backend_class, get_version, import_attribute, parse_timeout, utcnow, compact
@@ -86,7 +86,7 @@ class Queue:
         Returns:
             queues (List[Queue]): A list of all queues.
         """
-        connection = resolve_connection(connection)
+        connection = connection or resolve_connection()
 
         def to_queue(queue_key: Union[bytes, str]):
             return cls.from_queue_key(
@@ -162,7 +162,7 @@ class Queue:
             serializer (Any, optional): Serializer. Defaults to None.
             death_penalty_class (Type[BaseDeathPenalty, optional): Job class or a string referencing the Job class path. Defaults to UnixSignalDeathPenalty.
         """
-        self.connection = resolve_connection(connection)
+        self.connection = connection or resolve_connection()
         prefix = self.redis_queue_namespace_prefix
         self.name = name
         self._key = '{0}{1}'.format(prefix, name)
@@ -1198,7 +1198,7 @@ class Queue:
         Returns:
             _type_: _description_
         """
-        connection = resolve_connection(connection)
+        connection = connection or resolve_connection()
         if timeout is not None:  # blocking variant
             if timeout == 0:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, List, Optional, Type, Union
 
-from .timeouts import JobTimeoutException, UnixSignalDeathPenalty, BaseDeathPenalty
+from .timeouts import UnixSignalDeathPenalty, BaseDeathPenalty
 
 if TYPE_CHECKING:
     from redis import Redis
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 from .utils import as_text
 from .connections import resolve_connection
-from .defaults import DEFAULT_FAILURE_TTL, CALLBACK_TIMEOUT
+from .defaults import DEFAULT_FAILURE_TTL
 from .exceptions import InvalidJobOperation, NoSuchJobError, AbandonedJobError
 from .job import Job, JobStatus
 from .queue import Queue
@@ -47,11 +47,11 @@ class BaseRegistry:
     ):
         if queue:
             self.name = queue.name
-            self.connection = resolve_connection(queue.connection)
+            self.connection = queue.connection or resolve_connection()
             self.serializer = queue.serializer
         else:
             self.name = name
-            self.connection = resolve_connection(connection)
+            self.connection = connection or resolve_connection()
             self.serializer = resolve_serializer(serializer)
 
         self.key = self.key_template.format(self.name)


### PR DESCRIPTION
Fix #1907

The function `resolve_connection` is now deprecated and doesn't need to be called from lots of places by default.

Now `resolve_connection` will only be called if `connection` has not been passed through already.

This should probably be done for `push_connection` also, but not in this PR.