### PR TITLE
Remove job from dependency's `dependent_key` on cancel

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -1196,6 +1196,15 @@ class Job:
                     if pipeline is None:
                         pipe.watch(self.dependents_key)
                     q.enqueue_dependents(self, pipeline=pipeline, exclude_job_id=self.id)
+
+                # Go through all dependencies and remove the current job from each dependency's dependents_key
+                for dependency in self.fetch_dependencies(pipeline=pipe):
+                    if not dependency:
+                        continue
+
+                    dependents_key = dependency.dependents_key
+                    pipe.srem(dependents_key, self.id)
+
                 self._remove_from_registries(pipeline=pipe, remove_from_queue=True)
 
                 registry = CanceledJobRegistry(


### PR DESCRIPTION
When a job is canceled, it should be removed from its dependencies `dependents_key`s. Otherwise, the code responsible for enqueuing parent job dependencies may fail.

This issue can occur in the following case:
There are two jobs: `X1` and `X2`, where `X2` depends on `X1`. If `X2` is recreated (canceled, then deleted, and a new job with the same ID is created), `X1` may fail when trying to enqueue its dependencies. This happens because `X2` no longer has any dependencies but still exists in `X1` `dependents_key`
```
Traceback (most recent call last):
  ...
  File "/opt/venv/lib/python3.10/site-packages/rq/job.py", line 1577, in dependencies_are_met
    connection.watch(*[self.key_for(dependency_id) for dependency_id in self._dependency_ids])
  File "/opt/venv/lib/python3.10/site-packages/redis/client.py", line 2138, in watch
    return self.execute_command("WATCH", *names)
  ...
redis.exceptions.ResponseError: wrong number of arguments for 'watch' command
```