### PR TITLE
dont append exc_string to log message

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.6.0
+      uses: actions/setup-python@v4.6.1
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -56,7 +56,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.6.0
+      uses: actions/setup-python@v4.6.1
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v4.6.0
+      uses: actions/setup-python@v4.6.1
       with:
         python-version: 3.8
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.6.0
+      uses: actions/setup-python@v4.6.1
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -80,7 +80,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.6.0
+      uses: actions/setup-python@v4.6.1
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,12 @@
 ### RQ 1.15 (2023-05-24)
 * Added `Callback(on_stopped='my_callback)`. Thanks @eswolinsky3241!
+* `Callback` now accepts dotted path to function as input. Thanks @rishabh-ranjan!
 * `queue.enqueue_many()` now supports job dependencies. Thanks @eswolinsky3241!
 * `rq worker` CLI script now configures logging based on `DICT_CONFIG` key present in config file. Thanks @juur!
 * Whenever possible, `Worker` now uses `lmove()` to implement [reliable queue pattern](https://redis.io/commands/lmove/). Thanks @selwin!
 * `Scheduler` should only release locks that it successfully acquires. Thanks @xzander!
 * Fixes crashes that may happen by changes to `as_text()` function in v1.14. Thanks @tchapi!
+* Various linting, CI and code quality improvements. Thanks @robhudson!
 
 ### RQ 1.14.1 (2023-05-05)
 * Fixes a crash that happens if Redis connection uses SSL. Thanks @tchapi!

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -131,8 +131,7 @@ with q.connection.pipeline() as pipe:
   pipe.execute()
 ```
 
-`Queue.prepare_data` accepts all arguments that `Queue.parse_args` does **EXCEPT** for `depends_on`,
-which is not supported at this time, so dependencies will be up to you to setup.
+`Queue.prepare_data` accepts all arguments that `Queue.parse_args` does.
 
 ## Job dependencies
 
@@ -195,18 +194,18 @@ job_2 = queue.enqueue(say_hello, depends_on=dependency)
 ## Job Callbacks
 _New in version 1.9.0._
 
-If you want to execute a function whenever a job completes or fails, RQ provides
-`on_success` and `on_failure` callbacks.
+If you want to execute a function whenever a job completes, fails, or is stopped, RQ provides
+`on_success`, `on_failure`, and `on_stopped` callbacks.
 
 ```python
-queue.enqueue(say_hello, on_success=report_success, on_failure=report_failure)
+queue.enqueue(say_hello, on_success=report_success, on_failure=report_failure, on_stopped=report_stopped)
 ```
 
 ### Callback Class and Callback Timeouts
 
 _New in version 1.14.0_
 
-RQ lets you configure the method and timeout for each callback - success and failure.   
+RQ lets you configure the method and timeout for each callback - success, failure, and stopped.   
 To configure callback timeouts, use RQ's
 `Callback` object that accepts `func` and `timeout` arguments. For example:
 
@@ -214,7 +213,8 @@ To configure callback timeouts, use RQ's
 from rq import Callback
 queue.enqueue(say_hello, 
               on_success=Callback(report_success),  # default callback timeout (60 seconds) 
-              on_failure=Callback(report_failure, timeout=10))  # 10 seconds timeout
+              on_failure=Callback(report_failure, timeout=10), # 10 seconds timeout
+              on_stopped=Callback(report_stopped, timeout="2m")) # 2 minute timeout  
 ```
 
 ### Success Callback
@@ -247,6 +247,19 @@ def report_failure(job, connection, type, value, traceback):
 ```
 
 Failure callbacks are limited to 60 seconds of execution time.
+
+
+### Stopped Callbacks
+
+Stopped callbacks are functions that accept `job` and `connection` arguments.
+
+```python
+def report_stopped(job, connection):
+  pass
+```
+
+Stopped callbacks are functions that are executed when a worker receives a command to stop
+a job that is currently executing. See [Stopping a Job](https://python-rq.org/docs/workers/#stopping-a-job).
 
 
 ### CLI Enqueueing

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -77,6 +77,7 @@ results are kept. Expired jobs will be automatically deleted. Defaults to 500 se
 * `description` to add additional description to enqueued jobs.
 * `on_success` allows you to run a function after a job completes successfully
 * `on_failure` allows you to run a function after a job fails
+* `on_stopped` allows you to run a function after a job is stopped
 * `args` and `kwargs`: use these to explicitly pass arguments and keyword to the
   underlying job function. This is useful if your function happens to have
   conflicting argument names with RQ, for example `description` or `ttl`.
@@ -216,6 +217,8 @@ queue.enqueue(say_hello,
               on_failure=Callback(report_failure, timeout=10), # 10 seconds timeout
               on_stopped=Callback(report_stopped, timeout="2m")) # 2 minute timeout  
 ```
+
+You can also pass the function as a string reference: `Callback('my_package.my_module.my_func')`
 
 ### Success Callback
 

--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from .job import Retry
 
 from .defaults import DEFAULT_RESULT_TTL
+from .job import Callback
 from .queue import Queue
 from .utils import backend_class
 
@@ -28,9 +29,9 @@ class job:  # noqa
         description: Optional[str] = None,
         failure_ttl: Optional[int] = None,
         retry: Optional['Retry'] = None,
-        on_failure: Optional[Callable[..., Any]] = None,
-        on_success: Optional[Callable[..., Any]] = None,
-        on_stopped: Optional[Callable[..., Any]] = None,
+        on_failure: Optional[Union[Callback, Callable[..., Any]]] = None,
+        on_success: Optional[Union[Callback, Callable[..., Any]]] = None,
+        on_stopped: Optional[Union[Callback, Callable[..., Any]]] = None,
     ):
         """A decorator that adds a ``delay`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required
@@ -59,9 +60,12 @@ class job:  # noqa
             description (Optional[str], optional): Job description. Defaults to None.
             failure_ttl (Optional[int], optional): Failture time to live. Defaults to None.
             retry (Optional[Retry], optional): A Retry object. Defaults to None.
-            on_failure (Optional[Callable[..., Any]], optional): Callable to run on failure. Defaults to None.
-            on_success (Optional[Callable[..., Any]], optional): Callable to run on success. Defaults to None.
-            on_stopped (Optional[Callable[..., Any]], optional): Callable to run when stopped. Defaults to None.
+            on_failure (Optional[Union[Callback, Callable[..., Any]]], optional): Callable to run on failure. Defaults
+                to None.
+            on_success (Optional[Union[Callback, Callable[..., Any]]], optional): Callable to run on success. Defaults
+                to None.
+            on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callable to run when stopped. Defaults
+                to None.
         """
         self.queue = queue
         self.queue_class = backend_class(self, 'queue_class', override=queue_class)

