### PR TITLE
fix: Add Timeout in PubSub thread

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1020,7 +1020,7 @@ class BaseWorker:
         self.pubsub = self.connection.pubsub()
         self.pubsub.subscribe(**{self.pubsub_channel_name: self.handle_payload})
         self.pubsub_thread = self.pubsub.run_in_thread(
-            sleep_time=None, daemon=True, exception_handler=self._pubsub_exception_handler
+            sleep_time=60, daemon=True, exception_handler=self._pubsub_exception_handler
         )
 
     def get_heartbeat_ttl(self, job: 'Job') -> int:


### PR DESCRIPTION
Fixes #2220


Socket timeout could be set by users or overridden by some library, in this case background pubsub thread exits and doesn't recover. 

Caused by my previous change: https://github.com/rq/rq/commit/3829df7cfef59ba0a49d7f0acf2b9236358b770d 

This change was required to avoid rapid polling and can be fixed by just increasing timeout to 60s instead of previous 0.2 seconds. 