### PR TITLE
docs: fix typo in `workers.md`

### DIFF
--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -75,7 +75,7 @@ _New in version 1.8.0._
 
 _New in version 1.14.0._
 * `--dequeue-strategy`: The strategy to dequeue jobs from multiple queues (one of `default`, `random` or `round_robin`,  defaults to `default`)
-* `--max-idle-time`: if specified, worker will wait for X seconds for a job to arrive before shuttind down.
+* `--max-idle-time`: if specified, worker will wait for X seconds for a job to arrive before shutting down.
 * `--maintenance-interval`: defaults to 600 seconds. Runs maintenance tasks every X seconds.
 
 


### PR DESCRIPTION
"shuttind" -> "shutting"