### PR TITLE
Fix handling completed job with expired result when work horse dies

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1328,6 +1328,17 @@ class TestWorker(RQTestCase):
 
         self.assertEqual(expected, sorted_ids)
 
+    def test_monitor_work_horse_handles_performed_job_with_non_zero_exit_code_and_result_ttl_0(self):
+        q = Queue(connection=self.connection)
+        w = Worker([q])
+        perform_job = w.perform_job
+        def p(*args, **kwargs):
+            perform_job(*args, **kwargs)
+            raise Exception
+
+        w.perform_job = p
+        q.enqueue(say_hello, args=('ccc',), result_ttl=0)
+        self.assertTrue(w.work(burst=True))
 
 def wait_and_kill_work_horse(pid, time_to_wait=0.0):
     time.sleep(time_to_wait)


### PR DESCRIPTION
Since https://github.com/rq/rq/pull/2039, `Job.get_status()` doesn't return `None` but raises `InvalidJobOperation` when `refresh=True`.

This change was not handled properly in `Worker.monitor_work_horse()`.

I stumbled upon this with a use-case where a job with `result_ttl=0` succeeds but the work horse doesn't exit with `0` (because it's wrapped). `Job.get_status()` ends up being called and raises an uncaught error.

There's no existing test for the behavior and I wasn't able to produce one.