### PR TITLE
add lint target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ force_release: clean
 	git push --tags
 	python setup.py sdist bdist_wheel
 	twine upload dist/*
+
+lint:
+	@ black --check --skip-string-normalization --line-length 120 rq tests
+	@ ruff check --show-source rq tests

--- a/dev-requirements-36.txt
+++ b/dev-requirements-36.txt
@@ -4,5 +4,3 @@ psutil
 pytest
 pytest-cov
 sentry-sdk
-black
-ruff

--- a/dev-requirements-36.txt
+++ b/dev-requirements-36.txt
@@ -4,3 +4,5 @@ psutil
 pytest
 pytest-cov
 sentry-sdk
+black
+ruff

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,5 +4,3 @@ psutil
 pytest
 pytest-cov
 sentry-sdk
-black
-ruff

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,5 @@ psutil
 pytest
 pytest-cov
 sentry-sdk
+black
+ruff


### PR DESCRIPTION
This PR add a "lint" target to the Makefile 
~~It also adds black and ruff to the dev-requirements~~
It does not add black and ruff to dev-requirements because ruff does not work with python 3.6 and adding those dependencies seems to cause the tests to fail for other python versions. I guess because they cause some version change of related dependencies which are specified without locked versions