### PR TITLE
Update log string for better output when multiple queues

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1274,7 +1274,7 @@ class Queue:
         if timeout is not None:  # blocking variant
             if timeout == 0:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
-            colored_queues = ''.join(map(str, [green(str(queue)) for queue in queue_keys]))
+            colored_queues = ', '.join(map(str, [green(str(queue)) for queue in queue_keys]))
             logger.debug(f"Starting BLPOP operation for queues {colored_queues} with timeout of {timeout}")
             result = connection.blpop(queue_keys, timeout)
             if result is None:


### PR DESCRIPTION
I added a 2nd queue to my worker today and saw the debug string as:

* `Starting BLPOP operation for queues rq:queue:defaultrq:queue:snitch with timeout of 405`
* `BLPOP Timeout, no jobs found on queues rq:queue:defaultrq:queue:snitch`

and wanted to fix this to be more readable.