### PR TITLE
Fix the "Fork me on GitHub" ribbon

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <header>
-        <a href="http://git.io/rq"><img class="nomargin" style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
+        <a href="http://git.io/rq"><img class="nomargin" style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
 
         <ul class="inline">
         {% for link in site.navigation %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <header>
-        <a href="http://git.io/rq"><img class="nomargin" style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
+        <a href="http://git.io/rq"><img class="nomargin" style="position: absolute; top: 0; right: 0; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
 
         <ul class="inline">
         {% for link in site.navigation %}


### PR DESCRIPTION
The image URL is broken. Replace it with the "official" URL found at <https://github.blog/2008-12-19-github-ribbons/>.