### PR TITLE
Update deprecated action runners

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     permissions:
       # required for all workflows

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     if: github.repository == 'rq/rq'
     name: Python${{ matrix.python-version }}/Redis${{ matrix.redis-version }}/redis-py${{ matrix.redis-py-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   push:
     if: github.repository == 'rq/rq'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,11 +2,7 @@ name: Test
 
 on:
   push:
-    branches:
-      - master
-      - "**"
   pull_request:
-    branches: [master]
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   ssl-test:
     name: Run SSL tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker test image for tox
@@ -31,7 +31,7 @@ jobs:
 
   test:
     name: Python${{ matrix.python-version }}/Redis${{ matrix.redis-version }}/redis-py${{ matrix.redis-py-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,12 +59,11 @@ jobs:
       - name: Test with pytest
         run: |
           RUN_SLOW_TESTS_TOO=1 hatch run test:cov --durations=5
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5.4.0
-      with:
-        files: ./coverage.xml
-        fail_ci_if_error: false
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5.4.0
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
 
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   ssl-test:
-    if: github.event_name != 'push' || github.ref == 'refs/heads/main'
     name: Run SSL tests
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +26,6 @@ jobs:
           run: stunnel & redis-server & RUN_SSL_TESTS=1 hatch run tox run -e ssl
 
   test:
-    if: github.event_name != 'push' || github.ref == 'refs/heads/main'
     name: Python${{ matrix.python-version }}/Redis${{ matrix.redis-version }}/redis-py${{ matrix.redis-py-version }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -68,7 +66,6 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     name: Type check
-    if: github.event_name != 'push' || github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -63,9 +63,9 @@ jobs:
         RUN_SLOW_TESTS_TOO=1 hatch run test:cov --durations=5
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v5.4.0
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
 
   mypy:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ easily.
 
 RQ requires Redis >= 3.0.0.
 
-[![Build status](https://github.com/rq/rq/workflows/Test%20rq/badge.svg)](https://github.com/rq/rq/actions?query=workflow%3A%22Test+rq%22)
+[![Build status](https://github.com/rq/rq/workflows/Test/badge.svg)](https://github.com/rq/rq/actions?query=workflow%3A%22Test%22)
 [![PyPI](https://img.shields.io/pypi/pyversions/rq.svg)](https://pypi.python.org/pypi/rq)
 [![Coverage](https://codecov.io/gh/rq/rq/branch/master/graph/badge.svg)](https://codecov.io/gh/rq/rq)
 [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/rq/utils.py
+++ b/rq/utils.py
@@ -127,7 +127,7 @@ def import_attribute(name: str) -> Callable[..., Any]:
         try:
             return __builtins__[name]  # type: ignore[index]
         except KeyError:
-            raise ValueError('Invalid attribute name: %s' % name)
+            raise ValueError(f'Invalid attribute name: {name}')
 
     attribute_name = '.'.join(attribute_bits)
     if hasattr(module, attribute_name):


### PR DESCRIPTION
Updated deprecated `run-os` to `ubuntu-latest`
Changed the [codecov deprecated](https://github.com/codecov/codecov-action?tab=readme-ov-file#migration-guide) `file` to `files.