### PR TITLE
Update the StartedJobRegistry to use correct job_id extracting

### DIFF
--- a/rq/executions.py
+++ b/rq/executions.py
@@ -86,7 +86,7 @@ class Execution:
     def delete(self, job: Job, pipeline: 'Pipeline'):
         """Delete an execution from Redis."""
         pipeline.delete(self.key)
-        job.started_job_registry.remove_execution(execution=self, job=job, pipeline=pipeline)
+        job.started_job_registry.remove_execution(execution=self, pipeline=pipeline)
         ExecutionRegistry(job_id=self.job_id, connection=self.connection).remove(execution=self, pipeline=pipeline)
 
     def serialize(self) -> Dict:

--- a/rq/job.py
+++ b/rq/job.py
@@ -1679,6 +1679,17 @@ class Job:
 
         return all(status.decode() in allowed_statuses for status in dependencies_statuses if status)
 
+    def remove_executions(self, pipeline: Optional['Pipeline'] = None) -> None:
+        """Method to remove all job executions.
+
+        Args:
+            pipeline (Optional[Pipeline]): a pipeline or a connection to use. Defaults to None.
+        """
+        connection = pipeline if pipeline is not None else self.connection
+        execution_ids = [execution.composite_key for execution in self.get_executions()]
+        if execution_ids:
+            connection.zrem(self.started_job_registry.key, *execution_ids)
+
 
 _job_stack = LocalStack()
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -1621,6 +1621,7 @@ class Job:
         parent_job: Optional['Job'] = None,
         pipeline: Optional['Pipeline'] = None,
         exclude_job_id: Optional[str] = None,
+        refresh_job_status: bool = True,
     ) -> bool:
         """Returns a boolean indicating if all of this job's dependencies are `FINISHED`
 
@@ -1634,7 +1635,8 @@ class Job:
         Args:
             parent_job (Optional[Job], optional): The parent Job. Defaults to None.
             pipeline (Optional[Pipeline], optional): The Redis' pipeline. Defaults to None.
-            exclude_job_id (Optional[str], optional): Whether to exclude the job id.. Defaults to None.
+            exclude_job_id (Optional[str], optional): Whether to exclude the job id. Defaults to None.
+            refresh_job_status (bool): whether to refresh job status when checking for dependencies. Defaults to True.
 
         Returns:
             are_met (bool): Whether the dependencies were met.
@@ -1656,9 +1658,9 @@ class Job:
             # If parent job is not finished, we should only continue
             # if this job allows parent job to fail
             dependencies_ids.discard(parent_job.id)
-            if parent_job.get_status() == JobStatus.CANCELED:
+            if parent_job.get_status(refresh=refresh_job_status) == JobStatus.CANCELED:
                 return False
-            elif parent_job._status == JobStatus.FAILED and not self.allow_dependency_failures:
+            elif parent_job.get_status(refresh=False) == JobStatus.FAILED and not self.allow_dependency_failures:
                 return False
 
             # If the only dependency is parent job, dependency has been met

--- a/rq/job.py
+++ b/rq/job.py
@@ -1250,12 +1250,10 @@ class Job:
             from .registry import StartedJobRegistry
 
             # TODO: need to cleanup job executions too
-
             registry = StartedJobRegistry(
                 self.origin, connection=self.connection, job_class=self.__class__, serializer=self.serializer
             )
             registry.remove_executions(self, pipeline=pipeline)
-            registry.remove(self, pipeline=pipeline)
 
         elif self.is_scheduled:
             from .registry import ScheduledJobRegistry
@@ -1678,17 +1676,6 @@ class Job:
             allowed_statuses.append(JobStatus.FAILED)
 
         return all(status.decode() in allowed_statuses for status in dependencies_statuses if status)
-
-    def remove_executions(self, pipeline: Optional['Pipeline'] = None) -> None:
-        """Method to remove all job executions.
-
-        Args:
-            pipeline (Optional[Pipeline]): a pipeline or a connection to use. Defaults to None.
-        """
-        connection = pipeline if pipeline is not None else self.connection
-        execution_ids = [execution.composite_key for execution in self.get_executions()]
-        if execution_ids:
-            connection.zrem(self.started_job_registry.key, *execution_ids)
 
 
 _job_stack = LocalStack()

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1192,7 +1192,11 @@ class Queue:
         return job
 
     def enqueue_dependents(
-        self, job: 'Job', pipeline: Optional['Pipeline'] = None, exclude_job_id: Optional[str] = None
+        self,
+        job: 'Job',
+        pipeline: Optional['Pipeline'] = None,
+        exclude_job_id: Optional[str] = None,
+        refresh_job_status: bool = True,
     ):
         """Enqueues all jobs in the given job's dependents set and clears it.
 
@@ -1204,6 +1208,7 @@ class Queue:
             job (Job): The Job to enqueue the dependents
             pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
             exclude_job_id (Optional[str], optional): Whether to exclude the job id. Defaults to None.
+            refresh_job_status (bool): whether to refresh job status when checking for dependencies. Defaults to True.
         """
         from .registry import DeferredJobRegistry
 
@@ -1233,6 +1238,7 @@ class Queue:
                         parent_job=job,
                         pipeline=pipe,
                         exclude_job_id=exclude_job_id,
+                        refresh_job_status=refresh_job_status,
                     )
                     and dependent_job.get_status(refresh=False) != JobStatus.CANCELED
                 ]
@@ -1315,7 +1321,7 @@ class Queue:
             if timeout == 0:
                 raise ValueError('RQ does not support indefinite timeouts. Please pick a timeout value > 0')
             colored_queues = ', '.join(map(str, [green(str(queue)) for queue in queue_keys]))
-            logger.debug("Starting BLPOP operation for queues %s with timeout of %d", colored_queues, timeout)
+            logger.debug('Starting BLPOP operation for queues %s with timeout of %d', colored_queues, timeout)
             assert connection
             result = connection.blpop(queue_keys, timeout)
             if result is None:

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -103,7 +103,7 @@ class BaseRegistry:
             self.cleanup()
         return self.connection.zcard(self.key)
 
-    def add(self, job: Union[Job, str], ttl: int = 0, pipeline: Optional['Pipeline'] = None, xx: bool = False) -> int:
+    def add(self, job: Job, ttl: int = 0, pipeline: Optional['Pipeline'] = None, xx: bool = False) -> int:
         """Adds a job to a registry with expiry time of now + ttl, unless it's -1 which is set to +inf
 
         Args:
