### PR TITLE
Fix duplicate multi() on the same pipeline

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -660,7 +660,9 @@ class Queue:
                         # if pipeline comes from caller, re-raise to them
                         raise
         elif pipeline is not None:
-            pipeline.multi()  # Ensure pipeline in multi mode before returning to caller
+            # Ensure pipeline in multi mode before returning to caller (if not set before)
+            if not pipeline.explicit_transaction:
+                pipeline.multi()
         return job
 
     def enqueue_call(


### PR DESCRIPTION
This PR enhances the handling of Redis pipelines within the `setup_dependencies` method in `rq/queue.py`. 

Specifically, it addresses the scenario where jobs without dependencies are enqueued using a shared Redis pipeline across multiple queues. Previously, the pipeline's multi() method was called unconditionally, which prevented enqueuing multiple jobs across different queues using the same pipeline.

This PR will resolve #2211. 