### PR TITLE
add: redis username to the settings

### DIFF
--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -75,6 +75,7 @@ def get_redis_from_config(settings, connection_class=Redis):
         'host': settings.get('REDIS_HOST', 'localhost'),
         'port': settings.get('REDIS_PORT', 6379),
         'db': settings.get('REDIS_DB', 0),
+        'username': settings.get('REDIS_USERNAME', None),
         'password': settings.get('REDIS_PASSWORD', None),
         'ssl': ssl,
         'ssl_ca_certs': settings.get('REDIS_SSL_CA_CERTS', None),

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,18 +17,20 @@ class TestHelpers(RQTestCase):
         self.assertEqual(connection_kwargs['port'], 1)
 
         settings = {
-            'REDIS_URL': 'redis://localhost:1/1',
             'REDIS_HOST': 'foo',
             'REDIS_DB': 2,
             'REDIS_PORT': 2,
+            'REDIS_USERNAME': 'foo',
             'REDIS_PASSWORD': 'bar',
         }
 
         # Ensure REDIS_URL is preferred
         redis = get_redis_from_config(settings)
         connection_kwargs = redis.connection_pool.connection_kwargs
-        self.assertEqual(connection_kwargs['db'], 1)
-        self.assertEqual(connection_kwargs['port'], 1)
+        self.assertEqual(connection_kwargs['db'], 2)
+        self.assertEqual(connection_kwargs['port'], 2)
+        self.assertEqual(connection_kwargs['username'], 'foo')
+        self.assertEqual(connection_kwargs['password'], 'bar')
 
         # Ensure fall back to regular connection parameters
         settings['REDIS_URL'] = None


### PR DESCRIPTION
Hello,

I have encounter the problem that we don't have username parameter, only password exists. The issue briefly raised in #1296 but I guess not solved.

I have implemented the username parameter to the settings. And fixed some tests.

Workaround: REDIS_URL parameter works fine even though we don't have username parameter.