@@ -118,11 +118,10 @@ class BaseRegistry:
         score: Union[int, str] = ttl if ttl < 0 else current_timestamp() + ttl
         if score == -1:
             score = '+inf'
-        job_id = job.id if isinstance(job, self.job_class) else job
         if pipeline is not None:
-            return cast(int, pipeline.zadd(self.key, {job_id: score}, xx=xx))
+            return cast(int, pipeline.zadd(self.key, {job.id: score}, xx=xx))
 
-        return self.connection.zadd(self.key, {job_id: score}, xx=xx)
+        return self.connection.zadd(self.key, {job.id: score}, xx=xx)
 
     def remove(self, job: Union[Job, str], pipeline: Optional['Pipeline'] = None, delete_job: bool = False):
         """Removes job from registry and deletes it if `delete_job == True`
@@ -383,7 +382,7 @@ class StartedJobRegistry(BaseRegistry):
             job_id = item.id
         return cast(str, job_id) in self.get_job_ids(cleanup=False)
 
-    def add(self, job: Union[Job, str], ttl: int = 0, pipeline: Optional['Pipeline'] = None, xx: bool = False) -> int:
+    def add(self, job: Job, ttl: int = 0, pipeline: Optional['Pipeline'] = None, xx: bool = False) -> int:
         raise NotImplementedError()
 
     def remove(self, job: Union[Job, str], pipeline: Optional['Pipeline'] = None, delete_job: bool = False):

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -384,27 +384,10 @@ class StartedJobRegistry(BaseRegistry):
         return cast(str, job_id) in self.get_job_ids(cleanup=False)
 
     def add(self, job: Union[Job, str], ttl: int = 0, pipeline: Optional['Pipeline'] = None, xx: bool = False) -> int:
-        warnings.warn(
-            'StartedJobRegistry can only contain execution records. Use add_execution method.', DeprecationWarning
-        )
-        # in the future will raise
-        # raise NotImplementedError('')
-        job_id = job.id if isinstance(job, self.job_class) else job
-        # use job_id: so the stored record is always a tuple, when split by ':'
-        return super().add(f'{job_id}:', ttl, pipeline, xx)
+        raise NotImplementedError()
 
     def remove(self, job: Union[Job, str], pipeline: Optional['Pipeline'] = None, delete_job: bool = False):
-        warnings.warn(
-            'StartedJobRegistry can only contain execution records. Use remove_execution method.', DeprecationWarning
-        )
-
-        # in the future will raise
-        # raise NotImplementedError('')
-        job_id = job.id if isinstance(job, self.job_class) else job
-        # if delete job is True, the following would fail. Prohibit deleting the job this way.
-        if delete_job:
-            raise RuntimeError('StartedJobRegistry.remove() method cannot auto-delete the job.')
-        return super().remove(f'{job_id}:', pipeline, delete_job)
+        raise NotImplementedError()
 
     @staticmethod
     def parse_job_id(entry: str) -> str:
@@ -416,16 +399,16 @@ class StartedJobRegistry(BaseRegistry):
         return job_id
 
     def remove_executions(self, job: Job, pipeline: Optional['Pipeline'] = None) -> None:
-        """Removes job executions from registry
+        """Removes job executions from the started job registry.
 
         Args:
             job (Job): The Job to remove from the registry
             pipeline (Optional['Pipeline']): The Redis Pipeline. Defaults to None.
         """
-        warnings.warn(
-            'StartedJobRegistry.remove_executions() is deprecated. Use Job.remove_executions()', DeprecationWarning
-        )
-        job.remove_executions(pipeline)
+        connection = pipeline if pipeline is not None else self.connection
+        execution_ids = [execution.composite_key for execution in job.get_executions()]
+        if execution_ids:
+            connection.zrem(self.key, *execution_ids)
 
 
 class FinishedJobRegistry(BaseRegistry):

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -2,8 +2,9 @@ import calendar
 import logging
 import time
 import traceback
+import warnings
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, Union, cast
 
 from rq.serializers import resolve_serializer
 
@@ -12,7 +13,7 @@ from .exceptions import AbandonedJobError, InvalidJobOperation, NoSuchJobError
 from .job import Job, JobStatus
 from .queue import Queue
 from .timeouts import BaseDeathPenalty, UnixSignalDeathPenalty
-from .utils import as_text, backend_class, current_timestamp
+from .utils import as_text, backend_class, current_timestamp, now, parse_composite_key
 
 if TYPE_CHECKING:
     from redis import Redis
@@ -34,7 +35,6 @@ class BaseRegistry:
     job_class = Job
     death_penalty_class = UnixSignalDeathPenalty
     key_template = 'rq:registry:{0}'