--- a/rq/defaults.py
+++ b/rq/defaults.py
@@ -71,8 +71,8 @@ in seconds. Defaults to 10 minutes.
 
 CALLBACK_TIMEOUT = 60
 """ The timeout period in seconds for Callback functions
-Means that Functions used in `success_callback` and `failure_callback`
-will timeout after N seconds
+Means that Functions used in `success_callback`, `stopped_callback`,
+and `failure_callback` will timeout after N seconds
 """
 
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -158,9 +158,9 @@ class Job:
         failure_ttl: Optional[int] = None,
         serializer=None,
         *,
-        on_success: Optional[Union['Callback', Callable[..., Any]]] = None,
-        on_failure: Optional[Union['Callback', Callable[..., Any]]] = None,
-        on_stopped: Optional[Union['Callback', Callable[..., Any]]] = None,
+        on_success: Optional[Union['Callback', Callable[..., Any]]] = None,  # Callable is deprecated
+        on_failure: Optional[Union['Callback', Callable[..., Any]]] = None,  # Callable is deprecated
+        on_stopped: Optional[Union['Callback', Callable[..., Any]]] = None,  # Callable is deprecated
     ) -> 'Job':
         """Creates a new Job instance for the given function, arguments, and
         keyword arguments.
@@ -193,20 +193,20 @@ class Job:
                 Defaults to None.
             serializer (Optional[str], optional): The serializer class path to use. Should be a string with the import
                 path for the serializer to use. eg. `mymodule.myfile.MySerializer` Defaults to None.
-            on_success (Optional[Callable[..., Any]], optional): A callback function, should be a callable to run
-                when/if the Job finishes sucessfully. Defaults to None.
-            on_failure (Optional[Callable[..., Any]], optional): A callback function, should be a callable to run
-                when/if the Job fails. Defaults to None.
-            on_stopped (Optional[Callable[..., Any]], optional): A callback function, should be a callable to run
-                when/if the Job is stopped. Defaults to None.
+            on_success (Optional[Union['Callback', Callable[..., Any]]], optional): A callback to run when/if the Job
+                finishes sucessfully. Defaults to None. Passing a callable is deprecated.
+            on_failure (Optional[Union['Callback', Callable[..., Any]]], optional): A callback to run when/if the Job
+                fails. Defaults to None. Passing a callable is deprecated.
+            on_stopped (Optional[Union['Callback', Callable[..., Any]]], optional): A callback to run when/if the Job
+                is stopped. Defaults to None. Passing a callable is deprecated.
 
         Raises:
             TypeError: If `args` is not a tuple/list
             TypeError: If `kwargs` is not a dict
             TypeError: If the `func` is something other than a string or a Callable reference
-            ValueError: If `on_failure` is not a function
-            ValueError: If `on_success` is not a function
-            ValueError: If `on_stopped` is not a function
+            ValueError: If `on_failure` is not a Callback or function or string
+            ValueError: If `on_success` is not a Callback or function or string
+            ValueError: If `on_stopped` is not a Callback or function or string
 
         Returns:
             Job: A job instance.
@@ -248,7 +248,8 @@ class Job:
         if on_success:
             if not isinstance(on_success, Callback):
                 warnings.warn(
-                    'Passing a `Callable` `on_success` is deprecated, pass `Callback` instead', DeprecationWarning
+                    'Passing a string or function for `on_success` is deprecated, pass `Callback` instead',
+                    DeprecationWarning,
                 )
                 on_success = Callback(on_success)  # backward compatibility
             job._success_callback_name = on_success.name
@@ -257,7 +258,8 @@ class Job:
         if on_failure:
             if not isinstance(on_failure, Callback):
                 warnings.warn(
-                    'Passing a `Callable` `on_failure` is deprecated, pass `Callback` instead', DeprecationWarning
+                    'Passing a string or function for `on_failure` is deprecated, pass `Callback` instead',
+                    DeprecationWarning,
                 )
                 on_failure = Callback(on_failure)  # backward compatibility
             job._failure_callback_name = on_failure.name
@@ -266,7 +268,8 @@ class Job:
         if on_stopped:
             if not isinstance(on_stopped, Callback):
                 warnings.warn(
-                    'Passing a `Callable` `on_stopped` is deprecated, pass `Callback` instead', DeprecationWarning
+                    'Passing a string or function for `on_stopped` is deprecated, pass `Callback` instead',
+                    DeprecationWarning,
                 )
                 on_stopped = Callback(on_stopped)  # backward compatibility
             job._stopped_callback_name = on_stopped.name
@@ -1640,13 +1643,15 @@ class Retry:
 
 
 class Callback:
-    def __init__(self, func: Callable[..., Any], timeout: Optional[Any] = None):
-        if not inspect.isfunction(func) and not inspect.isbuiltin(func):
-            raise ValueError('Callback func must be a function')
+    def __init__(self, func: Union[str, Callable[..., Any]], timeout: Optional[Any] = None):
+        if not isinstance(func, str) and not inspect.isfunction(func) and not inspect.isbuiltin(func):
+            raise ValueError('Callback `func` must be a string or function')
 
         self.func = func
         self.timeout = parse_timeout(timeout) if timeout else CALLBACK_TIMEOUT
 
     @property
     def name(self) -> str:
+        if isinstance(self.func, str):
+            return self.func
         return '{0}.{1}'.format(self.func.__module__, self.func.__qualname__)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -22,7 +22,7 @@ from .connections import resolve_connection
 from .defaults import DEFAULT_RESULT_TTL
 from .dependency import Dependency
 from .exceptions import DequeueTimeout, NoSuchJobError
-from .job import Job, JobStatus
+from .job import Callback, Job, JobStatus
 from .logutils import blue, green
 from .serializers import resolve_serializer
 from .types import FunctionReferenceType, JobDependencyType
@@ -515,9 +515,9 @@ class Queue:
         status: JobStatus = JobStatus.QUEUED,
         retry: Optional['Retry'] = None,
         *,
-        on_success: Optional[Callable] = None,
-        on_failure: Optional[Callable] = None,
-        on_stopped: Optional[Callable] = None,
+        on_success: Optional[Union[Callback, Callable]] = None,
+        on_failure: Optional[Union[Callback, Callable]] = None,
+        on_stopped: Optional[Union[Callback, Callable]] = None,
     ) -> Job:
         """Creates a job based on parameters given
 
