### PR TITLE
pass exc_string as an argument to log

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1498,7 +1498,9 @@ class Worker(BaseWorker):
         extra.update({'queue': job.origin, 'job_id': job.id})
 
         # func_name
-        self.log.error('[Job %s]: exception raised while executing (%s)\n%s', job.id, func_name, exc_string, extra=extra)
+        self.log.error(
+            '[Job %s]: exception raised while executing (%s)\n%s', job.id, func_name, exc_string, extra=extra
+        )
 
         for handler in self._exc_handlers:
             self.log.debug('Invoking exception handler %s', handler)

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1498,7 +1498,7 @@ class Worker(BaseWorker):
         extra.update({'queue': job.origin, 'job_id': job.id})
 
         # func_name
-        self.log.error('[Job %s]: exception raised while executing (%s)\n' + exc_string, job.id, func_name, extra=extra)
+        self.log.error('[Job %s]: exception raised while executing (%s)\n%s', job.id, func_name, exc_string, extra=extra)
 
         for handler in self._exc_handlers:
             self.log.debug('Invoking exception handler %s', handler)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -268,7 +268,7 @@ class TestWorker(RQTestCase):
         w.perform_job(job, queue)
 
         # An exception should be logged here at ERROR level
-        self.assertIn("Traceback", mock_logger_error.call_args[0][0])
+        self.assertIn("Traceback", mock_logger_error.call_args[0][3])
 
     def test_heartbeat(self):
         """Heartbeat saves last_heartbeat"""


### PR DESCRIPTION
https://docs.python.org/3/library/logging.html#logging.Logger.debug

self.log.error is called with arguments so % formatting operations are performed on the msg string. 

Before this PR exc_string was appended to the msg string and the new msg string if passed to the logging module. If exc_string contains, for example, %s it will be treated as a variable to be filled and the logging module will look for args to fill it. This will raise an exception if there are not enough args or the wrong args will get used.

This can be re-produced by raising an exception like this in a worker:

```python
raise Exception('desc %s' % value)
```

"raise Exception('desc %s' % value)" will be in exc_string and therefore part of the msg before this PR

The fix is not to append exc_string to msg but to include is in the msg string via %s processing and pass it as an arg 

 