### PR TITLE
Add __all__ to please mypy

### DIFF
--- a/rq/__init__.py
+++ b/rq/__init__.py
@@ -5,4 +5,19 @@ from .queue import Queue
 from .version import VERSION
 from .worker import SimpleWorker, Worker
 
+__all__ = [
+  "Connection", 
+  "get_current_connection", 
+  "pop_connection", 
+  "push_connection", 
+  "Callback", 
+  "Retry", 
+  "cancel_job", 
+  "get_current_job", 
+  "requeue_job", 
+  "Queue", 
+  "SimpleWorker", 
+  "Worker"
+]
+
 __version__ = VERSION

--- a/rq/__init__.py
+++ b/rq/__init__.py
@@ -6,18 +6,18 @@ from .version import VERSION
 from .worker import SimpleWorker, Worker
 
 __all__ = [
-  "Connection", 
-  "get_current_connection", 
-  "pop_connection", 
-  "push_connection", 
-  "Callback", 
-  "Retry", 
-  "cancel_job", 
-  "get_current_job", 
-  "requeue_job", 
-  "Queue", 
-  "SimpleWorker", 
-  "Worker"
+    "Connection",
+    "get_current_connection",
+    "pop_connection",
+    "push_connection",
+    "Callback",
+    "Retry",
+    "cancel_job",
+    "get_current_job",
+    "requeue_job",
+    "Queue",
+    "SimpleWorker",
+    "Worker",
 ]
 
 __version__ = VERSION


### PR DESCRIPTION
`mypy` complains with "implicit reexport disabled" when importing directly from the main `rq` package, eg.

```python
from rq import Worker
```

Without adding an `__all__` to `__init__.py`, mypy would expect it this way:

```python
from rq.worker import Worker
```

This PR does add the `__all__` to `__init__.py` to please mypy.