### PR TITLE
Don't use `os.setsid()` after forking workhorse

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -425,7 +425,7 @@ class BaseWorker:
     @property
     def dequeue_timeout(self) -> int:
         return max(1, self.worker_ttl - 15)
-    
+
     @property
     def connection_timeout(self) -> int:
         return self.dequeue_timeout + 10
@@ -1107,6 +1107,7 @@ class BaseWorker:
         """Pushes an exception handler onto the exc handler stack."""
         self._exc_handlers.append(handler_func)
 
+
 class Worker(BaseWorker):
     @property
     def horse_pid(self):
@@ -1217,7 +1218,7 @@ class Worker(BaseWorker):
         os.environ['RQ_WORKER_ID'] = self.name
         os.environ['RQ_JOB_ID'] = job.id
         if child_pid == 0:
-            os.setsid()
+            os.setpgrp()
             self.main_work_horse(job, queue)
             os._exit(0)  # just in case
         else:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -98,8 +98,8 @@ def create_file_after_timeout(path, timeout):
     create_file(path)
 
 
-def create_file_after_timeout_and_setsid(path, timeout):
-    os.setsid()
+def create_file_after_timeout_and_setpgrp(path, timeout):
+    os.setpgrp()
     create_file_after_timeout(path, timeout)
 
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -309,10 +309,7 @@ class TestQueue(RQTestCase):
 
         # Dequeue simply ignores the missing job and returns None
         self.assertEqual(q.count, 1)
-        self.assertEqual(
-            Queue.dequeue_any([Queue(), Queue('low')], timeout=None, connection=self.connection),
-            None
-        )
+        self.assertEqual(Queue.dequeue_any([Queue(), Queue('low')], timeout=None, connection=self.connection), None)
         self.assertEqual(q.count, 0)
 
     def test_enqueue_with_ttl(self):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -34,7 +34,7 @@ from tests.fixtures import (
     access_self,
     create_file,
     create_file_after_timeout,
-    create_file_after_timeout_and_setsid,
+    create_file_after_timeout_and_setpgrp,
     div_by_zero,
     do_nothing,
     kill_worker,
@@ -1546,7 +1546,7 @@ class HerokuWorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
         w = HerokuWorker('foo')
 
         path = os.path.join(self.sandbox, 'shouldnt_exist')
-        p = Process(target=create_file_after_timeout_and_setsid, args=(path, 2))
+        p = Process(target=create_file_after_timeout_and_setpgrp, args=(path, 2))
         p.start()
         self.assertEqual(p.exitcode, None)
         time.sleep(0.1)


### PR DESCRIPTION
In 9adcd7e50c511ceba622ba20c826a0b701a917ea a change was made to make the workhorse process into a session leader. This appears to have been done in order to set the process group ID of the workhorse so that it can be killed easily along with its descendants when `Worker.kill_horse()` is called.

However, `setsid` is overkill for this purpose; it sets not only the process group ID but also the session ID. This can cause issues for user jobs which may rely on session IDs being less-than-unique for arbitrary reasons.

This change switches to `setpgrp`; this sets the process group ID so that the workhorse and its descendants can be killed *without* changing the session ID.