### PR TITLE
Lift restriction on function parameter types

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,11 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black ruff
-
-    - name: Lint with black
-      run: |
-        black --check --skip-string-normalization --line-length 120 rq tests
+        pip install ruff
 
     - name: Lint with ruff
       run: |

--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,4 @@ force_release: clean
 	twine upload dist/*
 
 lint:
-	@ black --check --skip-string-normalization --line-length 120 rq tests
 	@ ruff check --show-source rq tests

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ RQ requires Redis >= 3.0.0.
 [![Build status](https://github.com/rq/rq/workflows/Test%20rq/badge.svg)](https://github.com/rq/rq/actions?query=workflow%3A%22Test+rq%22)
 [![PyPI](https://img.shields.io/pypi/pyversions/rq.svg)](https://pypi.python.org/pypi/rq)
 [![Coverage](https://codecov.io/gh/rq/rq/branch/master/graph/badge.svg)](https://codecov.io/gh/rq/rq)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-
+[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Full documentation can be found [here][d].
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ include = [
 
 [tool.hatch.envs.test]
 dependencies = [
-  "black",
   "coverage",
   "mypy",
   "packaging",
@@ -92,11 +91,6 @@ dependencies = [
 [tool.hatch.envs.test.scripts]
 cov = "pytest --cov=rq --cov-config=.coveragerc --cov-report=xml {args:tests}"
 typing = "mypy --enable-incomplete-feature=Unpack rq"
-
-[tool.black]
-line-length = 120
-target-version = ["py38"]
-skip-string-normalization = true
 
 [tool.mypy]
 allow_redefinition = true
@@ -120,12 +114,15 @@ lint.select = [
     "I", # import sorting
     "W", # pycodestyle warnings
 ]
-line-length = 120  # To match black.
+line-length = 120
 target-version = "py38"
 
 [tool.ruff.lint.isort]
 known-first-party = ["rq"]
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+
+[tool.ruff.format]
+quote-style = "single"
 
 [tool.pyright]
 reportOptionalMemberAccess = false

--- a/rq/dependency.py
+++ b/rq/dependency.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Iterable
 
 from redis.client import Pipeline
 from redis.exceptions import WatchError
@@ -8,7 +8,7 @@ from .job import Job
 
 class Dependency:
     @classmethod
-    def get_jobs_with_met_dependencies(cls, jobs: List['Job'], pipeline: Pipeline):
+    def get_jobs_with_met_dependencies(cls, jobs: Iterable['Job'], pipeline: Pipeline):
         jobs_with_met_dependencies = []
         jobs_with_unmet_dependencies = []
         for job in jobs:

--- a/rq/group.py
+++ b/rq/group.py
@@ -25,7 +25,7 @@ class Group:
         self.key = '{0}{1}'.format(self.REDIS_GROUP_NAME_PREFIX, self.name)
 
     def __repr__(self):
-        return "Group(id={})".format(self.name)
+        return 'Group(id={})'.format(self.name)
 
     def _add_jobs(self, jobs: Iterable[Job], pipeline: Pipeline):
         """Add jobs to the group"""

--- a/rq/group.py
+++ b/rq/group.py
@@ -1,4 +1,5 @@
-from collections.abc import Iterable
+# TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
+from typing import Iterable
 from typing import List, Optional
 from uuid import uuid4
 

--- a/rq/group.py
+++ b/rq/group.py
@@ -1,4 +1,5 @@
-from typing import List, Iterable, Optional
+from collections.abc import Iterable
+from typing import List, Optional
 from uuid import uuid4
 
 from redis import Redis

--- a/rq/group.py
+++ b/rq/group.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Iterable, Optional
 from uuid import uuid4
 
 from redis import Redis
@@ -25,7 +25,7 @@ class Group:
     def __repr__(self):
         return "Group(id={})".format(self.name)
 
-    def _add_jobs(self, jobs: List[Job], pipeline: Pipeline):
+    def _add_jobs(self, jobs: Iterable[Job], pipeline: Pipeline):
         """Add jobs to the group"""
         pipeline.sadd(self.key, *[job.id for job in jobs])
         pipeline.sadd(self.REDIS_GROUP_KEY, self.name)
@@ -49,7 +49,7 @@ class Group:
         if pipeline is None:
             pipe.execute()
 
-    def enqueue_many(self, queue: Queue, job_datas: List['EnqueueData'], pipeline: Optional['Pipeline'] = None):
+    def enqueue_many(self, queue: Queue, job_datas: Iterable['EnqueueData'], pipeline: Optional['Pipeline'] = None):
         pipe = pipeline if pipeline else self.connection.pipeline()
 
         jobs = queue.enqueue_many(job_datas, group_id=self.name, pipeline=pipe)

--- a/rq/group.py
+++ b/rq/group.py
@@ -1,6 +1,5 @@
 # TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
-from typing import Iterable
-from typing import List, Optional
+from typing import Iterable, List, Optional
 from uuid import uuid4
 
 from redis import Redis

--- a/rq/job.py
+++ b/rq/job.py
@@ -45,7 +45,7 @@ from .utils import (
     utcformat,
 )
 
-logger = logging.getLogger("rq.job")
+logger = logging.getLogger('rq.job')
 
 
 class JobStatus(str, Enum):
@@ -86,9 +86,9 @@ class Dependency:
         """
         dependent_jobs = ensure_list(jobs)
         if not all(isinstance(job, Job) or isinstance(job, str) for job in dependent_jobs if job):
-            raise ValueError("jobs: must contain objects of type Job and/or strings representing Job ids")
+            raise ValueError('jobs: must contain objects of type Job and/or strings representing Job ids')
         elif len(dependent_jobs) < 1:
-            raise ValueError("jobs: cannot be empty.")
+            raise ValueError('jobs: cannot be empty.')
 
         self.dependencies = dependent_jobs
         self.allow_failure = allow_failure
@@ -126,9 +126,9 @@ def get_current_job(connection: Optional['Redis'] = None, job_class: Optional['J
         job (Optional[Job]): The current Job running
     """
     if connection:
-        warnings.warn("connection argument for get_current_job is deprecated.", DeprecationWarning)
+        warnings.warn('connection argument for get_current_job is deprecated.', DeprecationWarning)
     if job_class:
-        warnings.warn("job_class argument for get_current_job is deprecated.", DeprecationWarning)
+        warnings.warn('job_class argument for get_current_job is deprecated.', DeprecationWarning)
     return _job_stack.top
 
 
@@ -397,7 +397,7 @@ class Job:
         if refresh:
             status = self.connection.hget(self.key, 'status')
             if not status:
-                raise InvalidJobOperation(f"Failed to retrieve status for job: {self.id}")
+                raise InvalidJobOperation(f'Failed to retrieve status for job: {self.id}')
             self._status = JobStatus(as_text(status))
         return self._status
 
@@ -730,7 +730,7 @@ class Job:
         if not isinstance(value, str):
             raise TypeError('id must be a string, not {0}'.format(type(value)))
 
-        if ":" in value:
+        if ':' in value:
             raise ValueError('id must not contain ":"')
 
         self._id = value
@@ -822,7 +822,7 @@ class Job:
         """
         Get the latest result and returns `exc_info` only if the latest result is a failure.
         """
-        warnings.warn("job.exc_info is deprecated, use job.latest_result() instead.", DeprecationWarning)
+        warnings.warn('job.exc_info is deprecated, use job.latest_result() instead.', DeprecationWarning)
 
         from .results import Result
 
@@ -886,7 +886,7 @@ class Job:
         seconds by default).
         """
 
-        warnings.warn("job.result is deprecated, use job.return_value instead.", DeprecationWarning)
+        warnings.warn('job.result is deprecated, use job.return_value instead.', DeprecationWarning)
 
         from .results import Result
 
@@ -1064,7 +1064,7 @@ class Job:
             try:
                 obj['result'] = self.serializer.dumps(self._result)
             except:  # noqa
-                obj['result'] = "Unserializable return value"
+                obj['result'] = 'Unserializable return value'
         if self._exc_info is not None and include_result:
             obj['exc_info'] = zlib.compress(str(self._exc_info).encode('utf-8'))
         if self.timeout is not None:
@@ -1091,10 +1091,10 @@ class Job:
 
         if self.allow_dependency_failures is not None:
             # convert boolean to integer to avoid redis.exception.DataError
-            obj["allow_dependency_failures"] = int(self.allow_dependency_failures)
+            obj['allow_dependency_failures'] = int(self.allow_dependency_failures)
 
         if self.enqueue_at_front is not None:
-            obj["enqueue_at_front"] = int(self.enqueue_at_front)
+            obj['enqueue_at_front'] = int(self.enqueue_at_front)
 
         return obj
 
@@ -1158,7 +1158,7 @@ class Job:
             InvalidJobOperation: If the job has already been cancelled.
         """
         if self.is_canceled:
-            raise InvalidJobOperation("Cannot cancel already canceled job: {}".format(self.get_id()))
+            raise InvalidJobOperation('Cannot cancel already canceled job: {}'.format(self.get_id()))
         from .queue import Queue
         from .registry import CanceledJobRegistry
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -69,6 +69,8 @@ def parse_job_id(job_or_execution_id: str) -> str:
 
 
 class Dependency:
+    dependencies: List[Union['Job', str]]
+
     def __init__(self, jobs: Iterable[Union['Job', str]], allow_failure: bool = False, enqueue_at_front: bool = False):
         """The definition of a Dependency.
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -69,11 +69,11 @@ def parse_job_id(job_or_execution_id: str) -> str:
 
 
 class Dependency:
-    def __init__(self, jobs: List[Union['Job', str]], allow_failure: bool = False, enqueue_at_front: bool = False):
+    def __init__(self, jobs: Iterable[Union['Job', str]], allow_failure: bool = False, enqueue_at_front: bool = False):
         """The definition of a Dependency.
 
         Args:
-            jobs (List[Union[Job, str]]): A list of Job instances or Job IDs.
+            jobs (Iterable[Union[Job, str]]): An iterable of Job instances or Job IDs.
                 Anything different will raise a ValueError
             allow_failure (bool, optional): Whether to allow for failure when running the depency,
                 meaning, the dependencies should continue running even after one of them failed.

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -292,11 +292,7 @@ class Queue:
                 count = count + 1
             end
             return count
-        """.format(
-            self.job_class.redis_job_namespace_prefix
-        ).encode(
-            'utf-8'
-        )
+        """.format(self.job_class.redis_job_namespace_prefix).encode('utf-8')
         script = self.connection.register_script(script)
         return script(keys=[self.key])
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -4,10 +4,23 @@ import traceback
 import uuid
 import warnings
 from collections import namedtuple
-from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta, timezone
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+
+# TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
+from typing import Iterable, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from redis import WatchError
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -4,9 +4,10 @@ import traceback
 import uuid
 import warnings
 from collections import namedtuple
+from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta, timezone
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Iterable, Sequence, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
 
 from redis import WatchError
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -42,29 +42,29 @@ from .serializers import resolve_serializer
 from .types import FunctionReferenceType, JobDependencyType
 from .utils import as_text, backend_class, compact, get_version, import_attribute, now, parse_timeout
 
-logger = logging.getLogger("rq.queue")
+logger = logging.getLogger('rq.queue')
 
 
 class EnqueueData(
     namedtuple(
         'EnqueueData',
         [
-            "func",
-            "args",
-            "kwargs",
-            "timeout",
-            "result_ttl",
-            "ttl",
-            "failure_ttl",
-            "description",
-            "depends_on",
-            "job_id",
-            "at_front",
-            "meta",
-            "retry",
-            "on_success",
-            "on_failure",
-            "on_stopped",
+            'func',
+            'args',
+            'kwargs',
+            'timeout',
+            'result_ttl',
+            'ttl',
+            'failure_ttl',
+            'description',
+            'depends_on',
+            'job_id',
+            'at_front',
+            'meta',
+            'retry',
+            'on_success',
+            'on_failure',
+            'on_stopped',
         ],
     )
 ):
@@ -292,11 +292,7 @@ class Queue:
                 count = count + 1
             end
             return count
-        """.format(
-            self.job_class.redis_job_namespace_prefix
-        ).encode(
-            "utf-8"
-        )
+        """.format(self.job_class.redis_job_namespace_prefix).encode('utf-8')
         script = self.connection.register_script(script)
         return script(keys=[self.key])
 
@@ -823,23 +819,23 @@ class Queue:
 
         def get_job_kwargs(job_data, initial_status):
             return {
-                "func": job_data.func,
-                "args": job_data.args,
-                "kwargs": job_data.kwargs,
-                "result_ttl": job_data.result_ttl,
-                "ttl": job_data.ttl,
-                "failure_ttl": job_data.failure_ttl,
-                "description": job_data.description,
-                "depends_on": job_data.depends_on,
-                "job_id": job_data.job_id,
-                "meta": job_data.meta,
-                "status": initial_status,
-                "timeout": job_data.timeout,
-                "retry": job_data.retry,
-                "on_success": job_data.on_success,
-                "on_failure": job_data.on_failure,
-                "on_stopped": job_data.on_stopped,
-                "group_id": group_id,
+                'func': job_data.func,
+                'args': job_data.args,
+                'kwargs': job_data.kwargs,
+                'result_ttl': job_data.result_ttl,
+                'ttl': job_data.ttl,
+                'failure_ttl': job_data.failure_ttl,
+                'description': job_data.description,
+                'depends_on': job_data.depends_on,
+                'job_id': job_data.job_id,
+                'meta': job_data.meta,
+                'status': initial_status,
+                'timeout': job_data.timeout,
+                'retry': job_data.retry,
+                'on_success': job_data.on_success,
+                'on_failure': job_data.on_failure,
+                'on_stopped': job_data.on_stopped,
+                'group_id': group_id,
             }
 
         # Enqueue jobs without dependencies
@@ -1315,11 +1311,11 @@ class Queue:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
             colored_queues = ', '.join(map(str, [green(str(queue)) for queue in queue_keys]))
             # We use percent placeholder for logger because we don't want to build message when log level doesnot match.
-            logger.debug("Starting BLPOP operation for queues %s with timeout of %d", colored_queues, timeout)
+            logger.debug('Starting BLPOP operation for queues %s with timeout of %d', colored_queues, timeout)
             assert connection
             result = connection.blpop(queue_keys, timeout)
             if result is None:
-                logger.debug("BLPOP timeout, no jobs found on queues %s", colored_queues)
+                logger.debug('BLPOP timeout, no jobs found on queues %s', colored_queues)
                 raise DequeueTimeout(timeout, queue_keys)
             queue_key, job_id = result
             return queue_key, job_id
@@ -1341,10 +1337,10 @@ class Queue:
             if timeout == 0:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
             colored_queue = green(queue_key)
-            logger.debug(f"Starting BLMOVE operation for {colored_queue} with timeout of {timeout}")
+            logger.debug(f'Starting BLMOVE operation for {colored_queue} with timeout of {timeout}')
             result: Optional[Any] = connection.blmove(queue_key, intermediate_queue.key, timeout)
             if result is None:
-                logger.debug(f"BLMOVE timeout, no jobs found on {colored_queue}")
+                logger.debug(f'BLMOVE timeout, no jobs found on {colored_queue}')
                 raise DequeueTimeout(timeout, queue_key)
             return queue_key, result
         else:  # non-blocking variant

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -292,7 +292,11 @@ class Queue:
                 count = count + 1
             end
             return count
-        """.format(self.job_class.redis_job_namespace_prefix).encode('utf-8')
+        """.format(
+            self.job_class.redis_job_namespace_prefix
+        ).encode(
+            'utf-8'
+        )
         script = self.connection.register_script(script)
         return script(keys=[self.key])
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -8,14 +8,15 @@ from datetime import datetime, timedelta, timezone
 from functools import total_ordering
 
 # TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
-from typing import Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Optional,
+    Sequence,
     Tuple,
     Type,
     Union,

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -41,6 +41,7 @@ from .exceptions import TimeoutFormatError
 _T = TypeVar('_T')
 _O = TypeVar('_O', bound=object)
 _BT = TypeVar('_BT', bool, int, float, str, bytes)
+ObjOrStr = Union[_O, str]
 
 
 logger = logging.getLogger(__name__)
@@ -228,8 +229,8 @@ def is_nonstring_iterable(obj: Any) -> bool:
 
 @overload
 def ensure_list(obj: str) -> List[str]: ...
-# @overload
-# def ensure_list(obj: Iterable[Union[_O, str]]) -> List[Union[_O, str]]: ...
+@overload
+def ensure_list(obj: Iterable[ObjOrStr]) -> List[ObjOrStr]: ...
 @overload
 def ensure_list(obj: Union[_BT, Iterable[_BT]]) -> List[_BT]: ...
 @overload

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -166,7 +166,9 @@ def utcparse(string: str) -> dt.datetime:
             return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
 
 
-def first(iterable: Iterable[_T], default: Optional[_T] = None, key: Optional[Callable[[_T], bool]] = None) -> Optional[_T]:
+def first(
+    iterable: Iterable[_T], default: Optional[_T] = None, key: Optional[Callable[[_T], bool]] = None
+) -> Optional[_T]:
     """Return first element of `iterable` that evaluates true, else return None
     (or an optional default value).
 

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -313,19 +313,19 @@ def get_version(connection: 'Redis') -> Tuple[int, int, int]:
     """
     try:
         # Getting the connection info for each job tanks performance, we can cache it on the connection object
-        if not getattr(connection, "__rq_redis_server_version", None):
+        if not getattr(connection, '__rq_redis_server_version', None):
             # Cast the version string to a tuple of integers. Some Redis implementations may return a float.
-            version_str = str(connection.info("server")["redis_version"])
+            version_str = str(connection.info('server')['redis_version'])
             version_parts = [int(i) for i in version_str.split('.')[:3]]
             # Ensure the version tuple has exactly three elements
             while len(version_parts) < 3:
                 version_parts.append(0)
             setattr(
                 connection,
-                "__rq_redis_server_version",
+                '__rq_redis_server_version',
                 tuple(version_parts),
             )
-        return getattr(connection, "__rq_redis_server_version")
+        return getattr(connection, '__rq_redis_server_version')
     except ResponseError:  # fakeredis doesn't implement Redis' INFO command
         return (5, 0, 9)
 

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -13,14 +13,16 @@ import logging
 import numbers
 
 # TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
-from typing import Generator, Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Dict,
+    Generator,
+    Iterable,
     List,
     Optional,
+    Sequence,
     Tuple,
     Type,
     TypeVar,
@@ -36,7 +38,6 @@ if TYPE_CHECKING:
 from redis.exceptions import ResponseError
 
 from .exceptions import TimeoutFormatError
-
 
 _T = TypeVar('_T')
 _O = TypeVar('_O', bound=object)

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -11,7 +11,7 @@ import datetime as dt
 import importlib
 import logging
 import numbers
-from collections.abc import Generator, Hashable, Iterable, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 if TYPE_CHECKING:
@@ -60,7 +60,7 @@ def as_text(v: Union[bytes, str]) -> str:
         raise ValueError('Unknown type %r' % type(v))
 
 
-def decode_redis_hash(h: Dict[Hashable, _T]) -> Dict[str, _T]:
+def decode_redis_hash(h: Dict[Union[bytes, str], _T]) -> Dict[str, _T]:
     """Decodes the Redis hash, ensuring that keys are strings
     Most importantly, decodes bytes strings, ensuring the dict has str keys.
 
@@ -149,7 +149,7 @@ def utcparse(string: str) -> dt.datetime:
             return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
 
 
-def first(iterable: Iterable, default=None, key=None):
+def first(iterable: Iterable[_T], default: Optional[_T] = None, key: Optional[Callable[[_T], bool]] = None) -> Optional[_T]:
     """Return first element of `iterable` that evaluates true, else return None
     (or an optional default value).
 
@@ -206,14 +206,14 @@ def is_nonstring_iterable(obj: Any) -> bool:
     return isinstance(obj, Iterable) and not isinstance(obj, str)
 
 
-def ensure_list(obj: Any) -> List:
+def ensure_list(obj: Union[Iterable[_T], _T]) -> List[_T]:
     """When passed an iterable of objects, does nothing, otherwise, it returns
     a list with just that object in it.
 
     Args:
         obj (Any): _description_
 
-    Returns:
+    returns:
         List: _description_
     """
     return obj if is_nonstring_iterable(obj) else [obj]

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -39,7 +39,8 @@ from .exceptions import TimeoutFormatError
 
 
 _T = TypeVar('_T')
-BasicType = Union[bool, int, float, str, bytes, object]
+_O = TypeVar('_O', bound=object)
+_BT = TypeVar('_BT', bool, int, float, str, bytes)
 
 
 logger = logging.getLogger(__name__)
@@ -227,8 +228,12 @@ def is_nonstring_iterable(obj: Any) -> bool:
 
 @overload
 def ensure_list(obj: str) -> List[str]: ...
+# @overload
+# def ensure_list(obj: Iterable[Union[_O, str]]) -> List[Union[_O, str]]: ...
 @overload
-def ensure_list(obj: Union[BasicType, Iterable[BasicType]]) -> List[BasicType]: ...
+def ensure_list(obj: Union[_BT, Iterable[_BT]]) -> List[_BT]: ...
+@overload
+def ensure_list(obj: Union[_O, Iterable[_O]]) -> List[_O]: ...
 def ensure_list(obj):
     """When passed an iterable of objects, convert to list, otherwise, it returns
     a list with just that object in it.

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -11,8 +11,8 @@ import datetime as dt
 import importlib
 import logging
 import numbers
-from collections.abc import Iterable, Hashable
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Sequence, Generator, Type, Union, TypeVar
+from collections.abc import Generator, Hashable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 if TYPE_CHECKING:
     from redis import Redis

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -4,9 +4,9 @@ import logging
 import os
 import signal
 import time
+from collections.abc import Iterable
 from enum import Enum
 from multiprocessing import Process
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Type, Union
 from uuid import uuid4
 

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -6,6 +6,7 @@ import signal
 import time
 from enum import Enum
 from multiprocessing import Process
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Type, Union
 from uuid import uuid4
 
@@ -39,7 +40,7 @@ class WorkerPool:
 
     def __init__(
         self,
-        queues: List[Union[str, Queue]],
+        queues: Iterable[Union[str, Queue]],
         connection: Redis,
         num_workers: int = 1,
         worker_class: Type[BaseWorker] = Worker,
@@ -242,7 +243,7 @@ class WorkerPool:
 
 def run_worker(
     worker_name: str,
-    queue_names: List[str],
+    queue_names: Iterable[str],
     connection_class,
     connection_pool_class,
     connection_pool_kwargs: dict,

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -152,7 +152,7 @@ class WorkerPool:
         name: str,
         burst: bool,
         _sleep: float = 0,
-        logging_level: str = "INFO",
+        logging_level: str = 'INFO',
     ) -> Process:
         """Returns the worker process"""
         return Process(
@@ -174,7 +174,7 @@ class WorkerPool:
         count: Optional[int] = None,
         burst: bool = True,
         _sleep: float = 0,
-        logging_level: str = "INFO",
+        logging_level: str = 'INFO',
     ):
         """
         Starts a worker and adds the data to worker_datas.
@@ -187,7 +187,7 @@ class WorkerPool:
         self.worker_dict[name] = worker_data
         self.log.debug('Spawned worker: %s with PID %d', name, process.pid)
 
-    def start_workers(self, burst: bool = True, _sleep: float = 0, logging_level: str = "INFO"):
+    def start_workers(self, burst: bool = True, _sleep: float = 0, logging_level: str = 'INFO'):
         """
         Run the workers
         * sleep: waits for X seconds before creating worker, only for testing purposes
@@ -217,7 +217,7 @@ class WorkerPool:
         for worker_data in worker_datas:
             self.stop_worker(worker_data)
 
-    def start(self, burst: bool = False, logging_level: str = "INFO"):
+    def start(self, burst: bool = False, logging_level: str = 'INFO'):
         self._burst = burst
         respawn = not burst  # Don't respawn workers if burst mode is on
         setup_loghandlers(logging_level, DEFAULT_LOGGING_DATE_FORMAT, DEFAULT_LOGGING_FORMAT, name=__name__)
@@ -253,7 +253,7 @@ def run_worker(
     serializer: Type['Serializer'] = DefaultSerializer,
     job_class: Type[Job] = Job,
     burst: bool = True,
-    logging_level: str = "INFO",
+    logging_level: str = 'INFO',
     _sleep: int = 0,
 ):
     connection = connection_class(
@@ -261,6 +261,6 @@ def run_worker(
     )
     queues = [Queue(name, connection=connection) for name in queue_names]
     worker = worker_class(queues, name=worker_name, connection=connection, serializer=serializer, job_class=job_class)
-    worker.log.info("Starting worker started with PID %s", os.getpid())
+    worker.log.info('Starting worker started with PID %s', os.getpid())
     time.sleep(_sleep)
     worker.work(burst=burst, with_scheduler=True, logging_level=logging_level)

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -8,8 +8,7 @@ from enum import Enum
 from multiprocessing import Process
 
 # TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
-from typing import Iterable
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Type, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, NamedTuple, Optional, Type, Union
 from uuid import uuid4
 
 from redis import ConnectionPool, Redis

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -4,9 +4,11 @@ import logging
 import os
 import signal
 import time
-from collections.abc import Iterable
 from enum import Enum
 from multiprocessing import Process
+
+# TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
+from typing import Iterable
 from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Type, Union
 from uuid import uuid4
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,8 +71,8 @@ class TestUtils(RQTestCase):
         """Ensure function ensure_list works correctly"""
         self.assertEqual([], ensure_list([]))
         self.assertEqual(['test'], ensure_list('test'))
-        self.assertEqual({}, ensure_list({}))
-        self.assertEqual((), ensure_list(()))
+        self.assertEqual([], ensure_list({}))
+        self.assertEqual([], ensure_list(()))
 
     def test_utcparse(self):
         """Ensure function utcparse works correctly"""

--- a/tox.ini
+++ b/tox.ini
@@ -14,10 +14,8 @@ passenv=
 ; [testenv:lint]
 ; basepython = python3.10
 ; deps =
-;     black
 ;     ruff
 ; commands =
-;     black --check rq tests
 ;     ruff check rq tests
 
 [testenv:py37]


### PR DESCRIPTION
Many functions declare input parameter type as `List[T]` but only need to iterate over it. This PR changes the type of `Iterable[T]` or `Sequence[T]` to let user pass `tuple`, `deque`, generator.

`Iterable` is broader than `Sequence`, allowing user to pass generator. But a generator can only be iterated once (after that, it will exhaust), so if the function uses that argument twice, we limit the type to `Sequence`.

I also change some type hint from `Any` to generic type (using `TypeVar`) because `Any` makes type checker (MyPy, Pyright useless).

I observe that many function return data as a list, but that data then is not mutated. In that case, I think we better use `tuple` because it is has lower overhead than list and it is immutable, better match our use case.