### PR TITLE
perf: Avoid polling in PubSub thread

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1021,7 +1021,7 @@ class BaseWorker:
         self.pubsub = self.connection.pubsub()
         self.pubsub.subscribe(**{self.pubsub_channel_name: self.handle_payload})
         self.pubsub_thread = self.pubsub.run_in_thread(
-            sleep_time=0.2, daemon=True, exception_handler=self._pubsub_exception_handler
+            sleep_time=None, daemon=True, exception_handler=self._pubsub_exception_handler
         )
 
     def get_heartbeat_ttl(self, job: 'Job') -> int:
@@ -1054,9 +1054,9 @@ class BaseWorker:
         """Unsubscribe from pubsub channel"""
         if self.pubsub_thread:
             self.log.info('Unsubscribing from channel %s', self.pubsub_channel_name)
-            self.pubsub_thread.stop()
-            self.pubsub_thread.join()
             self.pubsub.unsubscribe()
+            self.pubsub_thread.stop()
+            self.pubsub_thread.join(timeout=1)
             self.pubsub.close()
 
     def dequeue_job_and_maintain_ttl(


### PR DESCRIPTION
My understanding of how this works could be wrong. So please take a look at it carefully.

Currently, each worker spawns a pub-sub thread to listen for shutdown or stop/kill job commands. This thread polls every 0.2 seconds.

The 0.2 seconds on its own doesn't do anything, Redis' socket connection can block on it forever if you just specify `sleep_time=None`, but now that thread will be permanently blocked until its blocking `recv` ends with a response from Redis.

There are three solutions here:
- We can increase timeout, this will increase the time it takes to shut things down.
- The thread doesn't "need" to be joined, it's a daemon thread and if it dies without joining with a worker it shouldn't be a problem.
- We can set blocking behavior AND unsubscribe pubsub before joining the thread. This way Redis will stop the blocking receive call and everything will cleanly exit.

I like the last approach as it's consistent with the current design.

This change:
- Makes pubsub calls completely blocking.
- `worker.unsubscribe` now unsubscribed before stopping pubsub thread. 
- Redis sends `unsubscribe` message back to pubsub thread, which wakes it up from long sleep and thread now exits cleanly. Here's strace output: `recvfrom(4, "*3\r\n$11\r\nunsubscribe\r\n$42\r\nrq:pu"..., 65536, 0, NULL, NULL) = 75`
- In the rare event of the thread not exiting cleanly, we exit anyway after waiting for 1 second. 

This should close https://github.com/rq/rq/issues/2170