### PR TITLE
FIX bug worker override logging configuration

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -164,7 +164,7 @@ def info(cli_config, interval, raw, only_queues, only_workers, by_queue, queues,
 
 @main.command()
 @click.option('--burst', '-b', is_flag=True, help='Run in burst mode (quit after all work is done)')
-@click.option('--logging_level', type=str, default='INFO', help='Set logging level')
+@click.option('--logging_level', type=str, default=None, help='Set logging level')
 @click.option('--log-format', type=str, default=DEFAULT_LOGGING_FORMAT, help='Set the format of the logs')
 @click.option('--date-format', type=str, default=DEFAULT_LOGGING_DATE_FORMAT, help='Set the date format of the logs')
 @click.option('--name', '-n', help='Specify a different name')

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -245,7 +245,8 @@ def setup_loghandlers_from_args(verbose, quiet, date_format, log_format):
     elif quiet:
         level = 'WARNING'
     else:
-        level = 'INFO'
+        # Pass None not to set logging level explicitly
+        level = None
     setup_loghandlers(level, date_format=date_format, log_format=log_format)
 
 

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -75,8 +75,10 @@ except ImportError:
     def setprocname(title: str) -> None:
         pass
 
-
+# Set initial level to INFO. 
 logger = logging.getLogger('rq.worker')
+if logger.level == logging.NOTSET:
+    logger.setLevel(logging.INFO)
 
 
 class StopRequested(Exception):
@@ -558,7 +560,7 @@ class BaseWorker:
     def work(
         self,
         burst: bool = False,
-        logging_level: str = 'INFO',
+        logging_level: Optional[str] = None,
         date_format: str = DEFAULT_LOGGING_DATE_FORMAT,
         log_format: str = DEFAULT_LOGGING_FORMAT,
         max_jobs: Optional[int] = None,
@@ -577,7 +579,8 @@ class BaseWorker:
 
         Args:
             burst (bool, optional): Whether to work on burst mode. Defaults to False.
-            logging_level (str, optional): Logging level to use. Defaults to "INFO".
+            logging_level (Optional[str], optional): Logging level to use. 
+                If not provided, defaults to "INFO" unless a class-level logging level is already set.
             date_format (str, optional): Date Format. Defaults to DEFAULT_LOGGING_DATE_FORMAT.
             log_format (str, optional): Log Format. Defaults to DEFAULT_LOGGING_FORMAT.
             max_jobs (Optional[int], optional): Max number of jobs. Defaults to None.
@@ -843,7 +846,7 @@ class BaseWorker:
         self.scheduler = RQScheduler(
             self.queues,
             connection=self.connection,
-            logging_level=logging_level,
+            logging_level=logging_level if logging_level is not None else self.log.level,
             date_format=date_format,
             log_format=log_format,
             serializer=self.serializer,

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -75,7 +75,7 @@ except ImportError:
     def setprocname(title: str) -> None:
         pass
 
-# Set initial level to INFO. 
+# Set initial level to INFO.
 logger = logging.getLogger('rq.worker')
 if logger.level == logging.NOTSET:
     logger.setLevel(logging.INFO)
@@ -579,7 +579,7 @@ class BaseWorker:
 
         Args:
             burst (bool, optional): Whether to work on burst mode. Defaults to False.
-            logging_level (Optional[str], optional): Logging level to use. 
+            logging_level (Optional[str], optional): Logging level to use.
                 If not provided, defaults to "INFO" unless a class-level logging level is already set.
             date_format (str, optional): Date Format. Defaults to DEFAULT_LOGGING_DATE_FORMAT.
             log_format (str, optional): Log Format. Defaults to DEFAULT_LOGGING_FORMAT.
@@ -826,7 +826,7 @@ class BaseWorker:
     def _start_scheduler(
         self,
         burst: bool = False,
-        logging_level: str = 'INFO',
+        logging_level: Optional[str] = 'INFO',
         date_format: str = DEFAULT_LOGGING_DATE_FORMAT,
         log_format: str = DEFAULT_LOGGING_FORMAT,
     ):
@@ -909,7 +909,7 @@ class BaseWorker:
 
     def bootstrap(
         self,
-        logging_level: str = 'INFO',
+        logging_level: Optional[str] = 'INFO',
         date_format: str = DEFAULT_LOGGING_DATE_FORMAT,
         log_format: str = DEFAULT_LOGGING_FORMAT,
     ):


### PR DESCRIPTION
FIX Bug From #1702 
Only resolve bug that Worker override logging configuration.
Just set INFO if logging is logging.NOTSET. Otherwise,`None` is passed, makes not override default logging level.