### PR TITLE
Fix maintenance task issues raised in #2005

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -253,6 +253,10 @@ class Queue:
             return False
         return lock_acquired
 
+    def release_maintenance_lock(self) -> None:
+        """Deletes the maintenance lock of this queue."""
+        self.connection.delete(self.registry_cleaning_key)
+
     def empty(self):
         """Removes all messages on the queue.
         This is currently being done using a Lua script,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1058,7 +1058,8 @@ class TestWorker(RQTestCase):
 
         worker = Worker([foo_queue, bar_queue])
         self.assertEqual(worker.last_cleaned_at, None)
-        worker.clean_registries()
+        if worker.should_run_maintenance_tasks:
+            worker.clean_registries()
         self.assertNotEqual(worker.last_cleaned_at, None)
         self.assertEqual(self.testconn.zcard(foo_registry.key), 0)
         self.assertEqual(self.testconn.zcard(bar_registry.key), 0)
@@ -1066,7 +1067,8 @@ class TestWorker(RQTestCase):
         # worker.clean_registries() only runs once every 15 minutes
         # If we add another key, calling clean_registries() should do nothing
         self.testconn.zadd(bar_registry.key, {'bar': 1})
-        worker.clean_registries()
+        if worker.should_run_maintenance_tasks:
+            worker.clean_registries()
         self.assertEqual(self.testconn.zcard(bar_registry.key), 1)
 
     def test_should_run_maintenance_tasks(self):


### PR DESCRIPTION
- share 'last_cleaned_at' between workers and set it at maintenance task start time
- release maintenance lock when maintenance task is finished