### PR TITLE
TTL documentation clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ If you want the cutting edge version (that may well be broken), use this:
 To build and run the docs, install [jekyll](https://jekyllrb.com/docs/) and run:
 
 ```shell
+cd docs
 jekyll serve
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ If you want the cutting edge version (that may well be broken), use this:
     pip install git+https://github.com/rq/rq.git@master#egg=rq
 
 
+## Docs
+
+To build and run the docs, install [jekyll](https://jekyllrb.com/docs/) and run:
+
+```shell
+jekyll serve
+```
+
 ## Related Projects
 
 If you use RQ, Check out these below repos which might be useful in your rq based project.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 baseurl: /
-exclude: design
+exclude: [design]
 permalink: pretty
 
 navigation:

--- a/docs/docs/connections.md
+++ b/docs/docs/connections.md
@@ -124,10 +124,21 @@ SENTINEL: {
 ### Timeout
 
 To avoid potential issues with hanging Redis commands, specifically the blocking `BLPOP` command,
-RQ automatically sets a `socket_timeout` value that is 10 seconds higher than the `default_worker_ttl`.
+RQ automatically sets a `socket_timeout` value that is 10 seconds higher than the `dequeue_timeout`. The `dequeue_timeout` is computed as 15 seconds shorter than the `worker_ttl` value.
+
+Here are the following computed timeout values if you were not to adjust anything.
+
+| Setting              | Default Value |
+|:---------------------|:-------------:|
+| `worker_ttl`         |      420      |
+| `connection_timeout` |      415      |
+| `dequeue_timeout`    |      405      |
+|                      |               |
+
+
 
 If you prefer to manually set the `socket_timeout` value,
-make sure that the value being set is higher than the `default_worker_ttl` (which is 420 by default).
+make sure that the value being set is higher than the `dequeue_timeout` (which is 405 by default).
 
 ```python
 from redis import Redis
@@ -137,7 +148,7 @@ conn = Redis('localhost', 6379, socket_timeout=500)
 q = Queue(connection=conn)
 ```
 
-Setting a `socket_timeout` with a lower value than the `default_worker_ttl` will cause a `TimeoutError`
+Setting a `socket_timeout` with a lower value than the `dequeue_timeout` will cause a `TimeoutError`
 since it will interrupt the worker while it gets new jobs from the queue.
 
 

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -267,7 +267,8 @@ def worker(
             queues,
             name=name,
             connection=cli_config.connection,
-            default_worker_ttl=worker_ttl,
+            default_worker_ttl=worker_ttl,  # TODO remove this arg in 2.0
+            worker_ttl=worker_ttl,
             default_result_ttl=results_ttl,
             maintenance_interval=maintenance_interval,
             job_monitoring_interval=job_monitoring_interval,

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -152,11 +152,7 @@ class BaseWorker:
         work_horse_killed_handler: Optional[Callable[[Job, int, int, 'struct_rusage'], None]] = None,
     ):  # noqa
 
-        warnings.warn(
-            "default_worker_ttl is deprecated. Use worker_ttl instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
+        warnings.warn("default_worker_ttl is deprecated. Use worker_ttl instead.", DeprecationWarning, stacklevel=2)
         self.default_result_ttl = default_result_ttl
         self.worker_ttl = worker_ttl
         self.job_monitoring_interval = job_monitoring_interval

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -139,7 +139,8 @@ class BaseWorker:
         connection: Optional['Redis'] = None,
         exc_handler=None,
         exception_handlers=None,
-        default_worker_ttl=DEFAULT_WORKER_TTL,
+        default_worker_ttl=DEFAULT_WORKER_TTL,  # TODO remove this arg in 2.0
+        worker_ttl=DEFAULT_WORKER_TTL,
         maintenance_interval: int = DEFAULT_MAINTENANCE_TASK_INTERVAL,
         job_class: Optional[Type['Job']] = None,
         queue_class: Optional[Type['Queue']] = None,
@@ -150,8 +151,14 @@ class BaseWorker:
         serializer=None,
         work_horse_killed_handler: Optional[Callable[[Job, int, int, 'struct_rusage'], None]] = None,
     ):  # noqa
+
+        warnings.warn(
+            "default_worker_ttl is deprecated. Use worker_ttl instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         self.default_result_ttl = default_result_ttl
-        self.worker_ttl = default_worker_ttl
+        self.worker_ttl = worker_ttl
         self.job_monitoring_interval = job_monitoring_interval
         self.maintenance_interval = maintenance_interval
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -742,7 +742,7 @@ class TestWorker(RQTestCase):
         w = Worker([q])
         self.assertEqual(w.dequeue_timeout, 405)
         self.assertEqual(w.connection_timeout, 415)
-        w = Worker([q], default_worker_ttl=500)
+        w = Worker([q], worker_ttl=500)
         self.assertEqual(w.dequeue_timeout, 485)
         self.assertEqual(w.connection_timeout, 495)
 


### PR DESCRIPTION
Resolves: https://github.com/rq/rq/issues/2099

- clarify usage of the various timeouts and their values in the docs
- rename `default_worker_ttl` -> `worker_ttl` argument int he worker class
- sets a deprecation warning for the `default_workert_ttl` argument 