### PR TITLE
Add callback protocols and runtime type checking for callback functions

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -274,6 +274,7 @@ class Job:
                     DeprecationWarning,
                 )
                 on_success = Callback(on_success)  # backward compatibility
+            on_success.assert_type(CallbackType.SUCCESS)
             job._success_callback_name = on_success.name
             job._success_callback_timeout = on_success.timeout
 
@@ -284,6 +285,7 @@ class Job:
                     DeprecationWarning,
                 )
                 on_failure = Callback(on_failure)  # backward compatibility
+            on_success.assert_type(CallbackType.FAILURE)
             job._failure_callback_name = on_failure.name
             job._failure_callback_timeout = on_failure.timeout
 
@@ -294,6 +296,7 @@ class Job:
                     DeprecationWarning,
                 )
                 on_stopped = Callback(on_stopped)  # backward compatibility
+            on_success.assert_type(CallbackType.STOPPED)
             job._stopped_callback_name = on_stopped.name
             job._stopped_callback_timeout = on_stopped.timeout
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -5,7 +5,7 @@ import logging
 import warnings
 import zlib
 from datetime import datetime, timedelta, timezone
-from enum import Enum, StrEnum
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1693,7 +1693,7 @@ class Retry:
 
 
 
-class CallbackType(StrEnum):
+class CallbackType(str, Enum):
     SUCCESS = "success"
     FAILURE = "failure"
     STOPPED = "stopped"


### PR DESCRIPTION
This PR intends to implement the suggestion in #2091

I've made the following changes:

1. `success`, `failure`, and `stopped` callback types as a string enumeration class.
2. Protocol classes for each callback type.
3. `assert_type` method for the `Callback` class to assert the protocol of a callback function in runtime.
4. `InvalidCallbackException` exception class to raise when a callback function does not follow the protocol.
