### PR TITLE
 Replace deprecated utcnow() with timezone aware now() 

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -125,7 +125,7 @@ def import_attribute(name: str) -> Callable[..., Any]:
 
 
 def utcnow():
-    return datetime.datetime.now(tz=datetime.timezone.utc)
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
 def now():

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -145,7 +145,11 @@ def utcparse(string: str) -> dt.datetime:
         return datetime.datetime.strptime(string, _TIMESTAMP_FORMAT)
     except ValueError:
         # This catches any jobs remain with old datetime format
-        return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%S.%fZ')
+        try:
+         return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%S.%fZ')
+        except:
+         return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%S.%fZ')
+
 
 
 def first(iterable: Iterable, default=None, key=None):

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -148,7 +148,7 @@ def utcparse(string: str) -> dt.datetime:
         try:
          return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%S.%fZ')
         except:
-         return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%S.%fZ')
+         return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
 
 
 

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -125,8 +125,8 @@ def import_attribute(name: str) -> Callable[..., Any]:
 
 
 def utcnow():
-    dt=datetime.datetime.now(datetime.timezone.utc)
-    return dt.replace(tzinfo=None)
+    
+    return datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
 
 
 def now():

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -125,7 +125,8 @@ def import_attribute(name: str) -> Callable[..., Any]:
 
 
 def utcnow():
-    return datetime.datetime.now(datetime.timezone.utc)
+    dt=datetime.datetime.now(datetime.timezone.utc)
+    return dt.replace(tzinfo=None)
 
 
 def now():

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -125,7 +125,7 @@ def import_attribute(name: str) -> Callable[..., Any]:
 
 
 def utcnow():
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(tz=datetime.timezone.utc)
 
 
 def now():
@@ -145,7 +145,7 @@ def utcparse(string: str) -> dt.datetime:
         return datetime.datetime.strptime(string, _TIMESTAMP_FORMAT)
     except ValueError:
         # This catches any jobs remain with old datetime format
-        return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
+        return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
 def first(iterable: Iterable, default=None, key=None):
@@ -224,7 +224,7 @@ def current_timestamp() -> int:
     Returns:
         int: _description_
     """
-    return calendar.timegm(datetime.datetime.utcnow().utctimetuple())
+    return calendar.timegm(datetime.datetime.now(datetime.timezone.utc).utctimetuple())
 
 
 def backend_class(holder, default_name, override=None) -> TypeVar('T'):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -691,7 +691,7 @@ class TestWorker(RQTestCase):
         w = Worker([q])
         w.worker_ttl = 2
         w.work(max_idle_time=3)
-        self.assertLess((utcnow() - now).total_seconds(), 5)  # 5 for some buffer
+        self.assertLess((utcnow() - now).total_seconds(), 6)  # 5 for some buffer
 
     @slow  # noqa
     def test_timeouts(self):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -691,7 +691,7 @@ class TestWorker(RQTestCase):
         w = Worker([q])
         w.worker_ttl = 2
         w.work(max_idle_time=3)
-        self.assertLess((utcnow() - now).total_seconds(), 6)  # 5 for some buffer
+        self.assertLess((utcnow() - now).total_seconds(), 5)  # 5 for some buffer
 
     @slow  # noqa
     def test_timeouts(self):


### PR DESCRIPTION
Replace datetime.datetime.utcnow() which will be depreceated in the future with the timezone aware datetime.datetime.now(datetime.timezone.utc).

This change is in regards to issue https://github.com/rq/rq/issues/2044#issue-2146821884