### PR TITLE
Add the Python dev packages for Python headers to tests/Dockerfile

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8.3", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         redis-version: [3, 4, 5, 6, 7]
         redis-py-version: [3.5.0]
 
@@ -49,7 +49,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8.3", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         redis-version: [3, 4, 5, 6, 7]
 
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.7", "3.8.3", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         redis-version: [3, 4, 5, 6, 7]
         redis-py-version: [3.5.0]
 
@@ -55,45 +55,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install redis==${{ matrix.redis-py-version }}
         pip install -r requirements.txt -r dev-requirements.txt
-        pip install -e .
-
-    - name: Test with pytest
-      run: |
-        RUN_SLOW_TESTS_TOO=1 pytest --cov=rq --cov-config=.coveragerc --cov-report=xml --durations=5
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: false
-  test-python-36:
-    name: Python${{ matrix.python-version }}/Redis${{ matrix.redis-version }}/redis-py${{ matrix.redis-py-version }}
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-    strategy:
-      matrix:
-        python-version: ["3.6"]
-        redis-version: [3, 4, 5, 6, 7]
-        redis-py-version: [3.5.0]
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4.6.1
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Start Redis
-      uses: supercharge/redis-github-action@1.5.0
-      with:
-        redis-version: ${{ matrix.redis-version }}
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install redis==${{ matrix.redis-py-version }}
-        pip install -r requirements.txt -r dev-requirements-36.txt
         pip install -e .
 
     - name: Test with pytest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### RQ unreleased
+* Dropped support for Python 3.6
+
 ### RQ 1.15.1 (2023-06-20)
 * Fixed a bug that may cause a crash when cleaning intermediate queue. Thanks @selwin!
 * Fixed a bug that may cause canceled jobs to still run dependent jobs. Thanks @fredsod!

--- a/docs/contrib/testing.md
+++ b/docs/contrib/testing.md
@@ -5,7 +5,7 @@ layout: contrib
 
 ### Testing RQ locally
 
-To run tests locally you can use `tox`, which will run the tests with all supported Python versions (3.6 - 3.11)
+To run tests locally you can use `tox`, which will run the tests with all supported Python versions (3.7 - 3.11)
 
 ```
 tox

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=get_requirements(),
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     entry_points={
         'console_scripts': [
             'rq = rq.cli:main',
@@ -72,7 +72,6 @@ setup(
         'Operating System :: Unix',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,6 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
+# See: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa for supported versions of Python.
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
@@ -14,7 +15,8 @@ RUN apt-get update && \
     libnss3-dev \
     libssl-dev \
     libreadline-dev \
-    libffi-dev wget \
+    libffi-dev \
+    wget \
     software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update
@@ -24,12 +26,17 @@ RUN apt-get install -y \
     python3-pip \
     stunnel \
     python3.6 \
+    libpython3.6-dev \
     python3.7 \
+    python3.7-dev \
+    python3.7-distutils \
     python3.8 \
+    python3.8-dev \
     python3.9 \
+    python3.9-dev \
     python3.10 \
     python3.6-distutils \
-    python3.7-distutils
+    python3.10-dev \
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -25,8 +25,6 @@ RUN apt-get install -y \
     redis-server \
     python3-pip \
     stunnel \
-    python3.6 \
-    libpython3.6-dev \
     python3.7 \
     python3.7-dev \
     python3.7-distutils \
@@ -35,8 +33,9 @@ RUN apt-get install -y \
     python3.9 \
     python3.9-dev \
     python3.10 \
-    python3.6-distutils \
     python3.10-dev \
+    python3.11 \
+    python3.11-dev
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py37,py38,py39,py310
+envlist=py37,py38,py39,py310,py311
 
 [testenv]
 commands=pytest --cov rq --cov-config=.coveragerc --durations=5 {posargs}
@@ -21,11 +21,6 @@ passenv=
 ;     black --check rq tests
 ;     ruff check rq tests
 
-[testenv:py36]
-skipdist = True
-basepython = python3.6
-deps = {[testenv]deps}
-
 [testenv:py37]
 skipdist = True
 basepython = python3.7
@@ -44,6 +39,11 @@ deps = {[testenv]deps}
 [testenv:py310]
 skipdist = True
 basepython = python3.10
+deps = {[testenv]deps}
+
+[testenv:py311]
+skipdist = True
+basepython = python3.11
 deps = {[testenv]deps}
 
 [testenv:ssl]


### PR DESCRIPTION
The Docker tests were failing for me since psutil was trying to compile and looking for Python headers. With the python dev packages added these now work again.

Python 3.6 is skipped during the test runs presumably because the deadsnakes packages no longer build Python 3.6. So this could be removed later as part of an overall update to drop support. I'm leaving it as-is for now.