### PR TITLE
Replace deprecated utcnow() with timezone aware now()

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -125,7 +125,7 @@ def import_attribute(name: str) -> Callable[..., Any]:
 
 
 def utcnow():
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(tz=datetime.timezone.utc)
 
 
 def now():
@@ -224,7 +224,7 @@ def current_timestamp() -> int:
     Returns:
         int: _description_
     """
-    return calendar.timegm(datetime.datetime.utcnow().utctimetuple())
+    return calendar.timegm(datetime.datetime.now(tz=datetime.timezone.utc).utctimetuple())
 
 
 def backend_class(holder, default_name, override=None) -> TypeVar('T'):


### PR DESCRIPTION
Replace datetime.datetime.utcnow() which will be depreceated in the future with the timezone aware datetime.datetime.now(tz=datetime.timezone.utc).

This change is in regards to issue #https://github.com/rq/rq/issues/2044#issue-2146821884