### PR TITLE
Remove timezone naive coversion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  -   repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.3.0
+      hooks:
+      -   id: check-yaml
+      -   id: end-of-file-fixer
+      -   id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,10 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-        - id: black
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.267"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.9
     hooks:
       - id: ruff
+      - id: ruff-format
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.12.0
+    rev: "v2.5.0"
     hooks:
       - id: pyproject-fmt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ include = [
   "requirements.txt",
   "tox.ini",
 ]
+[tool.hatch.envs.default]
+installer = "uv"
 
 [tool.hatch.envs.test]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ description = "RQ is a simple, lightweight, library for creating background jobs
 readme = "README.md"
 license = "BSD-2-Clause"
 maintainers = [
-    {name = "Selwin Ong"},
+  { name = "Selwin Ong" },
 ]
 authors = [
-    { name = "Selwin Ong", email = "selwin.ong@gmail.com" },
-    { name = "Vincent Driessen", email = "vincent@3rdcloud.com" },
+  { name = "Selwin Ong", email = "selwin.ong@gmail.com" },
+  { name = "Vincent Driessen", email = "vincent@3rdcloud.com" },
 ]
 requires-python = ">=3.8"
 classifiers = [
@@ -35,6 +35,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Internet",
   "Topic :: Scientific/Engineering",
   "Topic :: Software Development :: Libraries :: Python Modules",
@@ -49,30 +50,42 @@ dependencies = [
   "click>=5",
   "redis>=3.5",
 ]
-[project.urls]
-changelog = "https://github.com/rq/rq/blob/master/CHANGES.md"
-documentation = "https://python-rq.org/docs/"
-homepage = "https://python-rq.org/"
-repository = "https://github.com/rq/rq/"
-[project.scripts]
-rq = "rq.cli:main"
-rqinfo = "rq.cli:info"  # TODO [v2]: Remove
-rqworker = "rq.cli:worker"  # TODO [v2]: Remove
+urls.changelog = "https://github.com/rq/rq/blob/master/CHANGES.md"
+urls.documentation = "https://python-rq.org/docs/"
+urls.homepage = "https://python-rq.org/"
+urls.repository = "https://github.com/rq/rq/"
+scripts.rq = "rq.cli:main"
+scripts.rqinfo = "rq.cli:info" # TODO [v2]: Remove
+scripts.rqworker = "rq.cli:worker" # TODO [v2]: Remove
+
+[dependency-groups]
+dev = [
+  "coverage>=7.6.1",
+  "mypy>=1.14.1",
+  "packaging>=24.2",
+  "psutil>=7",
+  "pytest>=8.3.5",
+  "pytest-cov>=5",
+  "ruff>=0.9.9",
+  "tox>=4.24.1",
+  "types-greenlet>=3.1.0.20241221",
+  "types-redis>=4.6.0.20241004",
+]
 
 [tool.hatch.version]
 path = "rq/version.py"
 
 [tool.hatch.build.targets.sdist]
 include = [
-    "/docs",
-    "/rq",
-    "/tests",
-    "CHANGES.md",
-    "LICENSE",
-    "pyproject.toml",
-    "README.md",
-    "requirements.txt",
-    "tox.ini",
+  "/docs",
+  "/rq",
+  "/tests",
+  "CHANGES.md",
+  "LICENSE",
+  "pyproject.toml",
+  "README.md",
+  "requirements.txt",
+  "tox.ini",
 ]
 
 [tool.hatch.envs.test]
@@ -92,6 +105,22 @@ dependencies = [
 cov = "pytest --cov=rq --cov-config=.coveragerc --cov-report=xml {args:tests}"
 typing = "mypy --enable-incomplete-feature=Unpack rq"
 
+[tool.ruff]
+target-version = "py38"
+
+# Set what ruff should check for.
+# See https://beta.ruff.rs/docs/rules/ for a list of rules.
+line-length = 120
+format.quote-style = "single"
+lint.select = [
+  "E", # pycodestyle errors
+  "F", # pyflakes errors
+  "I", # import sorting
+  "W", # pycodestyle warnings
+]
+lint.isort.known-first-party = [ "rq" ]
+lint.isort.section-order = [ "future", "standard-library", "third-party", "first-party", "local-folder" ]
+
 [tool.mypy]
 allow_redefinition = true
 pretty = true
@@ -104,25 +133,6 @@ warn_unreachable = true
 [[tool.mypy.overrides]]
 module = "setproctitle.*"
 ignore_missing_imports = true
-
-[tool.ruff]
-# Set what ruff should check for.
-# See https://beta.ruff.rs/docs/rules/ for a list of rules.
-lint.select = [
-    "E", # pycodestyle errors
-    "F", # pyflakes errors
-    "I", # import sorting
-    "W", # pycodestyle warnings
-]
-line-length = 120
-target-version = "py38"
-
-[tool.ruff.lint.isort]
-known-first-party = ["rq"]
-section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
-
-[tool.ruff.format]
-quote-style = "single"
 
 [tool.pyright]
 reportOptionalMemberAccess = false

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -192,7 +192,7 @@ class BaseRegistry:
             job (Job): The Job to get the expiration
         """
         score = self.connection.zscore(self.key, job.id)
-        return datetime.utcfromtimestamp(score)  # type: ignore[arg-type]
+        return datetime.fromtimestamp(score, timezone.utc)  # type: ignore[arg-type]
 
     def requeue(self, job_or_id: Union['Job', str], at_front: bool = False) -> 'Job':
         """Requeues the job with the given job ID.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest import mock
 from unittest.mock import ANY
 
@@ -15,7 +15,7 @@ from rq.registry import (
     clean_registries,
 )
 from rq.serializers import JSONSerializer
-from rq.utils import as_text, current_timestamp
+from rq.utils import as_text, current_timestamp, now
 from rq.worker import Worker
 from tests import RQTestCase
 from tests.fixtures import div_by_zero, say_hello
@@ -71,7 +71,7 @@ class TestRegistry(RQTestCase):
 
         registry.add(job, 5)
         time = registry.get_expiration_time(job)
-        expected_time = (datetime.utcnow() + timedelta(seconds=5)).replace(microsecond=0)
+        expected_time = (now() + timedelta(seconds=5)).replace(microsecond=0)
         self.assertGreaterEqual(time, expected_time - timedelta(seconds=2))
         self.assertLessEqual(time, expected_time + timedelta(seconds=2))
 


### PR DESCRIPTION
[Mentioned here](https://github.com/rq/rq/pull/2180#issuecomment-2696048019) there's one more timezone-naive timestamp conversion. This fixes it. 
Also updated the pre-commit versions of ruff, pyproject-fmt, and added simple pre-commit-hooks.

`pyproject.yaml` changes:
* Most formatting comes from the `pyproject-fmt`
* Added dev dependency group so `uv sync` installs everything for local development.