@@ -535,9 +535,13 @@ class Queue:
             meta (Optional[Dict], optional): Job metadata. Defaults to None.
             status (JobStatus, optional): Job status. Defaults to JobStatus.QUEUED.
             retry (Optional[Retry], optional): The Retry Object. Defaults to None.
-            on_success (Optional[Callable], optional): On success callable. Defaults to None.
-            on_failure (Optional[Callable], optional): On failure callable. Defaults to None.
-            on_stopped (Optional[Callable], optional): On stopped callable. Defaults to None.
+            on_success (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on success. Defaults to
+                None. Callable is deprecated.
+            on_failure (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on failure. Defaults to
+                None. Callable is deprecated.
+            on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on stopped. Defaults to
+                None. Callable is deprecated.
+            pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
 
         Raises:
             ValueError: If the timeout is 0
@@ -659,9 +663,9 @@ class Queue:
         at_front: bool = False,
         meta: Optional[Dict] = None,
         retry: Optional['Retry'] = None,
-        on_success: Optional[Callable[..., Any]] = None,
-        on_failure: Optional[Callable[..., Any]] = None,
-        on_stopped: Optional[Callable[..., Any]] = None,
+        on_success: Optional[Union[Callback, Callable[..., Any]]] = None,
+        on_failure: Optional[Union[Callback, Callable[..., Any]]] = None,
+        on_stopped: Optional[Union[Callback, Callable[..., Any]]] = None,
         pipeline: Optional['Pipeline'] = None,
     ) -> Job:
         """Creates a job to represent the delayed function call and enqueues it.
@@ -684,9 +688,12 @@ class Queue:
             at_front (bool, optional): Whether to enqueue the job at the front. Defaults to False.
             meta (Optional[Dict], optional): Metadata to attach to the job. Defaults to None.
             retry (Optional[Retry], optional): Retry object. Defaults to None.
-            on_success (Optional[Callable[..., Any]], optional): Callable for on success. Defaults to None.
-            on_failure (Optional[Callable[..., Any]], optional): Callable for on failure. Defaults to None.
-            on_stopped (Optional[Callable[..., Any]], optional): Callable for on stopped. Defaults to None.
+            on_success (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on success. Defaults to
+                None. Callable is deprecated.
+            on_failure (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on failure. Defaults to
+                None. Callable is deprecated.
+            on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on stopped. Defaults to
+                None. Callable is deprecated.
             pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
 
         Returns:
@@ -728,9 +735,9 @@ class Queue:
         at_front: bool = False,
         meta: Optional[Dict] = None,
         retry: Optional['Retry'] = None,
-        on_success: Optional[Callable] = None,
-        on_failure: Optional[Callable] = None,
-        on_stopped: Optional[Callable] = None,
+        on_success: Optional[Union[Callback, Callable]] = None,
+        on_failure: Optional[Union[Callback, Callable]] = None,
+        on_stopped: Optional[Union[Callback, Callable]] = None,
     ) -> EnqueueData:
         """Need this till support dropped for python_version < 3.7, where defaults can be specified for named tuples
         And can keep this logic within EnqueueData
@@ -749,9 +756,12 @@ class Queue:
             at_front (bool, optional): Whether to enqueue the job at the front. Defaults to False.
             meta (Optional[Dict], optional): Metadata to attach to the job. Defaults to None.
             retry (Optional[Retry], optional): Retry object. Defaults to None.
-            on_success (Optional[Callable[..., Any]], optional): Callable for on success. Defaults to None.
-            on_failure (Optional[Callable[..., Any]], optional): Callable for on failure. Defaults to None.
-            on_stopped (Optional[Callable[..., Any]], optional): Callable for on stopped. Defaults to None.
+            on_success (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on success. Defaults to
+                None. Callable is deprecated.
+            on_failure (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on failure. Defaults to
+                None. Callable is deprecated.
+            on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on stopped. Defaults to
+                None. Callable is deprecated.
 
         Returns:
             EnqueueData: The EnqueueData

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1274,7 +1274,7 @@ class Queue:
         if timeout is not None:  # blocking variant
             if timeout == 0:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
-            colored_queues = ''.join(map(str, [green(str(queue)) for queue in queue_keys]))
+            colored_queues = ', '.join(map(str, [green(str(queue)) for queue in queue_keys]))
             logger.debug(f"Starting BLPOP operation for queues {colored_queues} with timeout of {timeout}")
             result = connection.blpop(queue_keys, timeout)
             if result is None:

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -102,7 +102,11 @@ def import_attribute(name: str) -> Callable[..., Any]:
             attribute_bits.insert(0, module_name_bits.pop())
 
     if module is None:
-        raise ValueError('Invalid attribute name: %s' % name)
+        # maybe it's a builtin
+        try:
+            return __builtins__[name]
+        except KeyError:
+            raise ValueError('Invalid attribute name: %s' % name)
 
     attribute_name = '.'.join(attribute_bits)
     if hasattr(module, attribute_name):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1498,7 +1498,7 @@ class Worker(BaseWorker):
         extra.update({'queue': job.origin, 'job_id': job.id})
 
         # func_name
-        self.log.error('[Job %s]: exception raised while executing (%s)\n' + exc_string, job.id, func_name, extra=extra)
+        self.log.error('[Job %s]: exception raised while executing (%s)\n%s', job.id, func_name, exc_string, extra=extra)
 
         for handler in self._exc_handlers:
             self.log.debug('Invoking exception handler %s', handler)


### PR DESCRIPTION
https://docs.python.org/3/library/logging.html#logging.Logger.debug

self.log.error is called with arguments so % formatting operations are performed on the msg string. 

Before this PR exc_string was appended to the msg string and the new msg string if passed to the logging module. If exc_string contains, for example, %s it will be treated as a variable to be filled and the logging module will look for args to fill it. This will raise an exception if there are not enough args or the wrong args will get used.

This can be re-produced by raising an exception like this in a worker:

```python
raise Exception('desc %s' % value)
```

"raise Exception('desc %s' % value)" will be in exc_string and therefore part of the msg before this PR

The fix is not to append exc_string to msg but to include is in the msg string via %s processing and pass it as an arg 

 