### PR TITLE
Delete expired groups from registry

### DIFF
--- a/rq/group.py
+++ b/rq/group.py
@@ -89,7 +89,13 @@ class Group:
     def all(cls, connection: 'Redis') -> List['Group']:
         "Returns an iterable of all Groupes."
         group_keys = [as_text(key) for key in connection.smembers(cls.REDIS_GROUP_KEY)]
-        return [cls.fetch(key, connection=connection) for key in group_keys]
+        groups = []
+        for key in group_keys:
+            try:
+                groups.append(cls.fetch(key, connection=connection))
+            except NoSuchGroupError:
+                connection.srem(cls.REDIS_GROUP_KEY, key)
+        return groups
 
     @classmethod
     def get_key(cls, name: str) -> str:

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -142,3 +142,11 @@ class TestGroup(RQTestCase):
         assert len(all_groups) == 1
         assert "group1" in [group.name for group in all_groups]
         assert "group2" not in [group.name for group in all_groups]
+
+    def test_all_deletes_missing_groups(self):
+        q = Queue(connection=self.connection)
+        group = Group.create(connection=self.connection)
+        jobs = group.enqueue_many(q, [self.job_1_data])
+        jobs[0].delete()
+        assert not self.connection.exists(Group.get_key(group.name))
+        assert Group.all(connection=self.connection) == []


### PR DESCRIPTION
This was causing a bug when workers call `run_maintenance_tasks`, which involves cleaning up groups whose jobs have expired. 

If the group has already been deleted from Redis, due to all member jobs having been manually deleted with `job.delete()`, then the `Group.all()` method will raise a `NoSuchGroupError` as it iterates through the `rq:groups` set. 

This change will handle the `NoSuchGroupError` and remove the missing group from the registry.