### PR TITLE
Make Retry type hint more exact

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -1649,7 +1649,7 @@ _job_stack = LocalStack()
 
 
 class Retry:
-    def __init__(self, max: int, interval: Union[int, List[int]] = 0):
+    def __init__(self, max: int, interval: Union[int, Iterable[int]] = 0):
         """The main object to defined Retry logics for jobs.
 
         Args:


### PR DESCRIPTION
The current type hint of `Retry` makes MyPy check failed when user passes a tuple to `interval` parameter, though that usage is correct.