### PR TITLE
Do not run dependent jobs when parent is canceled

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -1586,7 +1586,7 @@ class Job:
             # If parent job is not finished, we should only continue
             # if this job allows parent job to fail
             dependencies_ids.discard(parent_job.id)
-            if parent_job._status == JobStatus.CANCELED:
+            if parent_job.get_status() == JobStatus.CANCELED:
                 return False
             elif parent_job._status == JobStatus.FAILED and not self.allow_dependency_failures:
                 return False

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1206,6 +1206,7 @@ class Queue:
                         pipeline=pipe,
                         exclude_job_id=exclude_job_id,
                     )
+                    and dependent_job.get_status(refresh=False) != JobStatus.CANCELED
                 ]
 
                 pipe.multi()


### PR DESCRIPTION
I ran into a problem when we canceled a running parent job and the dependent jobs were executed.

When rq cancel a running job the status is changed in the database but when rq tries to enqueue the dependent jobs it seems like it does not fetch the new value from the database.

I do not know that much about the internals of RQ, could be better ways to fix this.

Probably fixes #1902 