### PR TITLE
Add `SpawnWorker` to `__init__.py`

### DIFF
--- a/rq/__init__.py
+++ b/rq/__init__.py
@@ -2,7 +2,7 @@
 from .job import Callback, Retry, cancel_job, get_current_job, requeue_job
 from .queue import Queue
 from .version import VERSION
-from .worker import SimpleWorker, Worker
+from .worker import SimpleWorker, SpawnWorker, Worker
 
 __all__ = [
     'Callback',
@@ -12,6 +12,7 @@ __all__ = [
     'requeue_job',
     'Queue',
     'SimpleWorker',
+    'SpawnWorker',
     'Worker',
 ]
 


### PR DESCRIPTION
Added `SpawnWorker` to what `__init__.py` exposes, otherwise code like this won't work:

```python
from rq import SpawnWorker, Queue
````

------

I tried to start using `SpawnWorker` after installing HEAD from Git[0] but was getting ImportError[1] until I added `SpawnWorker` to `__all__`. This commit+PR resolves that issue.

- [0] - `pip install -U "git+https://github.com/rq/rq.git@97f1a4190a4b61e004b16ba8211baaac9eae2de7#egg=rq"`
- [1] `ImportError: cannot import name 'SpawnWorker' from 'rq' (/home/user/projects/victorb/actions/.venv/lib/python3.10/site-packages/rq/__init__.py)`