### PR TITLE
Add new queue to registry in enqueue_many

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -801,7 +801,7 @@ class Queue:
         pipe = pipeline if pipeline is not None else self.connection.pipeline()
 
         # Add Queue key set
-        pipe = pipeline if pipeline is not None else self.connection.pipeline()
+        pipe.sadd(self.redis_queues_keys, self.key)
 
         jobs_without_dependencies = []
         jobs_with_unmet_dependencies = []

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -799,6 +799,10 @@ class Queue:
             List[Job]: A list of enqueued jobs
         """
         pipe = pipeline if pipeline is not None else self.connection.pipeline()
+
+        # Add Queue key set
+        pipe = pipeline if pipeline is not None else self.connection.pipeline()
+
         jobs_without_dependencies = []
         jobs_with_unmet_dependencies = []
         jobs_with_met_dependencies = []

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -627,6 +627,7 @@ class TestQueue(RQTestCase):
         # Only in registry after execute, since passed in pipeline
         self.assertEqual(len(q), 3)
         self.assertEqual(q.job_ids, ['fake_job_id_3', 'fake_job_id_1', 'fake_job_id_2'])
+        self.assertEqual(len(Queue.all(connection=self.connection)), 1)
 
     def test_enqueue_many_with_passed_pipeline(self):
         """Jobs should be enqueued in bulk with a passed pipeline, enqueued in order provided


### PR DESCRIPTION
In https://github.com/rq/rq/commit/df5e99ba0b3274ab734cde612c270a788ee47ffc, the call to `sadd` new Queues to the `rq:queues` registry was moved from `queue._enqueue_job` to `queue.enqueue_job` due to `_enqueue_job` not being called on jobs that are deferred.

However, this broke the `queue.enqueue_many` function, which has its own handling for deferred jobs. Now, `enqueue_many` does not add the queue to `rq:queues`.

This change copies the `sadd` call to `enqueue_many` and tests that the registry contains the queue after the method is called.