### PR TITLE
Force UTC time zone when parsing timestamps

### DIFF
--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -22,7 +22,7 @@ from rq.defaults import (
     DEFAULT_WORKER_CLASS,
 )
 from rq.logutils import setup_loghandlers
-from rq.utils import import_attribute, parse_timeout
+from rq.utils import import_attribute, now, parse_timeout
 from rq.worker import WorkerStatus
 
 red = partial(click.style, fg='red')
@@ -323,7 +323,7 @@ def parse_schedule(schedule_in, schedule_at):
     if schedule_in is not None:
         if schedule_at is not None:
             raise click.BadArgumentUsage("You can't specify both --schedule-in and --schedule-at")
-        return datetime.now(timezone.utc) + timedelta(seconds=parse_timeout(schedule_in))
+        return now() + timedelta(seconds=parse_timeout(schedule_in))
     elif schedule_at is not None:
         return datetime.strptime(schedule_at, '%Y-%m-%dT%H:%M:%S')
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -1569,7 +1569,7 @@ class Job:
         assert self.retries_left
         self.retries_left = self.retries_left - 1
         if retry_interval:
-            scheduled_datetime = datetime.now(timezone.utc) + timedelta(seconds=retry_interval)
+            scheduled_datetime = now() + timedelta(seconds=retry_interval)
             self.set_status(JobStatus.SCHEDULED)
             queue.schedule_job(self, scheduled_datetime, pipeline=pipeline)
             logger.info(

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1085,7 +1085,7 @@ class Queue:
         Returns:
             job (Job): The enqueued Job
         """
-        return self.enqueue_at(datetime.now(timezone.utc) + time_delta, func, *args, **kwargs)
+        return self.enqueue_at(now() + time_delta, func, *args, **kwargs)
 
     def enqueue_job(self, job: 'Job', pipeline: Optional['Pipeline'] = None, at_front: bool = False) -> Job:
         """Enqueues a job for delayed execution checking dependencies.

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -138,13 +138,11 @@ def utcformat(dt: dt.datetime) -> str:
 
 def utcparse(string: str) -> dt.datetime:
     try:
-        return datetime.datetime.strptime(string, _TIMESTAMP_FORMAT)
+        parsed = datetime.datetime.strptime(string, _TIMESTAMP_FORMAT)
     except ValueError:
         # This catches any jobs remain with old datetime format
-        try:
-            return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%S.%fZ')
-        except ValueError:
-            return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
+        parsed = datetime.datetime.strptime(string, '%Y-%m-%dT%H:%M:%SZ')
+    return parsed.replace(tzinfo=datetime.timezone.utc)
 
 
 def first(iterable: Iterable, default=None, key=None):
@@ -223,7 +221,7 @@ def current_timestamp() -> int:
     Returns:
         int: _description_
     """
-    return calendar.timegm(datetime.datetime.now(datetime.timezone.utc).utctimetuple())
+    return calendar.timegm(now().utctimetuple())
 
 
 def backend_class(holder, default_name, override=None) -> Type:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1519,7 +1519,7 @@ class Worker(BaseWorker):
 
             if retry_interval > 0:
                 # Schedule job for later if there's an interval
-                scheduled_time = datetime.now(timezone.utc) + timedelta(seconds=retry_interval)
+                scheduled_time = now() + timedelta(seconds=retry_interval)
                 job.set_status(JobStatus.SCHEDULED, pipeline=pipeline)
                 queue.schedule_job(job, scheduled_time, pipeline=pipeline)
                 self.log.debug(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -3,7 +3,7 @@ import queue
 import time
 import unittest
 import zlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pickle import dumps, loads
 from uuid import uuid4
 
@@ -181,7 +181,8 @@ class TestJob(RQTestCase):
         self.assertIsNone(job.instance)
         self.assertEqual(job.args, (3, 4))
         self.assertEqual(job.kwargs, dict(z=2))
-        self.assertEqual(job.created_at, datetime(2012, 2, 7, 22, 13, 24, 123456))
+        self.assertEqual(job.created_at, datetime(2012, 2, 7, 22, 13, 24, 123456,
+                         tzinfo=timezone.utc))
 
         # Job.fetch also works with execution IDs
         queue = Queue(connection=self.connection)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,13 +76,17 @@ class TestUtils(RQTestCase):
 
     def test_utcparse(self):
         """Ensure function utcparse works correctly"""
-        utc_formated_time = '2017-08-31T10:14:02.123456Z'
-        self.assertEqual(datetime.datetime(2017, 8, 31, 10, 14, 2, 123456), utcparse(utc_formated_time))
+        utc_formatted_time = '2017-08-31T10:14:02.123456Z'
+        expected_time = datetime.datetime(2017, 8, 31, 10, 14, 2, 123456,
+                                          tzinfo=datetime.timezone.utc)
+        self.assertEqual(expected_time, utcparse(utc_formatted_time))
 
     def test_utcparse_legacy(self):
         """Ensure function utcparse works correctly"""
-        utc_formated_time = '2017-08-31T10:14:02Z'
-        self.assertEqual(datetime.datetime(2017, 8, 31, 10, 14, 2), utcparse(utc_formated_time))
+        utc_formatted_time = '2017-08-31T10:14:02Z'
+        expected_time = datetime.datetime(2017, 8, 31, 10, 14, 2,
+                                          tzinfo=datetime.timezone.utc)
+        self.assertEqual(expected_time, utcparse(utc_formatted_time))
 
     def test_backend_class(self):
         """Ensure function backend_class works correctly"""


### PR DESCRIPTION
## Problem description

See [original issue](https://github.com/rq/rq/issues/2174).

## Changes overview

* Updated `rq.utils.utcparse` to always return offset-aware `datetime` objects;
* Updated unit tests.