### PR TITLE
fix case when client does not have a name

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -222,7 +222,7 @@ class BaseWorker:
                 warnings.warn('CLIENT SETNAME command not supported, setting ip_address to unknown', Warning)
                 self.ip_address = 'unknown'
             else:
-                client_adresses = [client['addr'] for client in connection.client_list() if client['name'] == self.name]
+                client_adresses = [client['addr'] for client in connection.client_list() if client.get('name') == self.name]
                 if len(client_adresses) > 0:
                     self.ip_address = client_adresses[0]
                 else:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -222,7 +222,9 @@ class BaseWorker:
                 warnings.warn('CLIENT SETNAME command not supported, setting ip_address to unknown', Warning)
                 self.ip_address = 'unknown'
             else:
-                client_adresses = [client['addr'] for client in connection.client_list() if client.get('name') == self.name]
+                client_adresses = [
+                    client['addr'] for client in connection.client_list() if client.get('name') == self.name
+                ]
                 if len(client_adresses) > 0:
                     self.ip_address = client_adresses[0]
                 else:


### PR DESCRIPTION
I got this error when sharing Redis DB with other clients
```
│   File "/app/manage.py", line 15, in <module>
│     execute_from_command_line(sys.argv)
│   File "/app/.heroku/python/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
│     utility.execute()
│   File "/app/.heroku/python/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
│     self.fetch_command(subcommand).run_from_argv(self.argv)
│   File "/app/.heroku/python/lib/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
│     self.execute(*args, **cmd_options)
│   File "/app/.heroku/python/lib/python3.11/site-packages/django/core/management/base.py", line 458, in execute
│     output = self.handle(*args, **options)
│              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│   File "/app/.heroku/python/lib/python3.11/site-packages/django_rq/management/commands/rqworker.py", line 90, in handle
│     w = get_worker(*args, **worker_kwargs)
│         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│   File "/app/.heroku/python/lib/python3.11/site-packages/django_rq/workers.py", line 50, in get_worker
│     return worker_class(
│            ^^^^^^^^^^^^^
│   File "/app/.heroku/python/lib/python3.11/site-packages/rq/worker.py", line 209, in __init__
│     client_adresses = [client['addr'] for client in connection.client_list() if client['name'] == self.name]
│                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
│   File "/app/.heroku/python/lib/python3.11/site-packages/rq/worker.py", line 209, in <listcomp>
│     client_adresses = [client['addr'] for client in connection.client_list() if client['name'] == self.name]
│                                                                                 ~~~~~~^^^^^^^^
│ KeyError: 'name'
```

From official Redis document [client list](https://redis.io/docs/latest/commands/client-list/)
```
New fields are regularly added for debugging purpose. Some could be removed in the future. A version safe Redis client using this command should parse the output accordingly (i.e. handling gracefully missing fields, skipping unknown fields).
```

Therefore, it is better to handle this case in RQ initialization code.