-    cleanup: Callable[..., Any]
 
     def __init__(
         self,
@@ -103,32 +103,33 @@ class BaseRegistry:
             self.cleanup()
         return self.connection.zcard(self.key)
 
-    def add(self, job: 'Job', ttl=0, pipeline: Optional['Pipeline'] = None, xx: bool = False) -> int:
+    def add(self, job: Union[Job, str], ttl: int = 0, pipeline: Optional['Pipeline'] = None, xx: bool = False) -> int:
         """Adds a job to a registry with expiry time of now + ttl, unless it's -1 which is set to +inf
 
         Args:
-            job (Job): The Job to add
+            job (Job): The Job to add, or job_id.
             ttl (int, optional): The time to live. Defaults to 0.
-            pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
+            pipeline (Optional['Pipeline'], optional): The Redis Pipeline. Defaults to None.
             xx (bool, optional): .... Defaults to False.
 
         Returns:
             result (int): The ZADD command result
         """
-        score = ttl if ttl < 0 else current_timestamp() + ttl
+        score: Union[int, str] = ttl if ttl < 0 else current_timestamp() + ttl
         if score == -1:
             score = '+inf'
+        job_id = job.id if isinstance(job, self.job_class) else job
         if pipeline is not None:
-            return cast(int, pipeline.zadd(self.key, {job.id: score}, xx=xx))
+            return cast(int, pipeline.zadd(self.key, {job_id: score}, xx=xx))
 
-        return self.connection.zadd(self.key, {job.id: score}, xx=xx)
+        return self.connection.zadd(self.key, {job_id: score}, xx=xx)
 
-    def remove(self, job: Union['Job', str], pipeline: Optional['Pipeline'] = None, delete_job: bool = False):
+    def remove(self, job: Union[Job, str], pipeline: Optional['Pipeline'] = None, delete_job: bool = False):
         """Removes job from registry and deletes it if `delete_job == True`
 
         Args:
-            job (Job): The Job to remove from the registry
-            pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
+            job (Job|str): The Job to remove from the registry, or job_id
+            pipeline (Pipeline|None): The Redis Pipeline. Defaults to None.
             delete_job (bool, optional): If should delete the job.. Defaults to False.
         """
         connection = pipeline if pipeline is not None else self.connection
@@ -142,18 +143,6 @@ class BaseRegistry:
             job_instance.delete()
         return result
 
-    def remove_executions(self, job: 'Job', pipeline: Optional['Pipeline'] = None):
-        """Removes job executions from registry
-
-        Args:
-            job (Job): The Job to remove from the registry
-            pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
-        """
-        connection = pipeline if pipeline is not None else self.connection
-        execution_ids = [execution.composite_key for execution in job.get_executions()]
-        if execution_ids:
-            return connection.zrem(self.key, *execution_ids)
-
     def get_expired_job_ids(self, timestamp: Optional[float] = None):
         """Returns job ids whose score are less than current timestamp.
 
@@ -163,23 +152,23 @@ class BaseRegistry:
         """
         score = timestamp if timestamp is not None else current_timestamp()
         expired_jobs = self.connection.zrangebyscore(self.key, 0, score)
-        return [as_text(job_id) for job_id in expired_jobs]
+        return [self.parse_job_id(job_id) for job_id in expired_jobs]
 
     def get_job_ids(self, start: int = 0, end: int = -1, desc: bool = False, cleanup: bool = True) -> List[str]:
         """Returns list of all job ids.
 
         Args:
-            start (int, optional): _description_. Defaults to 0.
-            end (int, optional): _description_. Defaults to -1.
-            desc (bool, optional): _description_. Defaults to False.
-            cleanup (bool, optional): _description_. Defaults to True.
+            start (int, optional): start rank. Defaults to 0.
+            end (int, optional): end rank. Defaults to -1.
+            desc (bool, optional): sort in reversed order. Defaults to False.
+            cleanup (bool, optional): whether to perform the cleanup. Defaults to True.
 
         Returns:
-            _type_: _description_
+            List[str]: list of the job ids in the registry
         """
         if cleanup:
             self.cleanup()
-        return [as_text(job_id) for job_id in self.connection.zrange(self.key, start, end, desc=desc)]
+        return [self.parse_job_id(job_id) for job_id in self.connection.zrange(self.key, start, end, desc=desc)]
 
     def get_queue(self):
         """Returns Queue object associated with this registry."""
@@ -228,6 +217,26 @@ class BaseRegistry:
             pipeline.execute()
         return job
 
+    @staticmethod
+    def parse_job_id(entry: str) -> str:
+        """Generic function to retrieve the job id from the stored entry.
+        Some Registries might have a different entry format.
+
+        Args:
+            entry (str): the entry from the registry
+
+        Returns:
+            str: the job_id parsed from the registry.
+        """
+        # base registry only stores job_ids as is.
+        if not isinstance(entry, str):
+            entry = as_text(entry)  # type: ignore
+        return entry
+
+    def cleanup(self, timestamp: Optional[float] = None, exception_handlers: Optional[List] = None):
+        """This method is automatically called by `count()` and `get_job_ids()` methods
+        implemented in BaseRegistry. Base registry doesn't have any special cleanup instructions"""
+
 
 class StartedJobRegistry(BaseRegistry):
     """
@@ -237,6 +246,8 @@ class StartedJobRegistry(BaseRegistry):
 
     Jobs are added to registry right before they are executed and removed
     right after completion (success or failure).
+
+    Each entry is a {job_id}:{execution_id}
     """
 
     key_template = 'rq:wip:{0}'
@@ -255,7 +266,6 @@ class StartedJobRegistry(BaseRegistry):
         job_ids = self.get_expired_job_ids(score)
 
         if job_ids:
-            failed_job_registry = FailedJobRegistry(self.name, self.connection, serializer=self.serializer)
             queue = self.get_queue()
 
             with self.connection.pipeline() as pipeline:
@@ -286,59 +296,138 @@ class StartedJobRegistry(BaseRegistry):
 
                     if retry:
                         job.retry(queue, pipeline)
-
                     else:
-                        exc_string = f'due to {AbandonedJobError.__name__}'
-                        logger.warning(
-                            f'{self.__class__.__name__} cleanup: Moving job {job.id} to {FailedJobRegistry.__name__} '
-                            f'({exc_string})'
+                        exc_string = (
+                            f'Moved to {FailedJobRegistry.__name__}, due to {AbandonedJobError.__name__}, at {now()}'
                         )
-                        job.set_status(JobStatus.FAILED)
-                        job._exc_info = f'Moved to {FailedJobRegistry.__name__}, {exc_string}, at {datetime.now()}'
-                        job.save(pipeline=pipeline, include_meta=False)
-                        job.cleanup(ttl=-1, pipeline=pipeline)
-                        failed_job_registry.add(job, job.failure_ttl)
-                        queue.enqueue_dependents(job)
+                        logger.warning('%s cleanup: %s %s', self.__class__.__name__, job.id, exc_string)
+                        job.set_status(JobStatus.FAILED, pipeline=pipeline)
+                        job._handle_failure(exc_string, pipeline)
+                        # don't refresh the job status, because the job state is still in the pipeline
+                        queue.enqueue_dependents(job, refresh_job_status=False)
 
                 pipeline.zremrangebyscore(self.key, 0, score)
                 pipeline.execute()
 
         return job_ids
 
-    def add_execution(self, execution: 'Execution', pipeline: 'Pipeline', ttl=0, xx: bool = False) -> int:
+    def add_execution(self, execution: 'Execution', pipeline: 'Pipeline', ttl: int = 0, xx: bool = False) -> int:
         """Adds an execution to a registry with expiry time of now + ttl, unless it's -1 which is set to +inf
 
         Args:
-            execution (Execution): The Execution to add
+            execution (Execution): The Execution to add.
+            pipeline (Pipeline): The Redis Pipeline.
             ttl (int, optional): The time to live. Defaults to 0.
-            pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
             xx (bool, optional): .... Defaults to False.
 
         Returns:
             result (int): The ZADD command result
         """
-        score = ttl if ttl < 0 else current_timestamp() + ttl
+        score: Union[int, str] = ttl if ttl < 0 else current_timestamp() + ttl
         if score == -1:
             score = '+inf'
 
         return pipeline.zadd(self.key, {execution.composite_key: score}, xx=xx)  # type: ignore
 
-    def remove_execution(self, execution: 'Execution', job: 'Job', pipeline: 'Pipeline', delete_job: bool = False):
+    def remove_execution(
+        self,
+        execution: 'Union[Execution, str]',
+        job: Optional[Job] = None,
+        pipeline: Optional['Pipeline'] = None,
+        delete_job: bool = False,
+    ):
         """Removes job from registry and deletes it if `delete_job == True`
 
         Args:
-            execution (Execution): The Execution to add
-            job (Job): The Job to remove from the registry
-            pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
+            execution (Union[Execution,str]): The Execution to add
+            job (Optional[Job]): The Job to remove from the registry
+            pipeline (Optional['Pipeline'], optional): The Redis Pipeline. Defaults to None.
             delete_job (bool, optional): If should delete the job.. Defaults to False.
         """
         connection = pipeline if pipeline is not None else self.connection
-        result = connection.zrem(self.key, execution.composite_key)
+        to_delete = execution if isinstance(execution, str) else execution.composite_key
+        result = connection.zrem(self.key, to_delete)
         # if delete_job:
         #     job.delete()
         return result
 
-    # TODO: needs to add a method to cleanup executions
+    def get_job_and_execution_ids(
+        self, start: int = 0, end: int = -1, desc: bool = False, cleanup: bool = True
+    ) -> List[Tuple[str, str]]:
+        """Returns list of all job ids.
+
+        Args:
+            start (int, optional): start rank. Defaults to 0.
+            end (int, optional): end rank. Defaults to -1.
+            desc (bool, optional): sort in reversed order. Defaults to False.
+            cleanup (bool, optional): whether to perform the cleanup. Defaults to True.
+
+        Returns:
+            List[Tuple[str, str]]: list of the job ids in the registry
+        """
+        if cleanup:
+            self.cleanup()
+        return [
+            parse_composite_key(as_text(entry)) for entry in self.connection.zrange(self.key, start, end, desc=desc)
+        ]
+
+    def __contains__(self, item: Any) -> bool:
+        """Method to check if the item is in the registry.
+
+        Args:
+            item (Any): Either a Job (instance of job_class) or a job id.
+
+        Returns:
+            bool: True if the item is in the registry.
+        """
+        job_id = item
+        if isinstance(item, self.job_class):
+            job_id = item.id
+        return cast(str, job_id) in self.get_job_ids(cleanup=False)
+
+    def add(self, job: Union[Job, str], ttl: int = 0, pipeline: Optional['Pipeline'] = None, xx: bool = False) -> int:
+        warnings.warn(
+            'StartedJobRegistry can only contain execution records. Use add_execution method.', DeprecationWarning
+        )
+        # in the future will raise
+        # raise NotImplementedError('')
+        job_id = job.id if isinstance(job, self.job_class) else job
+        # use job_id: so the stored record is always a tuple, when split by ':'
+        return super().add(f'{job_id}:', ttl, pipeline, xx)
+
+    def remove(self, job: Union[Job, str], pipeline: Optional['Pipeline'] = None, delete_job: bool = False):
+        warnings.warn(
+            'StartedJobRegistry can only contain execution records. Use remove_execution method.', DeprecationWarning
+        )
+
+        # in the future will raise
+        # raise NotImplementedError('')
+        job_id = job.id if isinstance(job, self.job_class) else job
+        # if delete job is True, the following would fail. Prohibit deleting the job this way.
+        if delete_job:
+            raise RuntimeError('StartedJobRegistry.remove() method cannot auto-delete the job.')
+        return super().remove(f'{job_id}:', pipeline, delete_job)
+
+    @staticmethod
+    def parse_job_id(entry: str) -> str:
+        # other classes might have a different entry format
+        # base registry stores just the job id
+        if not isinstance(entry, str):
+            entry = as_text(entry)  # type: ignore
+        job_id, _execution_id = parse_composite_key(entry)
+        return job_id
+
+    def remove_executions(self, job: Job, pipeline: Optional['Pipeline'] = None):
+        """Removes job executions from registry
+
+        Args:
+            job (Job): The Job to remove from the registry
+            pipeline (Optional['Pipeline']): The Redis Pipeline. Defaults to None.
+        """
+        connection = pipeline if pipeline is not None else self.connection
+        execution_ids = [execution.composite_key for execution in job.get_executions()]
+        if execution_ids:
+            return connection.zrem(self.key, *execution_ids)
 
 
 class FinishedJobRegistry(BaseRegistry):
@@ -349,7 +438,7 @@ class FinishedJobRegistry(BaseRegistry):
 
     key_template = 'rq:finished:{0}'
 
-    def cleanup(self, timestamp: Optional[float] = None):
+    def cleanup(self, timestamp: Optional[float] = None, exception_handlers: Optional[List] = None):
         """Remove expired jobs from registry.
 
         Removes jobs with an expiry time earlier than timestamp, specified as
@@ -367,7 +456,7 @@ class FailedJobRegistry(BaseRegistry):
 
     key_template = 'rq:failed:{0}'
 
-    def cleanup(self, timestamp: Optional[float] = None):
+    def cleanup(self, timestamp: Optional[float] = None, exception_handlers: Optional[List] = None):
         """Remove expired jobs from registry.
 
         Removes jobs with an expiry time earlier than timestamp, specified as
@@ -414,7 +503,7 @@ class DeferredJobRegistry(BaseRegistry):
 
     key_template = 'rq:deferred:{0}'
 
-    def cleanup(self, timestamp=None):
+    def cleanup(self, timestamp: Optional[float] = None, exception_handlers: Optional[List] = None):
         """Remove expired jobs from registry and add them to FailedJobRegistry.
         Removes jobs with an expiry time earlier than timestamp, specified as
         seconds since the Unix epoch. timestamp defaults to call time if
@@ -424,8 +513,6 @@ class DeferredJobRegistry(BaseRegistry):
         job_ids = self.get_expired_job_ids(score)
 
         if job_ids:
-            failed_job_registry = FailedJobRegistry(self.name, self.connection, serializer=self.serializer)
-
             with self.connection.pipeline() as pipeline:
                 for job_id in job_ids:
                     try:
@@ -434,13 +521,11 @@ class DeferredJobRegistry(BaseRegistry):
                         continue
 
                     job.set_status(JobStatus.FAILED, pipeline=pipeline)
-                    exc_info = 'Expired in DeferredJobRegistry, moved to FailedJobRegistry at %s' % datetime.now()
-                    failed_job_registry.add(job, job.failure_ttl, exc_info, pipeline, True)
+                    exc_info = f'Expired in DeferredJobRegistry, moved to FailedJobRegistry at {now}'
+                    job._handle_failure(exc_string=exc_info, pipeline=pipeline)
 
                 pipeline.zremrangebyscore(self.key, 0, score)
                 pipeline.execute()
-
-        return job_ids
 
     def add(self, job, ttl=None, pipeline=None, xx=False):
         """
@@ -470,7 +555,7 @@ class ScheduledJobRegistry(BaseRegistry):
     def schedule(self, job: 'Job', scheduled_datetime, pipeline: Optional['Pipeline'] = None):
         """
         Adds job to registry, scored by its execution time (in UTC).
-        If datetime has no tzinfo, it will assume localtimezone.
+        If datetime has no tzinfo, it will assume local timezone.
         """
         # If datetime has no timezone, assume server's local timezone
         if not scheduled_datetime.tzinfo:
@@ -480,21 +565,18 @@ class ScheduledJobRegistry(BaseRegistry):
         timestamp = calendar.timegm(scheduled_datetime.utctimetuple())
         return self.connection.zadd(self.key, {job.id: timestamp})
 
-    def cleanup(self):
-        """This method is only here to prevent errors because this method is
-        automatically called by `count()` and `get_job_ids()` methods
-        implemented in BaseRegistry."""
-        pass
-
-    def remove_jobs(self, timestamp: Optional[datetime] = None, pipeline: Optional['Pipeline'] = None):
+    def remove_jobs(self, timestamp: Optional[int] = None, pipeline: Optional['Pipeline'] = None):
         """Remove jobs whose timestamp is in the past from registry.
 
         Args:
-            timestamp (Optional[datetime], optional): The timestamp. Defaults to None.
-            pipeline (Optional[Pipeline], optional): The Redis pipeline. Defaults to None.
+            timestamp (Optional[int], optional): The timestamp. Defaults to None.
+            pipeline (Optional['Pipeline'], optional): The Redis pipeline. Defaults to None.
         """
+        warnings.warn(
+            'ScheduledJobRegistry.remove_jobs() is deprecated and will be removed in the future.', DeprecationWarning
+        )
         connection = pipeline if pipeline is not None else self.connection
-        score: Any = timestamp if timestamp is not None else current_timestamp()
+        score: int = timestamp if timestamp is not None else current_timestamp()
         return connection.zremrangebyscore(self.key, 0, score)
 
     def get_jobs_to_schedule(self, timestamp: Optional[int] = None, chunk_size: int = 1000) -> List[str]:
@@ -540,12 +622,6 @@ class CanceledJobRegistry(BaseRegistry):
 
     def get_expired_job_ids(self, timestamp: Optional[float] = None):
         raise NotImplementedError
-
-    def cleanup(self):
-        """This method is only here to prevent errors because this method is
-        automatically called by `count()` and `get_job_ids()` methods
-        implemented in BaseRegistry."""
-        pass
 
 
 def clean_registries(queue: 'Queue', exception_handlers: Optional[list] = None):

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -657,16 +657,11 @@ class BaseWorker:
 
     def cleanup_execution(self, job: 'Job', pipeline: 'Pipeline'):
         """Cleans up the execution of a job.
-        It will remove the job from the `StartedJobRegistry` and delete the Execution object.
+        It will remove the job execution record from the `StartedJobRegistry` and delete the Execution object.
         """
         self.log.debug('Cleaning up execution of job %s', job.id)
-        started_job_registry = StartedJobRegistry(
-            job.origin, self.connection, job_class=self.job_class, serializer=self.serializer
-        )
         self.set_current_job_id(None, pipeline=pipeline)
-        started_job_registry.remove(job, pipeline=pipeline)
-        if self.execution:
-            started_job_registry.remove_execution(self.execution, job=job, pipeline=pipeline)
+        if self.execution is not None:
             self.execution.delete(job=job, pipeline=pipeline)
             self.execution = None
 

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -118,14 +118,14 @@ class TestRegistry(RQTestCase):
         worker = Worker([queue], connection=self.connection)
         execution = worker.prepare_execution(job=job)
 
-        self.assertIn(execution.composite_key, job.started_job_registry.get_job_ids())
+        self.assertIn(execution.job_id, job.started_job_registry.get_job_ids())
 
         registry = job.execution_registry
         pipeline = self.connection.pipeline()
         registry.delete(job=job, pipeline=pipeline)
         pipeline.execute()
 
-        self.assertNotIn(execution.composite_key, job.started_job_registry.get_job_ids())
+        self.assertNotIn(execution.job_id, job.started_job_registry.get_job_ids())
         self.assertFalse(self.connection.exists(registry.key))
 
     def test_get_execution_ids(self):
@@ -155,7 +155,7 @@ class TestRegistry(RQTestCase):
         # Execution should be registered in started job registry
         execution = job.get_executions()[0]
         self.assertEqual(len(job.get_executions()), 1)
-        self.assertIn(execution.composite_key, job.started_job_registry.get_job_ids())
+        self.assertIn(execution.job_id, job.started_job_registry.get_job_ids())
 
         last_heartbeat = execution.last_heartbeat
         last_heartbeat = now()

--- a/tests/test_intermediate_queue.py
+++ b/tests/test_intermediate_queue.py
@@ -2,10 +2,12 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
 from redis import Redis
 
 from rq import Queue, Worker
 from rq.intermediate_queue import IntermediateQueue
+from rq.job import JobStatus
 from rq.maintenance import clean_intermediate_queue
 from rq.utils import get_version
 from tests import RQTestCase
@@ -14,11 +16,15 @@ from tests.fixtures import say_hello
 
 @unittest.skipIf(get_version(Redis()) < (6, 2, 0), 'Skip if Redis server < 6.2.0')
 class TestIntermediateQueue(RQTestCase):
+    def setUp(self):
+        super().setUp()
+        self.queue = Queue('foo', connection=self.connection)
+        self.intermediate_queue = IntermediateQueue(self.queue.key, connection=self.connection)
+
     def test_set_first_seen(self):
         """Ensure that the first_seen attribute is set correctly."""
-        queue = Queue('foo', connection=self.connection)
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
-        job = queue.enqueue(say_hello)
+        intermediate_queue = self.intermediate_queue
+        job = self.queue.enqueue(say_hello)
 
         # set_first_seen() should only succeed the first time around
         self.assertTrue(intermediate_queue.set_first_seen(job.id))
@@ -29,22 +35,21 @@ class TestIntermediateQueue(RQTestCase):
 
     def test_get_first_seen(self):
         """Ensure that the first_seen attribute is set correctly."""
-        queue = Queue('foo', connection=self.connection)
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
-        job = queue.enqueue(say_hello)
+        intermediate_queue = self.intermediate_queue
+        job = self.queue.enqueue(say_hello)
 
         self.assertIsNone(intermediate_queue.get_first_seen(job.id))
 
         # Check first seen was set correctly
         intermediate_queue.set_first_seen(job.id)
         timestamp = intermediate_queue.get_first_seen(job.id)
-        self.assertTrue(datetime.now(tz=timezone.utc) - timestamp < timedelta(seconds=5))  # type: ignore
+        assert timestamp
+        self.assertTrue(datetime.now(tz=timezone.utc) - timestamp < timedelta(seconds=5))
 
     def test_should_be_cleaned_up(self):
         """Job in the intermediate queue should be cleaned up if it was seen more than 1 minute ago."""
-        queue = Queue('foo', connection=self.connection)
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
-        job = queue.enqueue(say_hello)
+        intermediate_queue = self.intermediate_queue
+        job = self.queue.enqueue(say_hello)
 
         # Returns False if there's no first seen timestamp
         self.assertFalse(intermediate_queue.should_be_cleaned_up(job.id))
@@ -59,23 +64,25 @@ class TestIntermediateQueue(RQTestCase):
 
     def test_get_job_ids(self):
         """Dequeueing job from a single queue moves job to intermediate queue."""
-        queue = Queue('foo', connection=self.connection)
-        job_1 = queue.enqueue(say_hello)
-
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
+        intermediate_queue = self.intermediate_queue
+        job_1 = self.queue.enqueue(say_hello)
 
         # Ensure that the intermediate queue is empty
         self.connection.delete(intermediate_queue.key)
 
         # Job ID is not in intermediate queue
         self.assertEqual(intermediate_queue.get_job_ids(), [])
-        job, queue = Queue.dequeue_any([queue], timeout=None, connection=self.connection)
+        result = Queue.dequeue_any([self.queue], timeout=None, connection=self.connection)
+        assert result
+        _job, queue = result
         # After job is dequeued, the job ID is in the intermediate queue
         self.assertEqual(intermediate_queue.get_job_ids(), [job_1.id])
 
         # Test the blocking version
         job_2 = queue.enqueue(say_hello)
-        job, queue = Queue.dequeue_any([queue], timeout=1, connection=self.connection)
+        result = Queue.dequeue_any([queue], timeout=1, connection=self.connection)
+        assert result
+        _job, queue = result
         # After job is dequeued, the job ID is in the intermediate queue
         self.assertEqual(intermediate_queue.get_job_ids(), [job_1.id, job_2.id])
 
@@ -85,27 +92,25 @@ class TestIntermediateQueue(RQTestCase):
 
     def test_cleanup_intermediate_queue_in_maintenance(self):
         """Ensure jobs stuck in the intermediate queue are cleaned up."""
-        queue = Queue('foo', connection=self.connection)
-        job = queue.enqueue(say_hello)
-
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
+        intermediate_queue = self.intermediate_queue
+        job = self.queue.enqueue(say_hello)
         self.connection.delete(intermediate_queue.key)
 
         # If job execution fails after it's dequeued, job should be in the intermediate queue
         # and it's status is still QUEUED
         with patch.object(Worker, 'execute_job'):
-            worker = Worker(queue, connection=self.connection)
+            worker = Worker(self.queue, connection=self.connection)
             worker.work(burst=True)
 
             # If worker.execute_job() does nothing, job status should be `queued`
             # even though it's not in the queue, but it should be in the intermediate queue
-            self.assertEqual(job.get_status(), 'queued')
-            self.assertFalse(job.id in queue.get_job_ids())
+            self.assertEqual(job.get_status(), JobStatus.QUEUED)
+            self.assertFalse(job.id in self.queue.get_job_ids())
             self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
 
             self.assertIsNone(intermediate_queue.get_first_seen(job.id))
-            clean_intermediate_queue(worker, queue)
-            # After clean_intermediate_queue is called, the job should be marked as seen,
+            intermediate_queue.cleanup(worker, self.queue)
+            # After intermediate_queue.cleanup is called, the job should be marked as seen,
             # but since it's been less than 1 minute, it should not be cleaned up
             self.assertIsNotNone(intermediate_queue.get_first_seen(job.id))
             self.assertFalse(intermediate_queue.should_be_cleaned_up(job.id))
@@ -116,42 +121,41 @@ class TestIntermediateQueue(RQTestCase):
             two_minutes_ago = datetime.now(tz=timezone.utc) - timedelta(minutes=2)
             self.connection.set(first_seen_key, two_minutes_ago.timestamp(), ex=10)
 
-            clean_intermediate_queue(worker, queue)
+            intermediate_queue.cleanup(worker, self.queue)
             self.assertEqual(intermediate_queue.get_job_ids(), [])
             self.assertEqual(job.get_status(), 'failed')
 
-            job = queue.enqueue(say_hello)
+            job = self.queue.enqueue(say_hello)
             worker.work(burst=True)
             self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
 
             # If job is gone, it should be immediately removed from the intermediate queue
             job.delete()
-            clean_intermediate_queue(worker, queue)
+            intermediate_queue.cleanup(worker, self.queue)
             self.assertEqual(intermediate_queue.get_job_ids(), [])
 
     def test_cleanup_intermediate_queue(self):
         """Ensure jobs stuck in the intermediate queue are cleaned up."""
-        queue = Queue('foo', connection=self.connection)
-        job = queue.enqueue(say_hello)
+        intermediate_queue = self.intermediate_queue
+        job = self.queue.enqueue(say_hello)
 
-        intermediate_queue = IntermediateQueue(queue.key, connection=self.connection)
         self.connection.delete(intermediate_queue.key)
 
         # If job execution fails after it's dequeued, job should be in the intermediate queue
         # and it's status is still QUEUED
         with patch.object(Worker, 'execute_job'):
-            worker = Worker(queue, connection=self.connection)
+            worker = Worker(self.queue, connection=self.connection)
             worker.work(burst=True)
 
             # If worker.execute_job() does nothing, job status should be `queued`
             # even though it's not in the queue, but it should be in the intermediate queue
-            self.assertEqual(job.get_status(), 'queued')
-            self.assertFalse(job.id in queue.get_job_ids())
+            self.assertEqual(job.get_status(), JobStatus.QUEUED)
+            self.assertFalse(job.id in self.queue.get_job_ids())
             self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
 
             self.assertIsNone(intermediate_queue.get_first_seen(job.id))
-            intermediate_queue.cleanup(worker, queue)
-            # After clean_intermediate_queue is called, the job should be marked as seen,
+            intermediate_queue.cleanup(worker, self.queue)
+            # After intermediate_queue.cleanup is called, the job should be marked as seen,
             # but since it's been less than 1 minute, it should not be cleaned up
             self.assertIsNotNone(intermediate_queue.get_first_seen(job.id))
             self.assertFalse(intermediate_queue.should_be_cleaned_up(job.id))
@@ -162,15 +166,53 @@ class TestIntermediateQueue(RQTestCase):
             two_minutes_ago = datetime.now(tz=timezone.utc) - timedelta(minutes=2)
             self.connection.set(first_seen_key, two_minutes_ago.timestamp(), ex=10)
 
-            intermediate_queue.cleanup(worker, queue)
+            intermediate_queue.cleanup(worker, self.queue)
             self.assertEqual(intermediate_queue.get_job_ids(), [])
             self.assertEqual(job.get_status(), 'failed')
 
-            job = queue.enqueue(say_hello)
+            job = self.queue.enqueue(say_hello)
             worker.work(burst=True)
             self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
 
             # If job is gone, it should be immediately removed from the intermediate queue
             job.delete()
-            intermediate_queue.cleanup(worker, queue)
+            intermediate_queue.cleanup(worker, self.queue)
             self.assertEqual(intermediate_queue.get_job_ids(), [])
+
+    def test_no_cleanup_while_in_started_queue(self):
+        """Ensure jobs stuck in the intermediate queue are cleaned up."""
+        intermediate_queue = self.intermediate_queue
+        job = self.queue.enqueue(say_hello)
+
+        self.connection.delete(intermediate_queue.key)
+
+        # If job execution fails after it's dequeued, job should be in the intermediate queue
+        # and it's status is still QUEUED
+        with patch.object(Worker, 'perform_job'):
+            worker = Worker(self.queue, connection=self.connection)
+            worker.work(burst=True)
+
+            # If worker.perform_job() does nothing, job status should be `queued`
+            # even though it's not in the queue, but it should be in the intermediate queue
+            # and the job should be in the started queue (since we only mocked perform_job)
+            self.assertEqual(job.get_status(), JobStatus.QUEUED)
+            self.assertFalse(job.id in self.queue.get_job_ids())
+            self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
+
+            self.assertTrue(job.id in job.started_job_registry.get_job_ids())
+            self.assertTrue(
+                (worker.execution.job_id, worker.execution.id) in job.started_job_registry.get_job_and_execution_ids()
+            )
+
+            # this should NOT remove the job from the queue, nor set the first see key
+            # because it's still in the "execution state".
+            # perform_job was mocked and never called success or failure.
+            intermediate_queue.cleanup(worker, self.queue)
+            self.assertIsNone(intermediate_queue.get_first_seen(job.id))
+
+            self.assertTrue(job.get_status() == JobStatus.QUEUED)
+
+    def test_clean_intermediate_queue_deprecation(self):
+        with pytest.deprecated_call():
+            worker = Worker(self.queue, connection=self.connection)
+            clean_intermediate_queue(worker, self.queue)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta, timezone
 from pickle import dumps, loads
 from uuid import uuid4
 
-import pytest
 from redis import Redis, WatchError
 
 from rq.defaults import CALLBACK_TIMEOUT
@@ -183,8 +182,7 @@ class TestJob(RQTestCase):
         self.assertIsNone(job.instance)
         self.assertEqual(job.args, (3, 4))
         self.assertEqual(job.kwargs, dict(z=2))
-        self.assertEqual(job.created_at, datetime(2012, 2, 7, 22, 13, 24, 123456,
-                         tzinfo=timezone.utc))
+        self.assertEqual(job.created_at, datetime(2012, 2, 7, 22, 13, 24, 123456, tzinfo=timezone.utc))
 
         # Job.fetch also works with execution IDs
         queue = Queue(connection=self.connection)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -7,10 +7,12 @@ from datetime import datetime, timedelta, timezone
 from pickle import dumps, loads
 from uuid import uuid4
 
+import pytest
 from redis import Redis, WatchError
 
 from rq.defaults import CALLBACK_TIMEOUT
 from rq.exceptions import DeserializationError, InvalidJobOperation, NoSuchJobError
+from rq.executions import Execution
 from rq.job import Callback, Dependency, Job, JobStatus, cancel_job, get_current_job
 from rq.queue import Queue
 from rq.registry import (
@@ -49,7 +51,7 @@ class TestJob(RQTestCase):
         # Jobs have a random UUID and a creation date
         self.assertIsNotNone(job.id)
         self.assertIsNotNone(job.created_at)
-        self.assertEqual(str(job), '<Job %s: test job>' % job.id)
+        self.assertEqual(str(job), f'<Job {job.id}: test job>')
 
         # ...and nothing else
         self.assertEqual(job.origin, '')
@@ -57,7 +59,7 @@ class TestJob(RQTestCase):
         self.assertIsNone(job.started_at)
         self.assertIsNone(job.ended_at)
         self.assertIsNone(job.result)
-        self.assertIsNone(job.exc_info)
+        self.assertIsNone(job._exc_info)
 
         with self.assertRaises(DeserializationError):
             job.func
@@ -315,7 +317,7 @@ class TestJob(RQTestCase):
     def test_store_then_fetch(self):
         """Store, then fetch."""
         job = Job.create(
-            func=fixtures.some_calculation, timeout='1h', args=(3, 4), kwargs=dict(z=2), connection=self.connection
+            func=fixtures.some_calculation, timeout=3600, args=(3, 4), kwargs=dict(z=2), connection=self.connection
         )
         job.save()
 
@@ -749,7 +751,10 @@ class TestJob(RQTestCase):
         job.save()
 
         registry = StartedJobRegistry(connection=self.connection, serializer=JSONSerializer)
-        registry.add(job, 500)
+        with self.connection.pipeline() as pipe:
+            # this will also add the execution to the registry
+            Execution.create(job, ttl=500, pipeline=pipe)
+            pipe.execute()
 
         job.delete()
         self.assertFalse(job in registry)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,9 @@
+import re
 from datetime import timedelta
 from unittest import mock
 from unittest.mock import ANY
+
+import pytest
 
 from rq.defaults import DEFAULT_FAILURE_TTL
 from rq.exceptions import AbandonedJobError, InvalidJobOperation
@@ -554,6 +557,22 @@ class TestStartedJobRegistry(RQTestCase):
         self.assertTrue(job in self.registry)
         self.assertTrue(job.id in self.registry)
 
+    def test_infinite_score(self):
+        """Test the StartedJobRegistry __contains__ method. It is slightly different
+        because the entries in the registry are {job_id}:{execution_id} format."""
+        job = self.q.enqueue(say_hello)
+
+        self.assertFalse(job in self.registry)
+        self.assertFalse(job.id in self.registry)
+
+        with self.connection.pipeline() as pipe:
+            execution = Execution(id='execution', job_id=job.id, connection=self.connection)
+            self.registry.add_execution(execution=execution, pipeline=pipe, ttl=-1)
+            pipe.execute()
+        self.assertTrue(job in self.registry)
+        self.assertTrue(job.id in self.registry)
+        self.assertTrue(self.connection.zscore(self.registry.key, execution.composite_key), '+inf')
+
     def test_remove_executions(self):
         """Ensure all executions for a job are removed from registry."""
         worker = Worker([self.q], connection=self.connection)
@@ -697,3 +716,28 @@ class TestStartedJobRegistry(RQTestCase):
 
         self.assertFalse(job_not_to_be_executed.is_finished)
         self.assertNotIn(job_not_to_be_executed, finished_job_registry)
+
+    def test_warnings_on_add_remove_and_exception(self):
+        """Test backwards compatibility of the .add and .remove methods for
+        the StartedJobRegistry."""
+        with pytest.deprecated_call():
+            self.registry.add('job_id')
+
+        self.assertIn('job_id', self.registry.get_job_ids(cleanup=False))
+        with pytest.deprecated_call():
+            self.registry.remove('job_id')
+        self.assertNotIn('job_id', self.registry.get_job_ids(cleanup=False))
+
+        job = self.q.enqueue(say_hello)
+        with pytest.deprecated_call():
+            self.registry.add(job)
+        self.assertIn(job.id, self.registry.get_job_ids(cleanup=False))
+
+        with pytest.deprecated_call():
+            self.registry.remove(job)
+        self.assertNotIn(job.id, self.registry.get_job_ids(cleanup=False))
+
+        with pytest.raises(
+            RuntimeError, match=re.escape('StartedJobRegistry.remove() method cannot auto-delete the job.')
+        ) as _raise_check, pytest.deprecated_call() as _deprecation_check:
+            self.registry.remove('job_id', delete_job=True)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -886,8 +886,8 @@ class TestWorker(RQTestCase):
 
         # Updates working queue, job execution should be there
         registry = StartedJobRegistry(connection=self.connection)
-        # self.assertTrue(job.id in registry.get_job_ids())
-        self.assertTrue(worker.execution.composite_key in registry.get_job_ids())
+        self.assertTrue(job.id in registry.get_job_ids())
+        self.assertTrue((worker.execution.job_id, worker.execution.id) in registry.get_job_and_execution_ids())
 
         # Updates worker's current job
         self.assertEqual(worker.get_current_job_id(), job.id)


### PR DESCRIPTION
* Added `parse_job_id` method. BaseRegistry would return the id as_text, but StartedJobRegistry would parse the job_id from `job_id:execution` format.
* StartedJobRegistry.cleanup() now properly saves the job result into job result (using the _handle_failure)
* Added an option for the `Queue.enqueue_dependents` to prevent refreshing the job status, if the job status has been updated in the pipeline)
* Added deprecation notices to avoid adding/removing a job to the StartedJobRegistry (only Executions are allowed)
* Added a test where the job that is still executing would not be cleaned up, while in the started queue (test_no_cleanup_while_in_started_queue)
* Updated tests to exercise the StartedJobRegistry separately from the BaseRegistry.
* Added tests for a few warnings