### PR TITLE
use `Serializer` Protocol instead of concrete `DefaultSerializer`

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -7,7 +7,7 @@ import logging.config
 import os
 import sys
 import warnings
-from typing import List, Type
+from typing import TYPE_CHECKING, List, Type, cast
 
 import click
 from redis.exceptions import ConnectionError
@@ -47,6 +47,9 @@ from rq.utils import get_call_string, import_attribute
 from rq.worker import Worker
 from rq.worker_pool import WorkerPool
 from rq.worker_registration import clean_worker_registry
+
+if TYPE_CHECKING:
+    from rq.serializers import Serializer
 
 
 @click.group()
@@ -461,7 +464,7 @@ def worker_pool(
     setup_loghandlers_from_args(verbose, quiet, date_format, log_format)
 
     if serializer:
-        serializer_class: Type[DefaultSerializer] = import_attribute(serializer)  # type: ignore[assignment]
+        serializer_class = cast(Type['Serializer'], import_attribute(serializer))
     else:
         serializer_class = DefaultSerializer
 

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -60,7 +60,7 @@ class WorkerPool:
         self._sleep: int = 0
         self.status: self.Status = self.Status.IDLE  # type: ignore
         self.worker_class: Type[BaseWorker] = worker_class
-        self.serializer: Type[DefaultSerializer] = serializer
+        self.serializer: Type['Serializer'] = serializer
         self.job_class: Type[Job] = job_class
 
         # A dictionary of WorkerData keyed by worker name
@@ -247,7 +247,7 @@ def run_worker(
     connection_pool_class,
     connection_pool_kwargs: dict,
     worker_class: Type[BaseWorker] = Worker,
-    serializer: Type[DefaultSerializer] = DefaultSerializer,
+    serializer: Type['Serializer'] = DefaultSerializer,
     job_class: Type[Job] = Job,
     burst: bool = True,
     logging_level: str = "INFO",

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -6,7 +6,7 @@ import signal
 import time
 from enum import Enum
 from multiprocessing import Process
-from typing import Dict, List, NamedTuple, Optional, Type, Union
+from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Type, Union
 from uuid import uuid4
 
 from redis import ConnectionPool, Redis
@@ -20,6 +20,9 @@ from .logutils import setup_loghandlers
 from .queue import Queue
 from .utils import parse_names
 from .worker import BaseWorker, Worker
+
+if TYPE_CHECKING:
+    from rq.serializers import Serializer
 
 
 class WorkerData(NamedTuple):
@@ -40,7 +43,7 @@ class WorkerPool:
         connection: Redis,
         num_workers: int = 1,
         worker_class: Type[BaseWorker] = Worker,
-        serializer: Type[DefaultSerializer] = DefaultSerializer,
+        serializer: Type['Serializer'] = DefaultSerializer,
         job_class: Type[Job] = Job,
         *args,
         **kwargs,


### PR DESCRIPTION
@selwin I happened to be looking at https://github.com/rq/django-rq/pull/683 and I noticed a few more uses of the concrete class that should be the protocol 