### PR TITLE
Log job success

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1400,10 +1400,7 @@ class Worker(BaseWorker):
 
                     time_taken = job.ended_at - job.started_at
                     self.log.info(
-                        'Successfully completed %s job in %ss on worker %s',
-                        job.description,
-                        time_taken,
-                        self.name
+                        'Successfully completed %s job in %ss on worker %s', job.description, time_taken, self.name
                     )
 
                     self.log.debug('Finished handling successful execution of job %s', job.id)

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1397,6 +1397,15 @@ class Worker(BaseWorker):
                     started_job_registry.remove(job, pipeline=pipeline)
 
                     pipeline.execute()
+
+                    time_taken = job.ended_at - job.started_at
+                    self.log.info(
+                        'Successfully completed %s job in %ss on worker %s',
+                        job.description,
+                        time_taken,
+                        self.name
+                    )
+
                     self.log.debug('Finished handling successful execution of job %s', job.id)
                     break
                 except redis.exceptions.WatchError:


### PR DESCRIPTION
This closes https://github.com/rq/rq/issues/1641

## Motivation

When dealing with any queue system at scale, you need to identify slow jobs and understand issues related to potential concurrency problems between workers.

In addition, this logging gives system administrators an overview of what happened in the past when debugging difficult problems.

## Why INFO level logging?

Because logging _what_ jobs got completed _when_ is as fundamental to a job system as an access log is to a web server. It helps the programmers monitor _their_ code (whereas debug level in the `rq` library gives insight into the `rq` internals and would be too much info for a typical persisted log)

## Demonstration

Here's an example of the output

```
[INFO] Successfully completed snakes.tasks.populate_projects_iso_matches() job in 0:00:00.066600s on worker 11b1ade34709410484c854c1066708d2  [worker:1402]
```