### PR TITLE
Lift restriction on function parameter types

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -481,7 +481,7 @@ def worker_pool(
         logging_level = None
 
     pool = WorkerPool(
-        queue_names,  # type: ignore[arg-type]
+        queue_names,
         connection=cli_config.connection,
         num_workers=num_workers,
         serializer=serializer_class,

--- a/rq/dependency.py
+++ b/rq/dependency.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Iterable
 
 from redis.client import Pipeline
 from redis.exceptions import WatchError
@@ -8,7 +8,7 @@ from .job import Job
 
 class Dependency:
     @classmethod
-    def get_jobs_with_met_dependencies(cls, jobs: List['Job'], pipeline: Pipeline):
+    def get_jobs_with_met_dependencies(cls, jobs: Iterable['Job'], pipeline: Pipeline):
         jobs_with_met_dependencies = []
         jobs_with_unmet_dependencies = []
         for job in jobs:

--- a/rq/group.py
+++ b/rq/group.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+# TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
+from typing import Iterable, List, Optional
 from uuid import uuid4
 
 from redis import Redis
@@ -25,7 +26,7 @@ class Group:
     def __repr__(self):
         return 'Group(id={})'.format(self.name)
 
-    def _add_jobs(self, jobs: List[Job], pipeline: Pipeline):
+    def _add_jobs(self, jobs: Iterable[Job], pipeline: Pipeline):
         """Add jobs to the group"""
         pipeline.sadd(self.key, *[job.id for job in jobs])
         pipeline.sadd(self.REDIS_GROUP_KEY, self.name)
@@ -49,7 +50,7 @@ class Group:
         if pipeline is None:
             pipe.execute()
 
-    def enqueue_many(self, queue: Queue, job_datas: List['EnqueueData'], pipeline: Optional['Pipeline'] = None):
+    def enqueue_many(self, queue: Queue, job_datas: Iterable['EnqueueData'], pipeline: Optional['Pipeline'] = None):
         pipe = pipeline if pipeline else self.connection.pipeline()
 
         jobs = queue.enqueue_many(job_datas, group_id=self.name, pipeline=pipe)

--- a/rq/job.py
+++ b/rq/job.py
@@ -69,11 +69,13 @@ def parse_job_id(job_or_execution_id: str) -> str:
 
 
 class Dependency:
-    def __init__(self, jobs: List[Union['Job', str]], allow_failure: bool = False, enqueue_at_front: bool = False):
+    dependencies: List[Union['Job', str]]
+
+    def __init__(self, jobs: Iterable[Union['Job', str]], allow_failure: bool = False, enqueue_at_front: bool = False):
         """The definition of a Dependency.
 
         Args:
-            jobs (List[Union[Job, str]]): A list of Job instances or Job IDs.
+            jobs (Iterable[Union[Job, str]]): An iterable of Job instances or Job IDs.
                 Anything different will raise a ValueError
             allow_failure (bool, optional): Whether to allow for failure when running the depency,
                 meaning, the dependencies should continue running even after one of them failed.

--- a/rq/job.py
+++ b/rq/job.py
@@ -35,7 +35,7 @@ from .types import FunctionReferenceType, JobDependencyType
 from .utils import (
     as_text,
     decode_redis_hash,
-    ensure_list,
+    ensure_job_list,
     get_call_string,
     get_version,
     import_attribute,
@@ -86,7 +86,7 @@ class Dependency:
         Raises:
             ValueError: If the `jobs` param has anything different than `str` or `Job` class or the job list is empty
         """
-        dependent_jobs = ensure_list(jobs)
+        dependent_jobs = ensure_job_list(jobs)
         if not all(isinstance(job, Job) or isinstance(job, str) for job in dependent_jobs if job):
             raise ValueError('jobs: must contain objects of type Job and/or strings representing Job ids')
         elif len(dependent_jobs) < 1:
@@ -358,7 +358,7 @@ class Job:
         # dependency could be job instance or id, or iterable thereof
         if depends_on is not None:
             depends_on_list = []
-            for depends_on_item in ensure_list(depends_on):
+            for depends_on_item in ensure_job_list(depends_on):
                 if isinstance(depends_on_item, Dependency):
                     # If a Dependency has enqueue_at_front or allow_failure set to True, these behaviors are used for
                     # all dependencies.
@@ -366,7 +366,7 @@ class Job:
                     job.allow_dependency_failures = job.allow_dependency_failures or depends_on_item.allow_failure
                     depends_on_list.extend(depends_on_item.dependencies)
                 else:
-                    depends_on_list.extend(ensure_list(depends_on_item))
+                    depends_on_list.extend(ensure_job_list(depends_on_item))
             job._dependency_ids = [dep.id if isinstance(dep, Job) else dep for dep in depends_on_list]
 
         return job

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -6,7 +6,22 @@ import warnings
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
 from functools import total_ordering
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+
+# TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from redis import WatchError
 
@@ -786,7 +801,7 @@ class Queue:
         )
 
     def enqueue_many(
-        self, job_datas: List['EnqueueData'], pipeline: Optional['Pipeline'] = None, group_id: Optional[str] = None
+        self, job_datas: Iterable['EnqueueData'], pipeline: Optional['Pipeline'] = None, group_id: Optional[str] = None
     ) -> List[Job]:
         """Creates multiple jobs (created via `Queue.prepare_data` calls)
         to represent the delayed function calls and enqueues them.
@@ -1264,8 +1279,10 @@ class Queue:
         """
         return as_text(self.connection.lpop(self.key))
 
+    # The queue_keys type is Sequence[str] instead of Iterable[str]
+    # because we loop over it twice, and we don't want user to pass a generator.
     @classmethod
-    def lpop(cls, queue_keys: List[str], timeout: Optional[int], connection: Optional['Redis'] = None):
+    def lpop(cls, queue_keys: Sequence[str], timeout: Optional[int], connection: Optional['Redis'] = None):
         """Helper method to abstract away from some Redis API details
         where LPOP accepts only a single key, whereas BLPOP
         accepts multiple.  So if we want the non-blocking LPOP, we need to
@@ -1279,7 +1296,7 @@ class Queue:
              > 0 - maximum number of seconds to block
 
         Args:
-            queue_keys (_type_): _description_
+            queue_keys (Sequence[str]): _description_
             timeout (Optional[int]): _description_
             connection (Optional[Redis], optional): _description_. Defaults to None.
 
@@ -1294,11 +1311,11 @@ class Queue:
             if timeout == 0:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
             colored_queues = ', '.join(map(str, [green(str(queue)) for queue in queue_keys]))
-            logger.debug(f'Starting BLPOP operation for queues {colored_queues} with timeout of {timeout}')
+            logger.debug("Starting BLPOP operation for queues %s with timeout of %d", colored_queues, timeout)
             assert connection
             result = connection.blpop(queue_keys, timeout)
             if result is None:
-                logger.debug(f'BLPOP timeout, no jobs found on queues {colored_queues}')
+                logger.debug('BLPOP timeout, no jobs found on queues %s', colored_queues)
                 raise DequeueTimeout(timeout, queue_keys)
             queue_key, job_id = result
             return queue_key, job_id
@@ -1335,7 +1352,7 @@ class Queue:
     @classmethod
     def dequeue_any(
         cls,
-        queues: List['Queue'],
+        queues: Iterable['Queue'],
         timeout: Optional[int],
         connection: 'Redis',
         job_class: Optional[Type['Job']] = None,
@@ -1353,7 +1370,7 @@ class Queue:
         See the documentation of cls.lpop for the interpretation of timeout.
 
         Args:
-            queues (List[Queue]): List of queue objects
+            queues (Iterable[Queue]): Iterable of queue objects
             timeout (Optional[int]): Timeout for the LPOP
             connection (Optional[Redis], optional): Redis Connection. Defaults to None.
             job_class (Optional[Type[Job]], optional): The job class. Defaults to None.

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -48,7 +48,7 @@ ObjOrStr = Union[_O, str]
 logger = logging.getLogger(__name__)
 
 
-def compact(lst: Iterable[_T]) -> List[_T]:
+def compact(lst: Iterable[Optional[_T]]) -> List[_T]:
     """Excludes `None` values from a list-like object.
 
     Args:
@@ -229,14 +229,10 @@ def is_nonstring_iterable(obj: Any) -> bool:
 
 
 @overload
-def ensure_list(obj: str) -> List[str]: ...
+def ensure_job_list(obj: ObjOrStr) -> List[ObjOrStr]: ...
 @overload
-def ensure_list(obj: Iterable[ObjOrStr]) -> List[ObjOrStr]: ...
-@overload
-def ensure_list(obj: Union[_BT, Iterable[_BT]]) -> List[_BT]: ...
-@overload
-def ensure_list(obj: Union[_O, Iterable[_O]]) -> List[_O]: ...
-def ensure_list(obj):
+def ensure_job_list(obj: Iterable[ObjOrStr]) -> List[ObjOrStr]: ...
+def ensure_job_list(obj):
     """When passed an iterable of objects, convert to list, otherwise, it returns
     a list with just that object in it.
 

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -41,7 +41,6 @@ from .exceptions import TimeoutFormatError
 
 _T = TypeVar('_T')
 _O = TypeVar('_O', bound=object)
-_BT = TypeVar('_BT', bool, int, float, str, bytes)
 ObjOrStr = Union[_O, str]
 
 
@@ -167,53 +166,6 @@ def utcparse(string: str) -> dt.datetime:
             return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%S.%fZ')
         except ValueError:
             return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
-
-
-def first(
-    iterable: Iterable[_T], default: Optional[_T] = None, key: Optional[Callable[[_T], bool]] = None
-) -> Optional[_T]:
-    """Return first element of `iterable` that evaluates true, else return None
-    (or an optional default value).
-
-    >>> first([0, False, None, [], (), 42])
-    42
-
-    >>> first([0, False, None, [], ()]) is None
-    True
-
-    >>> first([0, False, None, [], ()], default='ohai')
-    'ohai'
-
-    >>> import re
-    >>> m = first(re.match(regex, 'abc') for regex in ['b.*', 'a(.*)'])
-    >>> m.group(1)
-    'bc'
-
-    The optional `key` argument specifies a one-argument predicate function
-    like that used for `filter()`.  The `key` argument, if supplied, must be
-    in keyword form.  For example:
-
-    >>> first([1, 1, 3, 4, 5], key=lambda x: x % 2 == 0)
-    4
-
-    Args:
-        iterable (t.Iterable): _description_
-        default (_type_, optional): _description_. Defaults to None.
-        key (_type_, optional): _description_. Defaults to None.
-
-    Returns:
-        _type_: _description_
-    """
-    if key is None:
-        for el in iterable:
-            if el:
-                return el
-    else:
-        for el in iterable:
-            if key(el):
-                return el
-
-    return default
 
 
 def is_nonstring_iterable(obj: Any) -> bool:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -59,7 +59,7 @@ from .utils import (
     as_text,
     backend_class,
     compact,
-    ensure_list,
+    ensure_job_list,
     get_connection_from_queues,
     get_version,
     now,
@@ -191,7 +191,7 @@ class BaseWorker:
                 if isinstance(q, str)
                 else q
             )
-            for q in ensure_list(queues)
+            for q in ensure_job_list(queues)
         ]
 
         self.name: str = name or uuid4().hex
@@ -307,7 +307,7 @@ class BaseWorker:
         queue_class: Optional[Type['Queue']] = None,
         queue: Optional['Queue'] = None,
         serializer=None,
-    ) -> List['Worker']:
+    ) -> List['BaseWorker']:
         """Returns an iterable of all Workers.
 
         Returns:

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -6,7 +6,9 @@ import signal
 import time
 from enum import Enum
 from multiprocessing import Process
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Type, Union
+
+# TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
+from typing import TYPE_CHECKING, Dict, Iterable, List, NamedTuple, Optional, Type, Union
 from uuid import uuid4
 
 from redis import ConnectionPool, Redis
@@ -39,7 +41,7 @@ class WorkerPool:
 
     def __init__(
         self,
-        queues: List[Union[str, Queue]],
+        queues: Iterable[Union[str, Queue]],
         connection: Redis,
         num_workers: int = 1,
         worker_class: Type[BaseWorker] = Worker,
@@ -242,7 +244,7 @@ class WorkerPool:
 
 def run_worker(
     worker_name: str,
-    queue_names: List[str],
+    queue_names: Iterable[str],
     connection_class,
     connection_pool_class,
     connection_pool_kwargs: dict,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ from rq.utils import (
     as_text,
     backend_class,
     ceildiv,
-    ensure_list,
+    ensure_job_list,
     first,
     get_call_string,
     get_version,
@@ -69,10 +69,10 @@ class TestUtils(RQTestCase):
 
     def test_ensure_list(self):
         """Ensure function ensure_list works correctly"""
-        self.assertEqual([], ensure_list([]))
-        self.assertEqual(['test'], ensure_list('test'))
-        self.assertEqual([], ensure_list({}))
-        self.assertEqual([], ensure_list(()))
+        self.assertEqual([], ensure_job_list([]))
+        self.assertEqual(['test'], ensure_job_list('test'))
+        self.assertEqual([], ensure_job_list({}))
+        self.assertEqual([], ensure_job_list(()))
 
     def test_utcparse(self):
         """Ensure function utcparse works correctly"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,6 @@ from rq.utils import (
     backend_class,
     ceildiv,
     ensure_job_list,
-    first,
     get_call_string,
     get_version,
     import_attribute,
@@ -42,14 +41,6 @@ class TestUtils(RQTestCase):
         with self.assertRaises(TimeoutFormatError):
             for timeout in timeouts:
                 parse_timeout(timeout)
-
-    def test_first(self):
-        """Ensure function first works correctly"""
-        self.assertEqual(42, first([0, False, None, [], (), 42]))
-        self.assertEqual(None, first([0, False, None, [], ()]))
-        self.assertEqual('ohai', first([0, False, None, [], ()], default='ohai'))
-        self.assertEqual('bc', first(re.match(regex, 'abc') for regex in ['b.*', 'a(.*)']).group(1))
-        self.assertEqual(4, first([1, 1, 3, 4, 5], key=lambda x: x % 2 == 0))
 
     def test_is_nonstring_iterable(self):
         """Ensure function is_nonstring_iterable works correctly"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,8 +71,8 @@ class TestUtils(RQTestCase):
         """Ensure function ensure_list works correctly"""
         self.assertEqual([], ensure_list([]))
         self.assertEqual(['test'], ensure_list('test'))
-        self.assertEqual({}, ensure_list({}))
-        self.assertEqual((), ensure_list(()))
+        self.assertEqual([], ensure_list({}))
+        self.assertEqual([], ensure_list(()))
 
     def test_utcparse(self):
         """Ensure function utcparse works correctly"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import datetime
-import re
 from unittest.mock import Mock
 
 from redis import Redis


### PR DESCRIPTION
Many functions declare input parameter type as `List[T]` but only need to iterate over it. This PR changes the type of `Iterable[T]` or `Sequence[T]` to let user pass `tuple`, `deque`, generator.

`Iterable` is broader than `Sequence`, allowing user to pass generator. But a generator can only be iterated once (after that, it will exhaust), so if the function uses that argument twice, we limit the type to `Sequence`.

I also change some type hint from `Any` to generic type (using `TypeVar`) because `Any` makes type checker (MyPy, Pyright useless).

(This is a rework of #2146).

We will need more PR to get rid `Any` type.

For discussion:
I observe that many function return data as a list, but that data then is not mutated. In that case, I think we better use `tuple` because it is has lower overhead than `list` and it is immutable, better match our use case.
