### PR TITLE
Set ended_at for a job when using is_async=False

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -877,6 +877,7 @@ class Queue:
             Job: _description_
         """
         job.perform()
+        job.ended_at = now()
         result_ttl = job.get_result_ttl(default_ttl=DEFAULT_RESULT_TTL)
         with self.connection.pipeline() as pipeline:
             job._handle_success(result_ttl=result_ttl, pipeline=pipeline)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -389,6 +389,11 @@ class TestQueue(RQTestCase):
         keep_job = queue.enqueue(echo, result_ttl=100)
         self.assertLessEqual(queue.connection.ttl(keep_job.key), 100)
 
+    def test_synchronous_ended_at(self):
+        queue = Queue(is_async=False, connection=self.connection)
+        echo_job = queue.enqueue(echo)
+        self.assertIsNotNone(echo_job.ended_at)
+
     def test_enqueue_explicit_args(self):
         """enQueue(connection=self.connection) works for both implicit/explicit args."""
         q = Queue(connection=self.connection)


### PR DESCRIPTION
Fixes: #2119 