### PR TITLE
[Tests] Only run SSL tests in Docker

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,11 +21,11 @@ jobs:
         file: tests/Dockerfile
         tags: rqtest-image:latest
         push: false
-    - name: Launch tox for all test scenarii
+    - name: Launch tox SSL env only (will only run SSL specific tests)
       uses: addnab/docker-run-action@v3
       with:
         image: rqtest-image:latest
-        run: stunnel & redis-server & RUN_SSL_TESTS=1 tox
+        run: stunnel & redis-server & RUN_SSL_TESTS=1 tox run -e ssl
 
   test:
     name: Python${{ matrix.python-version }}/Redis${{ matrix.redis-version }}/redis-py${{ matrix.redis-py-version }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
-  test-with-ssl:
-    name: Test all, including SSL tests
+  ssl-test:
+    name: Run SSL tests
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 import unittest
 
+import pytest
 from redis import Redis
 
 from rq import pop_connection, push_connection
@@ -25,10 +26,12 @@ def find_empty_redis_database(ssl=False):
 
 
 def slow(f):
+    f = pytest.mark.slow(f)
     return unittest.skipUnless(os.environ.get('RUN_SLOW_TESTS_TOO'), "Slow tests disabled")(f)
 
 
 def ssl_test(f):
+    f = pytest.mark.ssl_test(f)
     return unittest.skipUnless(os.environ.get('RUN_SSL_TESTS'), "SSL tests disabled")(f)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,3 +45,14 @@ deps = {[testenv]deps}
 skipdist = True
 basepython = python3.10
 deps = {[testenv]deps}
+
+[testenv:ssl]
+skipdist = True
+basepython = python3.10
+deps=
+    pytest
+    sentry-sdk
+    psutil
+passenv=
+    RUN_SSL_TESTS
+commands=pytest -m ssl_test {posargs}


### PR DESCRIPTION
### Rationale

Following [this comment](https://github.com/rq/rq/pull/1911#issuecomment-1552758192):
- actually we only test Ubuntu's packaged Redis version (5.0.7 if I'm [not mistaken](https://packages.ubuntu.com/focal/database/redis))
- it takes a while because all tests are run for every tox env
- I'm proposing a modification so that only specific SSL tests are run on the `ssl-test` job, and only for the Python 3.10 env (_see tox config file_)
- We still only test against 5.0.7 but I think it's fine for now

### Result:

It's quicker now.

<img width="493" alt="Screenshot 2023-05-21 at 22 06 15" src="https://github.com/tchapi/rq/assets/1944007/c66dbe8f-cd7c-4a69-a63f-c6007d6a2921">

