### PR TITLE
Add support for functools.partial in Callback class

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -6,6 +6,7 @@ import warnings
 import zlib
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
 from uuid import uuid4
 
@@ -1646,7 +1647,7 @@ class Retry:
 
 class Callback:
     def __init__(self, func: Union[str, Callable[..., Any]], timeout: Optional[Any] = None):
-        if not isinstance(func, str) and not inspect.isfunction(func) and not inspect.isbuiltin(func):
+        if not isinstance(func, str) and not inspect.isfunction(func) and not inspect.isbuiltin(func) and not isinstance(func, partial):
             raise ValueError('Callback `func` must be a string or function')
 
         self.func = func


### PR DESCRIPTION
This commit adds support for `functools.partial` objects in the `Callback` class. The `__init__` method is updated to accept `functools.partial` objects in addition to strings, functions, and built-in functions. This extends the flexibility of the `Callback` class, allowing function arguments to be fixed in advance.