### PR TITLE
Remove side effects in count and get_job_ids

### DIFF
--- a/rq/registry.py
+++ b/rq/registry.py
@@ -213,6 +213,7 @@ class BaseRegistry:
     def cleanup(self):
         pass
 
+
 class StartedJobRegistry(BaseRegistry):
     """
     Registry of currently executing jobs. Each queue maintains a
@@ -479,7 +480,6 @@ class CanceledJobRegistry(BaseRegistry):
 
     def get_expired_job_ids(self, timestamp: Optional[datetime] = None):
         raise NotImplementedError
-
 
 
 def clean_registries(queue: 'Queue', exception_handlers: list = None):

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -87,7 +87,6 @@ class BaseRegistry:
         Returns:
             int: _description_
         """
-        self.cleanup()
         return self.connection.zcard(self.key)
 
     def add(self, job: 'Job', ttl=0, pipeline: Optional['Pipeline'] = None, xx: bool = False) -> int:
@@ -162,7 +161,6 @@ class BaseRegistry:
         Returns:
             _type_: _description_
         """
-        self.cleanup()
         return [as_text(job_id) for job_id in self.connection.zrange(self.key, start, end)]
 
     def get_queue(self):
@@ -212,6 +210,8 @@ class BaseRegistry:
             pipeline.execute()
         return job
 
+    def cleanup(self):
+        pass
 
 class StartedJobRegistry(BaseRegistry):
     """
@@ -397,12 +397,6 @@ class DeferredJobRegistry(BaseRegistry):
 
     key_template = 'rq:deferred:{0}'
 
-    def cleanup(self):
-        """This method is only here to prevent errors because this method is
-        automatically called by `count()` and `get_job_ids()` methods
-        implemented in BaseRegistry."""
-        pass
-
 
 class ScheduledJobRegistry(BaseRegistry):
     """
@@ -430,12 +424,6 @@ class ScheduledJobRegistry(BaseRegistry):
 
         timestamp = calendar.timegm(scheduled_datetime.utctimetuple())
         return self.connection.zadd(self.key, {job.id: timestamp})
-
-    def cleanup(self):
-        """This method is only here to prevent errors because this method is
-        automatically called by `count()` and `get_job_ids()` methods
-        implemented in BaseRegistry."""
-        pass
 
     def remove_jobs(self, timestamp: Optional[datetime] = None, pipeline: Optional['Pipeline'] = None):
         """Remove jobs whose timestamp is in the past from registry.
@@ -492,11 +480,6 @@ class CanceledJobRegistry(BaseRegistry):
     def get_expired_job_ids(self, timestamp: Optional[datetime] = None):
         raise NotImplementedError
 
-    def cleanup(self):
-        """This method is only here to prevent errors because this method is
-        automatically called by `count()` and `get_job_ids()` methods
-        implemented in BaseRegistry."""
-        pass
 
 
 def clean_registries(queue: 'Queue', exception_handlers: list = None):


### PR DESCRIPTION
Both count and get_job_ids methods in registries automatically call cleanup. It is an unexpected side effect that even triggers failure callbacks in the case of StartedJobRegistry. This have a couple of consequences:

- Logging or observability tooling end up having a real effect in the queue.
- Logging and observability scripts or tools using registries can fail due to undefined callbacks. This is the case with rq-exporter and rq-dashboard.
- Methods like a simple call to len(registry) or show_queues have obscure side effects. 

Based on the line blame I suspect there was a very good reason to put those cleanup calls there but I could not find any to keep them. @selwin may have more insights from 74a9982ecb4a01d8f60911b071c90cded806ce39 but this was 10 years ago. Registries are cleaned in the worker now as part of the maintainance tasks calling clean_registries, which makes me think this is no longer needed. 
