### PR TITLE
fix: cast redis server version from `float` to `str`

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -290,7 +290,7 @@ def get_version(connection: 'Redis') -> Tuple[int, int, int]:
             setattr(
                 connection,
                 "__rq_redis_server_version",
-                tuple(int(i) for i in connection.info("server")["redis_version"].split('.')[:3]),
+                tuple(int(i) for i in str(connection.info("server")["redis_version"]).split('.')[:3]),
             )
         return getattr(connection, "__rq_redis_server_version")
     except ResponseError:  # fakeredis doesn't implement Redis' INFO command


### PR DESCRIPTION
Currently, with Redis engine 7.1, and `redis` client 5.0.1 trying to enqueue a new job yields

```text
AttributeError: 'float' object has no attribute 'split'
```

This is caused by the fact that `redis_conn.info("server")["redis_version"]` returns a `float`, not a `str`.

The exact environment is [AWS Serverless Redis](https://aws.amazon.com/blogs/aws/amazon-elasticache-serverless-for-redis-and-memcached-now-generally-available/)