### PR TITLE
Update CHANGES.md to show change in Redis library requirement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * `queue.enqueue_many()` now supports job dependencies. Thanks @eswolinsky3241!
 * `rq worker` CLI script now configures logging based on `DICT_CONFIG` key present in config file. Thanks @juur!
 * Whenever possible, `Worker` now uses `lmove()` to implement [reliable queue pattern](https://redis.io/commands/lmove/). Thanks @selwin!
+* Require `redis>=4.0.0`
 * `Scheduler` should only release locks that it successfully acquires. Thanks @xzander!
 * Fixes crashes that may happen by changes to `as_text()` function in v1.14. Thanks @tchapi!
 * Various linting, CI and code quality improvements. Thanks @robhudson!


### PR DESCRIPTION
Version 1.15 added a new requirement for Redis 4.0.0 or greater. I didn't find out about this requirement until updating our dependencies. I think it would be helpful to add to the changelog.

Thank you for maintaining this wonderful library.