### PR TITLE
Fix StartedJobRegistry job_id parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dynamic = [
 dependencies = [
   "click>=5",
   "redis>=3.5",
+  "typing-extensions>=4.12.2",
 ]
 [project.urls]
 changelog = "https://github.com/rq/rq/blob/master/CHANGES.md"

--- a/rq/executions.py
+++ b/rq/executions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from uuid import uuid4
@@ -118,7 +120,7 @@ class ExecutionRegistry(BaseRegistry):
         self.job_id = job_id
         self.key = self.key_template.format(job_id)
 
-    def cleanup(self, timestamp: Optional[float] = None):
+    def cleanup(self, timestamp: float | None = None, exception_handlers: list | None = None):
         """Remove expired jobs from registry.
 
         Removes jobs with an expiry time earlier than timestamp, specified as

--- a/rq/executions.py
+++ b/rq/executions.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 from .job import Job
 from .registry import BaseRegistry, StartedJobRegistry
-from .utils import as_text, current_timestamp, now
+from .utils import as_text, current_timestamp, now, parse_composite_key
 
 
 # TODO: add execution.worker
@@ -63,8 +63,8 @@ class Execution:
     @classmethod
     def from_composite_key(cls, composite_key: str, connection: Redis) -> 'Execution':
         """A combination of job_id and execution_id separated by a colon."""
-        job_id, id = composite_key.split(':')
-        return cls(id=id, job_id=job_id, connection=connection)
+        job_id, execution_id = parse_composite_key(composite_key)
+        return cls(id=execution_id, job_id=job_id, connection=connection)
 
     @classmethod
     def create(cls, job: Job, ttl: int, pipeline: 'Pipeline') -> 'Execution':

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1192,7 +1192,11 @@ class Queue:
         return job
 
     def enqueue_dependents(
-        self, job: 'Job', pipeline: Optional['Pipeline'] = None, exclude_job_id: Optional[str] = None
+        self,
+        job: 'Job',
+        pipeline: Optional['Pipeline'] = None,
+        exclude_job_id: Optional[str] = None,
+        refresh_job_status: bool = True,
     ):
         """Enqueues all jobs in the given job's dependents set and clears it.
 
@@ -1204,6 +1208,7 @@ class Queue:
             job (Job): The Job to enqueue the dependents
             pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
             exclude_job_id (Optional[str], optional): Whether to exclude the job id. Defaults to None.
+            refresh_job_status (bool): whether to refresh job status when checking for dependencies. Defaults to True.
         """
         from .registry import DeferredJobRegistry
 
@@ -1233,6 +1238,7 @@ class Queue:
                         parent_job=job,
                         pipeline=pipe,
                         exclude_job_id=exclude_job_id,
+                        refresh_job_status=refresh_job_status,
                     )
                     and dependent_job.get_status(refresh=False) != JobStatus.CANCELED
                 ]
@@ -1315,7 +1321,7 @@ class Queue:
             if timeout == 0:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
             colored_queues = ', '.join(map(str, [green(str(queue)) for queue in queue_keys]))
-            logger.debug("Starting BLPOP operation for queues %s with timeout of %d", colored_queues, timeout)
+            logger.debug('Starting BLPOP operation for queues %s with timeout of %d', colored_queues, timeout)
             assert connection
             result = connection.blpop(queue_keys, timeout)
             if result is None:

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -4,9 +4,10 @@ import calendar
 import logging
 import time
 import traceback
-import warnings
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, List, Optional, Type, Union, cast
+
+from typing_extensions import deprecated
 
 from rq.serializers import resolve_serializer
 
@@ -381,7 +382,7 @@ class StartedJobRegistry(BaseRegistry):
             job_id = item.id
         return cast(str, job_id) in self.get_job_ids(cleanup=False)
 
-    @warnings.deprecated('StartedJobRegistry can only contain execution records. Use add_execution method.')
+    @deprecated('StartedJobRegistry can only contain execution records. Use add_execution method.')
     def add(self, job: Job | str, ttl: int = 0, pipeline: Pipeline | None = None, xx: bool = False) -> int:
         # in the future will raise
         # raise NotImplementedError('')
@@ -389,7 +390,7 @@ class StartedJobRegistry(BaseRegistry):
         # use job_id: so the stored record is always a tuple, when split by ':'
         return super().add(f'{job_id}:', ttl, pipeline, xx)
 
-    @warnings.deprecated('StartedJobRegistry can only contain execution records. Use remove_execution method.')
+    @deprecated('StartedJobRegistry can only contain execution records. Use remove_execution method.')
     def remove(self, job: Job | str, pipeline: Pipeline | None = None, delete_job: bool = False):
         # in the future will raise
         # raise NotImplementedError('')
@@ -556,7 +557,7 @@ class ScheduledJobRegistry(BaseRegistry):
         timestamp = calendar.timegm(scheduled_datetime.utctimetuple())
         return self.connection.zadd(self.key, {job.id: timestamp})
 
-    @warnings.deprecated('ScheduledJobRegistry.remove_jobs() is deprecated and will be removed in the future.')
+    @deprecated('ScheduledJobRegistry.remove_jobs() is deprecated and will be removed in the future.')
     def remove_jobs(self, timestamp: int | None = None, pipeline: Pipeline | None = None):
         """Remove jobs whose timestamp is in the past from registry.
 

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -5,9 +5,10 @@ The formatter for ANSI colored console output is heavily based on Pygments
 terminal colorizing code, originally by Georg Brandl.
 """
 
+from __future__ import annotations
+
 import calendar
 import datetime
-import datetime as dt
 import importlib
 import logging
 import numbers
@@ -153,11 +154,11 @@ def now() -> datetime.datetime:
 _TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 
-def utcformat(dt: dt.datetime) -> str:
+def utcformat(dt: datetime.datetime) -> str:
     return dt.strftime(as_text(_TIMESTAMP_FORMAT))
 
 
-def utcparse(string: str) -> dt.datetime:
+def utcparse(string: str) -> datetime.datetime:
     try:
         return datetime.datetime.strptime(string, _TIMESTAMP_FORMAT)
     except ValueError:
@@ -205,7 +206,7 @@ def current_timestamp() -> int:
     Returns:
         int: _description_
     """
-    return calendar.timegm(datetime.datetime.now(datetime.timezone.utc).utctimetuple())
+    return calendar.timegm(now().utctimetuple())
 
 
 def backend_class(holder, default_name, override=None) -> Type:
@@ -227,7 +228,7 @@ def backend_class(holder, default_name, override=None) -> Type:
         return override
 
 
-def str_to_date(date_str: Optional[bytes]) -> Optional[dt.datetime]:
+def str_to_date(date_str: Optional[bytes]) -> Optional[datetime.datetime]:
     if not date_str:
         return None
     else:
@@ -377,3 +378,16 @@ def get_connection_from_queues(queues_or_names: Iterable[Union[str, 'Queue']]) -
         if isinstance(queue_or_name, Queue):
             return queue_or_name.connection
     return None
+
+
+def parse_composite_key(composite_key: str) -> tuple[str, str]:
+    """Method returns a parsed composite key.
+
+    Args:
+        composite_key (str): the composite key to parse
+
+    Returns:
+        tuple[str, str]: tuple of job id and the execution id
+    """
+    job_id, execution_id = composite_key.split(':')
+    return (job_id, execution_id)

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -12,6 +12,7 @@ import datetime
 import importlib
 import logging
 import numbers
+import warnings
 
 # TODO: Change import path to "collections.abc" after we stop supporting Python 3.8
 from typing import (
@@ -389,5 +390,15 @@ def parse_composite_key(composite_key: str) -> tuple[str, str]:
     Returns:
         tuple[str, str]: tuple of job id and the execution id
     """
-    job_id, execution_id = composite_key.split(':')
+    result = composite_key.split(':')
+    if len(result) == 1:
+        # StartedJobRegistry contains a composite key under the sorted set
+        # a single job_id should've never ended up in the set, but
+        # just in case there's a regression (tests don't show any)
+        warnings.warn(
+            f'Composite key must contain job_id:execution_id, got {composite_key}',
+            DeprecationWarning,
+        )
+        return (result[0], '')
+    job_id, execution_id = result
     return (job_id, execution_id)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -233,7 +233,6 @@ class WorkerCallbackTestCase(RQTestCase):
         worker.work(burst=True)
         self.assertEqual(job.get_status(), JobStatus.FAILED)
         job.refresh()
-        print(job.exc_info)
         self.assertIn('div_by_zero', self.connection.get('failure_callback:%s' % job.id).decode())
 
         job = queue.enqueue(div_by_zero, on_success=save_result)
@@ -246,7 +245,6 @@ class WorkerCallbackTestCase(RQTestCase):
         worker.work(burst=True)
         self.assertEqual(job.get_status(), JobStatus.FAILED)
         job.refresh()
-        print(job.exc_info)
         self.assertIn('div_by_zero', self.connection.get('failure_callback:%s' % job.id).decode())
 
         job = queue.enqueue(div_by_zero, on_success=Callback('tests.fixtures.save_result'))

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -118,14 +118,14 @@ class TestRegistry(RQTestCase):
         worker = Worker([queue], connection=self.connection)
         execution = worker.prepare_execution(job=job)
 
-        self.assertIn(execution.composite_key, job.started_job_registry.get_job_ids())
+        self.assertIn(execution.job_id, job.started_job_registry.get_job_ids())
 
         registry = job.execution_registry
         pipeline = self.connection.pipeline()
         registry.delete(job=job, pipeline=pipeline)
         pipeline.execute()
 
-        self.assertNotIn(execution.composite_key, job.started_job_registry.get_job_ids())
+        self.assertNotIn(execution.job_id, job.started_job_registry.get_job_ids())
         self.assertFalse(self.connection.exists(registry.key))
 
     def test_get_execution_ids(self):
@@ -155,7 +155,7 @@ class TestRegistry(RQTestCase):
         # Execution should be registered in started job registry
         execution = job.get_executions()[0]
         self.assertEqual(len(job.get_executions()), 1)
-        self.assertIn(execution.composite_key, job.started_job_registry.get_job_ids())
+        self.assertIn(execution.job_id, job.started_job_registry.get_job_ids())
 
         last_heartbeat = execution.last_heartbeat
         last_heartbeat = now()

--- a/tests/test_intermediate_queue.py
+++ b/tests/test_intermediate_queue.py
@@ -2,10 +2,12 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
 from redis import Redis
 
 from rq import Queue, Worker
 from rq.intermediate_queue import IntermediateQueue
+from rq.job import JobStatus
 from rq.maintenance import clean_intermediate_queue
 from rq.utils import get_version
 from tests import RQTestCase
@@ -14,163 +16,201 @@ from tests.fixtures import say_hello
 
 @unittest.skipIf(get_version(Redis()) < (6, 2, 0), 'Skip if Redis server < 6.2.0')
 class TestIntermediateQueue(RQTestCase):
+    def setUp(self):
+        super().setUp()
+        self.queue = Queue('foo', connection=self.connection)
+        self.intermediate_queue = IntermediateQueue(self.queue.key, connection=self.connection)
+
+    @property
+    def iq(self):
+        """Shortcut for the intermediate queue"""
+        return self.intermediate_queue
+
     def test_set_first_seen(self):
         """Ensure that the first_seen attribute is set correctly."""
-        queue = Queue('foo', connection=self.connection)
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
-        job = queue.enqueue(say_hello)
+        job = self.queue.enqueue(say_hello)
 
         # set_first_seen() should only succeed the first time around
-        self.assertTrue(intermediate_queue.set_first_seen(job.id))
-        self.assertFalse(intermediate_queue.set_first_seen(job.id))
+        self.assertTrue(self.iq.set_first_seen(job.id))
+        self.assertFalse(self.iq.set_first_seen(job.id))
         # It should succeed again after deleting the key
-        self.connection.delete(intermediate_queue.get_first_seen_key(job.id))
-        self.assertTrue(intermediate_queue.set_first_seen(job.id))
+        self.connection.delete(self.iq.get_first_seen_key(job.id))
+        self.assertTrue(self.iq.set_first_seen(job.id))
 
     def test_get_first_seen(self):
         """Ensure that the first_seen attribute is set correctly."""
-        queue = Queue('foo', connection=self.connection)
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
-        job = queue.enqueue(say_hello)
+        job = self.queue.enqueue(say_hello)
 
-        self.assertIsNone(intermediate_queue.get_first_seen(job.id))
+        self.assertIsNone(self.iq.get_first_seen(job.id))
 
         # Check first seen was set correctly
-        intermediate_queue.set_first_seen(job.id)
-        timestamp = intermediate_queue.get_first_seen(job.id)
-        self.assertTrue(datetime.now(tz=timezone.utc) - timestamp < timedelta(seconds=5))  # type: ignore
+        self.iq.set_first_seen(job.id)
+        timestamp = self.iq.get_first_seen(job.id)
+        assert timestamp
+        self.assertTrue(datetime.now(tz=timezone.utc) - timestamp < timedelta(seconds=5))
 
     def test_should_be_cleaned_up(self):
         """Job in the intermediate queue should be cleaned up if it was seen more than 1 minute ago."""
-        queue = Queue('foo', connection=self.connection)
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
-        job = queue.enqueue(say_hello)
+        job = self.queue.enqueue(say_hello)
 
         # Returns False if there's no first seen timestamp
-        self.assertFalse(intermediate_queue.should_be_cleaned_up(job.id))
+        self.assertFalse(self.iq.should_be_cleaned_up(job.id))
         # Returns False since first seen timestamp is less than 1 minute ago
-        intermediate_queue.set_first_seen(job.id)
-        self.assertFalse(intermediate_queue.should_be_cleaned_up(job.id))
+        self.iq.set_first_seen(job.id)
+        self.assertFalse(self.iq.should_be_cleaned_up(job.id))
 
-        first_seen_key = intermediate_queue.get_first_seen_key(job.id)
+        first_seen_key = self.iq.get_first_seen_key(job.id)
         two_minutes_ago = datetime.now(tz=timezone.utc) - timedelta(minutes=2)
         self.connection.set(first_seen_key, two_minutes_ago.timestamp(), ex=10)
-        self.assertTrue(intermediate_queue.should_be_cleaned_up(job.id))
+        self.assertTrue(self.iq.should_be_cleaned_up(job.id))
 
     def test_get_job_ids(self):
         """Dequeueing job from a single queue moves job to intermediate queue."""
-        queue = Queue('foo', connection=self.connection)
-        job_1 = queue.enqueue(say_hello)
-
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
+        job_1 = self.queue.enqueue(say_hello)
 
         # Ensure that the intermediate queue is empty
-        self.connection.delete(intermediate_queue.key)
+        self.connection.delete(self.iq.key)
 
         # Job ID is not in intermediate queue
-        self.assertEqual(intermediate_queue.get_job_ids(), [])
-        job, queue = Queue.dequeue_any([queue], timeout=None, connection=self.connection)
+        self.assertEqual(self.iq.get_job_ids(), [])
+        result = Queue.dequeue_any([self.queue], timeout=None, connection=self.connection)
+        assert result
+        _job, queue = result
         # After job is dequeued, the job ID is in the intermediate queue
-        self.assertEqual(intermediate_queue.get_job_ids(), [job_1.id])
+        self.assertEqual(self.iq.get_job_ids(), [job_1.id])
 
         # Test the blocking version
         job_2 = queue.enqueue(say_hello)
-        job, queue = Queue.dequeue_any([queue], timeout=1, connection=self.connection)
+        result = Queue.dequeue_any([queue], timeout=1, connection=self.connection)
+        assert result
+        _job, queue = result
         # After job is dequeued, the job ID is in the intermediate queue
-        self.assertEqual(intermediate_queue.get_job_ids(), [job_1.id, job_2.id])
+        self.assertEqual(self.iq.get_job_ids(), [job_1.id, job_2.id])
 
         # After job_1.id is removed, only job_2.id is in the intermediate queue
-        intermediate_queue.remove(job_1.id)
-        self.assertEqual(intermediate_queue.get_job_ids(), [job_2.id])
+        self.iq.remove(job_1.id)
+        self.assertEqual(self.iq.get_job_ids(), [job_2.id])
 
     def test_cleanup_intermediate_queue_in_maintenance(self):
         """Ensure jobs stuck in the intermediate queue are cleaned up."""
-        queue = Queue('foo', connection=self.connection)
-        job = queue.enqueue(say_hello)
-
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
-        self.connection.delete(intermediate_queue.key)
+        job = self.queue.enqueue(say_hello)
+        self.connection.delete(self.iq.key)
 
         # If job execution fails after it's dequeued, job should be in the intermediate queue
         # and it's status is still QUEUED
         with patch.object(Worker, 'execute_job'):
-            worker = Worker(queue, connection=self.connection)
+            worker = Worker(self.queue, connection=self.connection)
             worker.work(burst=True)
 
             # If worker.execute_job() does nothing, job status should be `queued`
             # even though it's not in the queue, but it should be in the intermediate queue
-            self.assertEqual(job.get_status(), 'queued')
-            self.assertFalse(job.id in queue.get_job_ids())
-            self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
+            self.assertEqual(job.get_status(), JobStatus.QUEUED)
+            self.assertFalse(job.id in self.queue.get_job_ids())
+            self.assertEqual(self.iq.get_job_ids(), [job.id])
 
-            self.assertIsNone(intermediate_queue.get_first_seen(job.id))
-            clean_intermediate_queue(worker, queue)
-            # After clean_intermediate_queue is called, the job should be marked as seen,
+            self.assertIsNone(self.iq.get_first_seen(job.id))
+            self.iq.cleanup(worker, self.queue)
+            # After self.iq.cleanup is called, the job should be marked as seen,
             # but since it's been less than 1 minute, it should not be cleaned up
-            self.assertIsNotNone(intermediate_queue.get_first_seen(job.id))
-            self.assertFalse(intermediate_queue.should_be_cleaned_up(job.id))
-            self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
+            self.assertIsNotNone(self.iq.get_first_seen(job.id))
+            self.assertFalse(self.iq.should_be_cleaned_up(job.id))
+            self.assertEqual(self.iq.get_job_ids(), [job.id])
 
             # If we set the first seen timestamp to 2 minutes ago, the job should be cleaned up
-            first_seen_key = intermediate_queue.get_first_seen_key(job.id)
+            first_seen_key = self.iq.get_first_seen_key(job.id)
             two_minutes_ago = datetime.now(tz=timezone.utc) - timedelta(minutes=2)
             self.connection.set(first_seen_key, two_minutes_ago.timestamp(), ex=10)
 
-            clean_intermediate_queue(worker, queue)
-            self.assertEqual(intermediate_queue.get_job_ids(), [])
+            self.iq.cleanup(worker, self.queue)
+            self.assertEqual(self.iq.get_job_ids(), [])
             self.assertEqual(job.get_status(), 'failed')
 
-            job = queue.enqueue(say_hello)
+            job = self.queue.enqueue(say_hello)
             worker.work(burst=True)
-            self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
+            self.assertEqual(self.iq.get_job_ids(), [job.id])
 
             # If job is gone, it should be immediately removed from the intermediate queue
             job.delete()
-            clean_intermediate_queue(worker, queue)
-            self.assertEqual(intermediate_queue.get_job_ids(), [])
+            self.iq.cleanup(worker, self.queue)
+            self.assertEqual(self.iq.get_job_ids(), [])
 
     def test_cleanup_intermediate_queue(self):
         """Ensure jobs stuck in the intermediate queue are cleaned up."""
-        queue = Queue('foo', connection=self.connection)
-        job = queue.enqueue(say_hello)
+        job = self.queue.enqueue(say_hello)
 
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
-        self.connection.delete(intermediate_queue.key)
+        self.connection.delete(self.iq.key)
 
         # If job execution fails after it's dequeued, job should be in the intermediate queue
         # and it's status is still QUEUED
         with patch.object(Worker, 'execute_job'):
-            worker = Worker(queue, connection=self.connection)
+            worker = Worker(self.queue, connection=self.connection)
             worker.work(burst=True)
 
             # If worker.execute_job() does nothing, job status should be `queued`
             # even though it's not in the queue, but it should be in the intermediate queue
-            self.assertEqual(job.get_status(), 'queued')
-            self.assertFalse(job.id in queue.get_job_ids())
-            self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
+            self.assertEqual(job.get_status(), JobStatus.QUEUED)
+            self.assertFalse(job.id in self.queue.get_job_ids())
+            self.assertEqual(self.iq.get_job_ids(), [job.id])
 
-            self.assertIsNone(intermediate_queue.get_first_seen(job.id))
-            intermediate_queue.cleanup(worker, queue)
-            # After clean_intermediate_queue is called, the job should be marked as seen,
+            self.assertIsNone(self.iq.get_first_seen(job.id))
+            self.iq.cleanup(worker, self.queue)
+            # After self.iq.cleanup is called, the job should be marked as seen,
             # but since it's been less than 1 minute, it should not be cleaned up
-            self.assertIsNotNone(intermediate_queue.get_first_seen(job.id))
-            self.assertFalse(intermediate_queue.should_be_cleaned_up(job.id))
-            self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
+            self.assertIsNotNone(self.iq.get_first_seen(job.id))
+            self.assertFalse(self.iq.should_be_cleaned_up(job.id))
+            self.assertEqual(self.iq.get_job_ids(), [job.id])
 
             # If we set the first seen timestamp to 2 minutes ago, the job should be cleaned up
-            first_seen_key = intermediate_queue.get_first_seen_key(job.id)
+            first_seen_key = self.iq.get_first_seen_key(job.id)
             two_minutes_ago = datetime.now(tz=timezone.utc) - timedelta(minutes=2)
             self.connection.set(first_seen_key, two_minutes_ago.timestamp(), ex=10)
 
-            intermediate_queue.cleanup(worker, queue)
-            self.assertEqual(intermediate_queue.get_job_ids(), [])
+            self.iq.cleanup(worker, self.queue)
+            self.assertEqual(self.iq.get_job_ids(), [])
             self.assertEqual(job.get_status(), 'failed')
 
-            job = queue.enqueue(say_hello)
+            job = self.queue.enqueue(say_hello)
             worker.work(burst=True)
-            self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
+            self.assertEqual(self.iq.get_job_ids(), [job.id])
 
             # If job is gone, it should be immediately removed from the intermediate queue
             job.delete()
-            intermediate_queue.cleanup(worker, queue)
-            self.assertEqual(intermediate_queue.get_job_ids(), [])
+            self.iq.cleanup(worker, self.queue)
+            self.assertEqual(self.iq.get_job_ids(), [])
+
+    def test_no_cleanup_while_in_started_queue(self):
+        """Ensure jobs stuck in the intermediate queue are cleaned up."""
+        job = self.queue.enqueue(say_hello)
+
+        self.connection.delete(self.iq.key)
+
+        # If job execution fails after it's dequeued, job should be in the intermediate queue
+        # and it's status is still QUEUED
+        with patch.object(Worker, 'perform_job'):
+            worker = Worker(self.queue, connection=self.connection)
+            worker.work(burst=True)
+
+            # If worker.perform_job() does nothing, job status should be `queued`
+            # even though it's not in the queue, but it should be in the intermediate queue
+            # and the job should be in the started queue (since we only mocked perform_job)
+            self.assertEqual(job.get_status(), JobStatus.QUEUED)
+            self.assertFalse(job.id in self.queue.get_job_ids())
+            self.assertEqual(self.iq.get_job_ids(), [job.id])
+
+            self.assertTrue(job.id in job.started_job_registry.get_job_ids())
+            self.assertTrue(
+                (worker.execution.job_id, worker.execution.id) in job.started_job_registry.get_job_and_execution_ids()
+            )
+
+            # this should NOT remove the job from the queue, nor set the first see key
+            # because it's still in the "execution state".
+            # perform_job was mocked and never called success or failure.
+            self.iq.cleanup(worker, self.queue)
+            self.assertIsNone(self.iq.get_first_seen(job.id))
+
+            self.assertTrue(job.get_status() == JobStatus.QUEUED)
+
+    def test_clean_intermediate_queue_deprecation(self):
+        with pytest.deprecated_call():
+            worker = Worker(self.queue, connection=self.connection)
+            clean_intermediate_queue(worker, self.queue)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -7,10 +7,12 @@ from datetime import datetime, timedelta
 from pickle import dumps, loads
 from uuid import uuid4
 
+import pytest
 from redis import Redis, WatchError
 
 from rq.defaults import CALLBACK_TIMEOUT
 from rq.exceptions import DeserializationError, InvalidJobOperation, NoSuchJobError
+from rq.executions import Execution
 from rq.job import Callback, Dependency, Job, JobStatus, cancel_job, get_current_job
 from rq.queue import Queue
 from rq.registry import (
@@ -49,7 +51,7 @@ class TestJob(RQTestCase):
         # Jobs have a random UUID and a creation date
         self.assertIsNotNone(job.id)
         self.assertIsNotNone(job.created_at)
-        self.assertEqual(str(job), '<Job %s: test job>' % job.id)
+        self.assertEqual(str(job), f'<Job {job.id}: test job>')
 
         # ...and nothing else
         self.assertEqual(job.origin, '')
@@ -57,7 +59,7 @@ class TestJob(RQTestCase):
         self.assertIsNone(job.started_at)
         self.assertIsNone(job.ended_at)
         self.assertIsNone(job.result)
-        self.assertIsNone(job.exc_info)
+        self.assertIsNone(job._exc_info)
 
         with self.assertRaises(DeserializationError):
             job.func
@@ -314,7 +316,7 @@ class TestJob(RQTestCase):
     def test_store_then_fetch(self):
         """Store, then fetch."""
         job = Job.create(
-            func=fixtures.some_calculation, timeout='1h', args=(3, 4), kwargs=dict(z=2), connection=self.connection
+            func=fixtures.some_calculation, timeout=3600, args=(3, 4), kwargs=dict(z=2), connection=self.connection
         )
         job.save()
 
@@ -376,13 +378,13 @@ class TestJob(RQTestCase):
         self.assertEqual(as_text(zlib.decompress(exc_info)), exception_string)
 
         job.refresh()
-        self.assertEqual(job.exc_info, exception_string)
+        self.assertEqual(job._exc_info, exception_string)
 
         # Uncompressed exc_info is also handled
         self.connection.hset(job.key, 'exc_info', exception_string)
 
         job.refresh()
-        self.assertEqual(job.exc_info, exception_string)
+        self.assertEqual(job._exc_info, exception_string)
 
     def test_compressed_job_data_handling(self):
         """Jobs handle both compressed and uncompressed data"""
@@ -748,7 +750,10 @@ class TestJob(RQTestCase):
         job.save()
 
         registry = StartedJobRegistry(connection=self.connection, serializer=JSONSerializer)
-        registry.add(job, 500)
+        with self.connection.pipeline() as pipe:
+            # this will also add the execution to the registry
+            Execution.create(job, ttl=500, pipeline=pipe)
+            pipe.execute()
 
         job.delete()
         self.assertFalse(job in registry)
@@ -1319,3 +1324,13 @@ class TestJob(RQTestCase):
         self.assertIsNotNone(result)
         self.assertGreaterEqual(blocked_for, job_sleep_seconds)
         self.assertLess(blocked_for, block_seconds)
+
+    @unittest.skipIf(get_version(Redis()) < (5, 0, 0), 'Skip if Redis server < 5.0')
+    def test_exc_info_deprecation_warning(self):
+        """The .exc_info call should show a deprecation call (only on Redis>=5.0.0)
+        Before Redis 5.0.0 the exc_info is saved in job's `_exc_info` property."""
+        job = Job.create(
+            func=fixtures.some_calculation, timeout=3600, args=(3, 4), kwargs=dict(z=2), connection=self.connection
+        )
+        with pytest.deprecated_call():
+            self.assertIsNone(job.exc_info)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,12 +1,14 @@
-from datetime import datetime, timedelta
+from datetime import timedelta, timezone
 from unittest import mock
 from unittest.mock import ANY
 
 from rq.defaults import DEFAULT_FAILURE_TTL
 from rq.exceptions import AbandonedJobError, InvalidJobOperation
+from rq.executions import Execution
 from rq.job import Dependency, Job, JobStatus, requeue_job
 from rq.queue import Queue
 from rq.registry import (
+    BaseRegistry,
     CanceledJobRegistry,
     DeferredJobRegistry,
     FailedJobRegistry,
@@ -15,7 +17,7 @@ from rq.registry import (
     clean_registries,
 )
 from rq.serializers import JSONSerializer
-from rq.utils import as_text, current_timestamp
+from rq.utils import as_text, current_timestamp, now
 from rq.worker import Worker
 from tests import RQTestCase
 from tests.fixtures import div_by_zero, say_hello
@@ -26,32 +28,34 @@ class CustomJob(Job):
 
 
 class TestRegistry(RQTestCase):
+    """Test all the BaseRegistry functionality"""
+
     def setUp(self):
         super().setUp()
-        self.registry = StartedJobRegistry(connection=self.connection)
+        self.registry = BaseRegistry(connection=self.connection)
 
     def test_init(self):
         """Registry can be instantiated with queue or name/Redis connection"""
         queue = Queue('foo', connection=self.connection)
-        registry = StartedJobRegistry(queue=queue)
+        registry = BaseRegistry(queue=queue)
         self.assertEqual(registry.name, queue.name)
         self.assertEqual(registry.connection, queue.connection)
         self.assertEqual(registry.serializer, queue.serializer)
 
-        registry = StartedJobRegistry('bar', self.connection, serializer=JSONSerializer)
+        registry = BaseRegistry('bar', self.connection, serializer=JSONSerializer)
         self.assertEqual(registry.name, 'bar')
         self.assertEqual(registry.connection, self.connection)
         self.assertEqual(registry.serializer, JSONSerializer)
 
     def test_key(self):
-        self.assertEqual(self.registry.key, 'rq:wip:default')
+        self.assertEqual(self.registry.key, 'rq:registry:default')
 
     def test_custom_job_class(self):
-        registry = StartedJobRegistry(job_class=CustomJob)
+        registry = BaseRegistry(job_class=CustomJob)
         self.assertFalse(registry.job_class == self.registry.job_class)
 
     def test_contains(self):
-        registry = StartedJobRegistry(connection=self.connection)
+        registry = BaseRegistry(connection=self.connection)
         queue = Queue(connection=self.connection)
         job = queue.enqueue(say_hello)
 
@@ -65,63 +69,68 @@ class TestRegistry(RQTestCase):
 
     def test_get_expiration_time(self):
         """registry.get_expiration_time() returns correct datetime objects"""
-        registry = StartedJobRegistry(connection=self.connection)
+        registry = BaseRegistry(connection=self.connection)
         queue = Queue(connection=self.connection)
         job = queue.enqueue(say_hello)
 
         registry.add(job, 5)
         time = registry.get_expiration_time(job)
-        expected_time = (datetime.utcnow() + timedelta(seconds=5)).replace(microsecond=0)
+        # workaround until https://github.com/rq/rq/pull/2180#issuecomment-2693263029
+        # is addressed
+        if time.tzinfo is None:
+            time = time.replace(tzinfo=timezone.utc)
+        expected_time = (now() + timedelta(seconds=5)).replace(microsecond=0)
         self.assertGreaterEqual(time, expected_time - timedelta(seconds=2))
         self.assertLessEqual(time, expected_time + timedelta(seconds=2))
 
     def test_add_and_remove(self):
-        """Adding and removing job to StartedJobRegistry."""
+        """Adding and removing job from BaseRegistry."""
+        registry = BaseRegistry(connection=self.connection)
         timestamp = current_timestamp()
 
         queue = Queue(connection=self.connection)
         job = queue.enqueue(say_hello)
 
         # Test that job is added with the right score
-        self.registry.add(job, 1000)
-        self.assertLess(self.connection.zscore(self.registry.key, job.id), timestamp + 1002)
+        registry.add(job, 1000)
+        self.assertLess(self.connection.zscore(registry.key, job.id), timestamp + 1002)
 
         # Ensure that a timeout of -1 results in a score of inf
-        self.registry.add(job, -1)
-        self.assertEqual(self.connection.zscore(self.registry.key, job.id), float('inf'))
+        registry.add(job, -1)
+        self.assertEqual(self.connection.zscore(registry.key, job.id), float('inf'))
 
         # Ensure that job is removed from sorted set, but job key is not deleted
-        self.registry.remove(job)
-        self.assertIsNone(self.connection.zscore(self.registry.key, job.id))
+        registry.remove(job)
+        self.assertIsNone(self.connection.zscore(registry.key, job.id))
         self.assertTrue(self.connection.exists(job.key))
 
-        self.registry.add(job, -1)
+        registry.add(job, -1)
 
         # registry.remove() also accepts job.id
-        self.registry.remove(job.id)
-        self.assertIsNone(self.connection.zscore(self.registry.key, job.id))
+        registry.remove(job.id)
+        self.assertIsNone(self.connection.zscore(registry.key, job.id))
 
-        self.registry.add(job, -1)
+        registry.add(job, -1)
 
         # delete_job = True deletes job key
-        self.registry.remove(job, delete_job=True)
-        self.assertIsNone(self.connection.zscore(self.registry.key, job.id))
+        registry.remove(job, delete_job=True)
+        self.assertIsNone(self.connection.zscore(registry.key, job.id))
         self.assertFalse(self.connection.exists(job.key))
 
         job = queue.enqueue(say_hello)
 
-        self.registry.add(job, -1)
+        registry.add(job, -1)
 
         # delete_job = True also works with job.id
-        self.registry.remove(job.id, delete_job=True)
-        self.assertIsNone(self.connection.zscore(self.registry.key, job.id))
+        registry.remove(job.id, delete_job=True)
+        self.assertIsNone(self.connection.zscore(registry.key, job.id))
         self.assertFalse(self.connection.exists(job.key))
 
     def test_add_and_remove_with_serializer(self):
-        """Adding and removing job to StartedJobRegistry (with serializer)."""
+        """Adding and removing job from BaseRegistry (with serializer)."""
         # delete_job = True also works with job.id and custom serializer
         queue = Queue(connection=self.connection, serializer=JSONSerializer)
-        registry = StartedJobRegistry(connection=self.connection, serializer=JSONSerializer)
+        registry = BaseRegistry(connection=self.connection, serializer=JSONSerializer)
         job = queue.enqueue(say_hello)
         registry.add(job, -1)
         registry.remove(job.id, delete_job=True)
@@ -129,23 +138,15 @@ class TestRegistry(RQTestCase):
         self.assertFalse(self.connection.exists(job.key))
 
     def test_get_job_ids(self):
-        """Getting job ids from StartedJobRegistry."""
+        """Getting job ids from BaseRegistry."""
         timestamp = current_timestamp()
         self.connection.zadd(self.registry.key, {'will-be-cleaned-up': 1})
         self.connection.zadd(self.registry.key, {'foo': timestamp + 10})
         self.connection.zadd(self.registry.key, {'bar': timestamp + 20})
-        self.assertEqual(self.registry.get_job_ids(), ['foo', 'bar'])
-
-    def test_get_job_ids_does_not_cleanup(self):
-        """Getting job ids from StartedJobRegistry without a cleanup."""
-        timestamp = current_timestamp()
-        self.connection.zadd(self.registry.key, {'will-be-returned-despite-outdated': 1})
-        self.connection.zadd(self.registry.key, {'foo': timestamp + 10})
-        self.connection.zadd(self.registry.key, {'bar': timestamp + 20})
-        self.assertEqual(self.registry.get_job_ids(cleanup=False), ['will-be-returned-despite-outdated', 'foo', 'bar'])
+        self.assertEqual(self.registry.get_job_ids(), ['will-be-cleaned-up', 'foo', 'bar'])
 
     def test_get_expired_job_ids(self):
-        """Getting expired job ids form StartedJobRegistry."""
+        """Getting expired job ids form BaseRegistry."""
         timestamp = current_timestamp()
 
         self.connection.zadd(self.registry.key, {'foo': 1})
@@ -159,106 +160,14 @@ class TestRegistry(RQTestCase):
         registry = CanceledJobRegistry(connection=self.connection)
         self.assertRaises(NotImplementedError, registry.get_expired_job_ids)
 
-    def test_cleanup_moves_jobs_to_failed_job_registry(self):
-        """Moving expired jobs to FailedJobRegistry."""
-        queue = Queue(connection=self.connection)
-        failed_job_registry = FailedJobRegistry(connection=self.connection)
-        job = queue.enqueue(say_hello)
-
-        self.connection.zadd(self.registry.key, {job.id: 2})
-
-        # Job has not been moved to FailedJobRegistry
-        self.registry.cleanup(1)
-        self.assertNotIn(job, failed_job_registry)
-        self.assertIn(job, self.registry)
-
-        with mock.patch.object(Job, 'execute_failure_callback') as mocked:
-            mock_handler = mock.MagicMock()
-            mock_handler.return_value = False
-            mock_handler_no_return = mock.MagicMock()
-            mock_handler_no_return.return_value = None
-            self.registry.cleanup(exception_handlers=[mock_handler_no_return, mock_handler])
-            mocked.assert_called_once_with(queue.death_penalty_class, AbandonedJobError, ANY, ANY)
-            mock_handler.assert_called_once_with(job, AbandonedJobError, ANY, ANY)
-            mock_handler_no_return.assert_called_once_with(job, AbandonedJobError, ANY, ANY)
-        self.assertIn(job.id, failed_job_registry)
-        self.assertNotIn(job, self.registry)
-        job.refresh()
-        self.assertEqual(job.get_status(), JobStatus.FAILED)
-        self.assertTrue(job.exc_info)  # explanation is written to exc_info
-
-    def test_job_execution(self):
-        """Job is removed from StartedJobRegistry after execution."""
-        registry = StartedJobRegistry(connection=self.connection)
-        queue = Queue(connection=self.connection)
-        worker = Worker([queue], connection=self.connection)
-
-        job = queue.enqueue(say_hello)
-        self.assertTrue(job.is_queued)
-        execution = worker.prepare_execution(job)
-        worker.prepare_job_execution(job)
-        self.assertIn(execution.composite_key, registry.get_job_ids())
-        self.assertTrue(job.is_started)
-
-        worker.perform_job(job, queue)
-        self.assertNotIn(execution.composite_key, registry.get_job_ids())
-        self.assertTrue(job.is_finished)
-
-        # Job that fails
-        job = queue.enqueue(div_by_zero)
-        execution = worker.prepare_execution(job)
-        worker.prepare_job_execution(job)
-        self.assertIn(execution.composite_key, registry.get_job_ids())
-
-        worker.perform_job(job, queue)
-        self.assertNotIn(execution.composite_key, registry.get_job_ids())
-
-    def test_remove_executions(self):
-        """Ensure all executions for a job are removed from registry."""
-        registry = StartedJobRegistry(connection=self.connection)
-        queue = Queue(connection=self.connection)
-        worker = Worker([queue], connection=self.connection)
-        job = queue.enqueue(say_hello)
-
-        execution_1 = worker.prepare_execution(job)
-        execution_2 = worker.prepare_execution(job)
-
-        self.assertIn(execution_1.composite_key, registry.get_job_ids())
-        self.assertIn(execution_2.composite_key, registry.get_job_ids())
-
-        registry.remove_executions(job)
-
-        self.assertNotIn(execution_1.composite_key, registry.get_job_ids())
-        self.assertNotIn(execution_2.composite_key, registry.get_job_ids())
-
-        job.delete()
-
-    def test_job_deletion(self):
-        """Ensure job is removed from StartedJobRegistry when deleted."""
-        registry = StartedJobRegistry(connection=self.connection)
-        queue = Queue(connection=self.connection)
-        worker = Worker([queue], connection=self.connection)
-
-        job = queue.enqueue(say_hello)
-        self.assertTrue(job.is_queued)
-
-        execution = worker.prepare_execution(job)
-        worker.prepare_job_execution(job)
-        self.assertIn(execution.composite_key, registry.get_job_ids())
-
-        pipeline = self.connection.pipeline()
-        job.delete(pipeline=pipeline)
-        pipeline.execute()
-        self.assertNotIn(execution.composite_key, registry.get_job_ids())
-
     def test_count(self):
-        """StartedJobRegistry returns the right number of job count."""
+        """BaseRegistry returns the right number of job count."""
         timestamp = current_timestamp() + 10
         self.connection.zadd(self.registry.key, {'will-be-cleaned-up': 1})
         self.connection.zadd(self.registry.key, {'foo': timestamp})
         self.connection.zadd(self.registry.key, {'bar': timestamp})
-        self.assertEqual(self.registry.count, 2)
-        self.assertEqual(len(self.registry), 2)
+        self.assertEqual(self.registry.count, 3)
+        self.assertEqual(len(self.registry), 3)
 
     def test_get_job_count(self):
         """Ensure cleanup is not called and does not affect the reported number of jobs.
@@ -283,7 +192,7 @@ class TestRegistry(RQTestCase):
         self.connection.zadd(finished_job_registry.key, {'foo': 1})
 
         started_job_registry = StartedJobRegistry(connection=self.connection)
-        self.connection.zadd(started_job_registry.key, {'foo': 1})
+        self.connection.zadd(started_job_registry.key, {'foo:execution_id': 1})
 
         failed_job_registry = FailedJobRegistry(connection=self.connection)
         self.connection.zadd(failed_job_registry.key, {'foo': 1})
@@ -302,7 +211,7 @@ class TestRegistry(RQTestCase):
         self.connection.zadd(finished_job_registry.key, {'foo': 1})
 
         started_job_registry = StartedJobRegistry(connection=self.connection, serializer=JSONSerializer)
-        self.connection.zadd(started_job_registry.key, {'foo': 1})
+        self.connection.zadd(started_job_registry.key, {'foo:execution_id': 1})
 
         failed_job_registry = FailedJobRegistry(connection=self.connection, serializer=JSONSerializer)
         self.connection.zadd(failed_job_registry.key, {'foo': 1})
@@ -314,52 +223,11 @@ class TestRegistry(RQTestCase):
 
     def test_get_queue(self):
         """registry.get_queue() returns the right Queue object."""
-        registry = StartedJobRegistry(connection=self.connection)
+        registry = BaseRegistry(connection=self.connection)
         self.assertEqual(registry.get_queue(), Queue(connection=self.connection))
 
-        registry = StartedJobRegistry('foo', connection=self.connection, serializer=JSONSerializer)
+        registry = BaseRegistry('foo', connection=self.connection, serializer=JSONSerializer)
         self.assertEqual(registry.get_queue(), Queue('foo', connection=self.connection, serializer=JSONSerializer))
-
-    def test_enqueue_dependents_when_parent_job_is_abandoned(self):
-        """Enqueuing parent job's dependencies after moving it to FailedJobRegistry due to AbandonedJobError."""
-        queue = Queue(connection=self.connection)
-        worker = Worker([queue])
-        failed_job_registry = FailedJobRegistry(connection=self.connection)
-        finished_job_registry = FinishedJobRegistry(connection=self.connection)
-        deferred_job_registry = DeferredJobRegistry(connection=self.connection)
-
-        parent_job = queue.enqueue(say_hello)
-        job_to_be_executed = queue.enqueue_call(say_hello, depends_on=Dependency(jobs=parent_job, allow_failure=True))
-        job_not_to_be_executed = queue.enqueue_call(
-            say_hello, depends_on=Dependency(jobs=parent_job, allow_failure=False)
-        )
-        self.assertIn(job_to_be_executed, deferred_job_registry)
-        self.assertIn(job_not_to_be_executed, deferred_job_registry)
-
-        self.connection.zadd(self.registry.key, {parent_job.id: 2})
-        queue.remove(parent_job.id)
-
-        with mock.patch.object(Job, 'execute_failure_callback') as mocked:
-            self.registry.cleanup()
-            mocked.assert_called_once_with(queue.death_penalty_class, AbandonedJobError, ANY, ANY)
-
-        # check that parent job was moved to FailedJobRegistry and has correct status
-        self.assertIn(parent_job, failed_job_registry)
-        self.assertNotIn(parent_job, self.registry)
-        self.assertTrue(parent_job.is_failed)
-
-        # check that only job_to_be_executed has been queued and executed
-        self.assertEqual(len(queue.get_job_ids()), 1)
-        self.assertTrue(job_to_be_executed.is_queued)
-        self.assertFalse(job_not_to_be_executed.is_queued)
-
-        worker.work(burst=True)
-        self.assertTrue(job_to_be_executed.is_finished)
-        self.assertNotIn(job_to_be_executed, deferred_job_registry)
-        self.assertIn(job_to_be_executed, finished_job_registry)
-
-        self.assertFalse(job_not_to_be_executed.is_finished)
-        self.assertNotIn(job_not_to_be_executed, finished_job_registry)
 
 
 class TestFinishedJobRegistry(RQTestCase):
@@ -485,7 +353,12 @@ class TestDeferredRegistry(RQTestCase):
         self.assertNotIn(job, self.registry)
         job.refresh()
         self.assertEqual(job.get_status(), JobStatus.FAILED)
-        self.assertTrue(job.exc_info)  # explanation is written to exc_info
+        if job.supports_redis_streams:
+            latest_result = job.latest_result()
+            self.assertIsNotNone(latest_result)
+            self.assertTrue(latest_result.exc_string)  # explanation is written to exc_info
+        else:
+            self.assertTrue(job.exc_info)
 
 
 class TestFailedJobRegistry(RQTestCase):
@@ -653,3 +526,186 @@ class TestFailedJobRegistry(RQTestCase):
         job = q.enqueue(div_by_zero, failure_ttl=5)
         w.handle_job_failure(job, q)
         self.assertLess(self.connection.zscore(registry.key, job.id), timestamp + 7)
+
+
+class TestStartedJobRegistry(RQTestCase):
+    def setUp(self):
+        super().setUp()
+        self.registry = StartedJobRegistry(connection=self.connection)
+        self.q = Queue(connection=self.connection)
+
+    def test_job_deletion(self):
+        """Ensure job is removed from StartedJobRegistry when deleted."""
+        worker = Worker([self.q], connection=self.connection)
+
+        job = self.q.enqueue(say_hello)
+        self.assertTrue(job.is_queued)
+
+        execution = worker.prepare_execution(job)
+        worker.prepare_job_execution(job)
+        self.assertIn(execution.job_id, self.registry.get_job_ids())
+
+        pipeline = self.connection.pipeline()
+        job.delete(pipeline=pipeline)
+        pipeline.execute()
+        self.assertNotIn(execution.job_id, self.registry.get_job_ids())
+
+    def test_contains(self):
+        """Test the StartedJobRegistry __contains__ method. It is slightly different
+        because the entries in the registry are {job_id}:{execution_id} format."""
+        job = self.q.enqueue(say_hello)
+
+        self.assertFalse(job in self.registry)
+        self.assertFalse(job.id in self.registry)
+
+        with self.connection.pipeline() as pipe:
+            self.registry.add_execution(
+                Execution(id='execution', job_id=job.id, connection=self.connection), pipeline=pipe, ttl=5
+            )
+            pipe.execute()
+        self.assertTrue(job in self.registry)
+        self.assertTrue(job.id in self.registry)
+
+    def test_remove_executions(self):
+        """Ensure all executions for a job are removed from registry."""
+        worker = Worker([self.q], connection=self.connection)
+        job = self.q.enqueue(say_hello)
+
+        execution_1 = worker.prepare_execution(job)
+        execution_2 = worker.prepare_execution(job)
+        self.assertIn((job.id, execution_1.id), self.registry.get_job_and_execution_ids())
+        self.assertIn((job.id, execution_2.id), self.registry.get_job_and_execution_ids())
+
+        self.registry.remove_executions(job)
+
+        self.assertNotIn((job.id, execution_1.id), self.registry.get_job_and_execution_ids())
+        self.assertNotIn((job.id, execution_2.id), self.registry.get_job_and_execution_ids())
+
+        job.delete()
+
+    def test_job_execution(self):
+        """Job is removed from StartedJobRegistry after execution."""
+        worker = Worker([self.q], connection=self.connection)
+
+        job = self.q.enqueue(say_hello)
+        self.assertTrue(job.is_queued)
+        execution = worker.prepare_execution(job)
+        worker.prepare_job_execution(job)
+        self.assertIn(job.id, self.registry.get_job_ids())
+        self.assertIn((job.id, execution.id), self.registry.get_job_and_execution_ids())
+        self.assertTrue(job.is_started)
+
+        worker.perform_job(job, self.q)
+        self.assertNotIn(job.id, self.registry.get_job_ids())
+        self.assertNotIn((job.id, execution.id), self.registry.get_job_and_execution_ids())
+        self.assertTrue(job.is_finished)
+
+        # Job that fails
+        job = self.q.enqueue(div_by_zero)
+        execution = worker.prepare_execution(job)
+        worker.prepare_job_execution(job)
+        self.assertIn(job.id, self.registry.get_job_ids())
+        self.assertIn((job.id, execution.id), self.registry.get_job_and_execution_ids())
+
+        worker.perform_job(job, self.q)
+        self.assertNotIn(job.id, self.registry.get_job_ids())
+        self.assertNotIn((job.id, execution.id), self.registry.get_job_and_execution_ids())
+
+    def test_get_job_ids(self):
+        """Getting job ids with cleanup."""
+        timestamp = current_timestamp()
+        self.connection.zadd(self.registry.key, {'will-be-cleaned-up:execution_id1': 1})
+        self.connection.zadd(self.registry.key, {'foo:execution_id2': timestamp + 10})
+        self.connection.zadd(self.registry.key, {'bar:execution_id3': timestamp + 20})
+        self.assertEqual(self.registry.get_job_ids(), ['foo', 'bar'])
+
+    def test_get_job_ids_does_not_cleanup(self):
+        """Getting job ids without a cleanup."""
+        timestamp = current_timestamp()
+        self.connection.zadd(self.registry.key, {'will-be-returned-despite-outdated:execution_id1': 1})
+        self.connection.zadd(self.registry.key, {'foo:execution_id2': timestamp + 10})
+        self.connection.zadd(self.registry.key, {'bar:execution_id3': timestamp + 20})
+        self.assertEqual(self.registry.get_job_ids(cleanup=False), ['will-be-returned-despite-outdated', 'foo', 'bar'])
+
+    def test_count(self):
+        """Return the right number of job count (cleanup should be performed)"""
+        timestamp = current_timestamp() + 10
+        self.connection.zadd(self.registry.key, {'will-be-cleaned-up': 1})
+        self.connection.zadd(self.registry.key, {'foo': timestamp})
+        self.connection.zadd(self.registry.key, {'bar': timestamp})
+        self.assertEqual(self.registry.count, 2)
+        self.assertEqual(len(self.registry), 2)
+
+    def test_cleanup_moves_jobs_to_failed_job_registry(self):
+        """Moving expired jobs to FailedJobRegistry."""
+
+        failed_job_registry = FailedJobRegistry(connection=self.connection)
+        job = self.q.enqueue(say_hello)
+
+        self.connection.zadd(self.registry.key, {f'{job.id}:execution_id': 100})
+
+        # Job has not been moved to FailedJobRegistry
+        self.registry.cleanup(1)
+        self.assertNotIn(job, failed_job_registry)
+        self.assertIn(job, self.registry)
+
+        with mock.patch.object(Job, 'execute_failure_callback') as mocked:
+            mock_handler = mock.MagicMock()
+            mock_handler.return_value = False
+            mock_handler_no_return = mock.MagicMock()
+            mock_handler_no_return.return_value = None
+            self.registry.cleanup(exception_handlers=[mock_handler_no_return, mock_handler])
+            mocked.assert_called_once_with(self.q.death_penalty_class, AbandonedJobError, ANY, ANY)
+            mock_handler.assert_called_once_with(job, AbandonedJobError, ANY, ANY)
+            mock_handler_no_return.assert_called_once_with(job, AbandonedJobError, ANY, ANY)
+        self.assertIn(job.id, failed_job_registry)
+        self.assertNotIn(job, self.registry)
+        job.refresh()
+        self.assertEqual(job.get_status(), JobStatus.FAILED)
+        if job.supports_redis_streams:
+            latest_result = job.latest_result()
+            self.assertIsNotNone(latest_result)
+            self.assertTrue(latest_result.exc_string)  # explanation is written to exc_info
+        else:
+            self.assertTrue(job.exc_info)
+
+    def test_enqueue_dependents_when_parent_job_is_abandoned(self):
+        """Enqueuing parent job's dependencies after moving it to FailedJobRegistry due to AbandonedJobError."""
+        queue = Queue(connection=self.connection)
+        worker = Worker([queue])
+        failed_job_registry = FailedJobRegistry(connection=self.connection)
+        finished_job_registry = FinishedJobRegistry(connection=self.connection)
+        deferred_job_registry = DeferredJobRegistry(connection=self.connection)
+
+        parent_job = queue.enqueue(say_hello)
+        job_to_be_executed = queue.enqueue_call(say_hello, depends_on=Dependency(jobs=[parent_job], allow_failure=True))
+        job_not_to_be_executed = queue.enqueue_call(
+            say_hello, depends_on=Dependency(jobs=[parent_job], allow_failure=False)
+        )
+        self.assertIn(job_to_be_executed, deferred_job_registry)
+        self.assertIn(job_not_to_be_executed, deferred_job_registry)
+
+        self.connection.zadd(self.registry.key, {f'{parent_job.id}:execution': 2})
+        queue.remove(parent_job.id)
+
+        with mock.patch.object(Job, 'execute_failure_callback') as mocked:
+            self.registry.cleanup()
+            mocked.assert_called_once_with(queue.death_penalty_class, AbandonedJobError, ANY, ANY)
+
+        # check that parent job was moved to FailedJobRegistry and has correct status
+        self.assertIn(parent_job, failed_job_registry)
+        self.assertNotIn(parent_job, self.registry)
+        self.assertTrue(parent_job.is_failed)
+
+        # check that only job_to_be_executed has been queued and executed
+        self.assertEqual(len(queue.get_job_ids()), 1)
+        self.assertTrue(job_to_be_executed.is_queued)
+        self.assertFalse(job_not_to_be_executed.is_queued)
+
+        worker.work(burst=True)
+        self.assertTrue(job_to_be_executed.is_finished)
+        self.assertNotIn(job_to_be_executed, deferred_job_registry)
+        self.assertIn(job_to_be_executed, finished_job_registry)
+
+        self.assertFalse(job_not_to_be_executed.is_finished)
+        self.assertNotIn(job_not_to_be_executed, finished_job_registry)


### PR DESCRIPTION
# Update the StartedJobRegistry to use correct job_id extracting (instead of job_id:execution_id, return job_id)

Changes/Updates:
* Added `parse_job_id` method. BaseRegistry would return the id as_text, but `StartedJobRegistry` would parse the job_id from `job_id:execution` format.
* StartedJobRegistry.cleanup() now properly saves the job result into the job result (using the _handle_failure)
* Added an option for the `Queue.enqueue_dependents` to prevent refreshing the job status, if the job status has been updated in the pipeline)
* Added deprecation notices to avoid adding/removing a job to the StartedJobRegistry (only Executions are allowed)
* Added a test where the job that is still executing would not be cleaned up, while in the started queue (test_no_cleanup_while_in_started_queue)
* Updated tests to exercise the StartedJobRegistry separately from the BaseRegistry.
* Added tests for a few warnings
* Update the `exc_info` in tests to avoid calling deprecated method (when available)

Issues it fixes:
* Fixes #2182 
* `get_expired_job_ids` would not return the job_ids, but rather `job_id:execution_id`. This means that the `StartedJobRegistry.cleanup()` would never actually clean anything, because the subsequent `Job.fetch` would not find the job with `job_id:execution_id`
* `IntermediateQueue.cleanup()` would never find the job in the `started_job_registry`. The `__contains__` method would only check if the job_id is in the Redis set and it would always return `False`.