### PR TITLE
Improve the typing of serializers

### DIFF
--- a/rq/cli/workers.py
+++ b/rq/cli/workers.py
@@ -3,7 +3,7 @@ import logging.config
 import os
 import sys
 import warnings
-from typing import TYPE_CHECKING, List, Type, cast
+from typing import TYPE_CHECKING, List, cast
 
 import click
 from redis.exceptions import ConnectionError
@@ -210,9 +210,9 @@ def worker_pool(
     setup_loghandlers_from_args(verbose, quiet, date_format, log_format)
 
     if serializer:
-        serializer_class = cast(Type['Serializer'], import_attribute(serializer))
+        serializer = cast('Serializer', import_attribute(serializer))
     else:
-        serializer_class = DefaultSerializer
+        serializer = DefaultSerializer
 
     if worker_class:
         worker_class = import_attribute(worker_class)
@@ -232,7 +232,7 @@ def worker_pool(
         queue_names,
         connection=cli_config.connection,
         num_workers=num_workers,
-        serializer=serializer_class,
+        serializer=serializer,
         worker_class=worker_class,
         job_class=job_class,
     )

--- a/rq/job.py
+++ b/rq/job.py
@@ -430,7 +430,7 @@ class Job:
         """
         if refresh:
             meta = self.connection.hget(self.key, 'meta')
-            self.meta = self.serializer.loads(meta) if meta else {}  # type: ignore[assignment]
+            self.meta = self.serializer.loads(meta) if meta else {}
 
         return self.meta
 
@@ -1002,7 +1002,7 @@ class Job:
         self.enqueue_at_front = bool(int(obj['enqueue_at_front'])) if 'enqueue_at_front' in obj else None
         self.ttl = int(obj['ttl']) if obj.get('ttl') else None
         try:
-            self.meta = self.serializer.loads(obj['meta']) if obj.get('meta') else {}  # type: ignore[assignment]
+            self.meta = self.serializer.loads(obj['meta']) if obj.get('meta') else {}
         except Exception:  # depends on the serializer
             self.meta = {'unserialized': obj.get('meta', {})}
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -40,7 +40,7 @@ from .intermediate_queue import IntermediateQueue
 from .job import Callback, Job, JobStatus
 from .logutils import blue, green
 from .repeat import Repeat
-from .serializers import resolve_serializer
+from .serializers import Serializer, resolve_serializer
 from .types import FunctionReferenceType, JobDependencyType
 from .utils import as_text, backend_class, compact, get_version, import_attribute, now, parse_timeout
 
@@ -125,7 +125,7 @@ class Queue:
         queue_key: str,
         connection: 'Redis',
         job_class: Optional[Type['Job']] = None,
-        serializer: Any = None,
+        serializer: Optional[Union[Serializer, str]] = None,
         death_penalty_class: Optional[Type[BaseDeathPenalty]] = None,
     ) -> 'Queue':
         """Returns a Queue instance, based on the naming conventions for naming
@@ -136,7 +136,7 @@ class Queue:
             queue_key (str): The queue key
             connection (Redis): Redis connection. Defaults to None.
             job_class (Optional[Job], optional): Job class. Defaults to None.
-            serializer (Any, optional): Serializer. Defaults to None.
+            serializer (Optional[Union[Serializer, str]], optional): Serializer. Defaults to None.
             death_penalty_class (Optional[BaseDeathPenalty], optional): Death penalty class. Defaults to None.
 
         Raises:
@@ -164,7 +164,7 @@ class Queue:
         default_timeout: Optional[int] = None,
         is_async: bool = True,
         job_class: Optional[Union[str, Type['Job']]] = None,
-        serializer: Any = None,
+        serializer: Optional[Union[Serializer, str]] = None,
         death_penalty_class: Optional[Type[BaseDeathPenalty]] = UnixSignalDeathPenalty,
         **kwargs,
     ):
@@ -178,7 +178,7 @@ class Queue:
                 If `is_async` is false, jobs will run on the same process from where it was called. Defaults to True.
             job_class (Union[str, 'Job', optional): Job class or a string referencing the Job class path.
                 Defaults to None.
-            serializer (Any, optional): Serializer. Defaults to None.
+            serializer (Optional[Union[Serializer, str]], optional): Serializer. Defaults to None.
             death_penalty_class (Type[BaseDeathPenalty, optional): Job class or a string referencing the Job class path.
                 Defaults to UnixSignalDeathPenalty.
         """
@@ -1388,7 +1388,7 @@ class Queue:
         timeout: Optional[int],
         connection: 'Redis',
         job_class: Optional[Type['Job']] = None,
-        serializer: Any = None,
+        serializer: Optional[Union[Serializer, str]] = None,
         death_penalty_class: Optional[Type[BaseDeathPenalty]] = None,
     ) -> Optional[Tuple['Job', 'Queue']]:
         """Class method returning the job_class instance at the front of the given
@@ -1406,7 +1406,7 @@ class Queue:
             timeout (Optional[int]): Timeout for the LPOP
             connection (Optional[Redis], optional): Redis Connection. Defaults to None.
             job_class (Optional[Type[Job]], optional): The job class. Defaults to None.
-            serializer (Any, optional): Serializer to use. Defaults to None.
+            serializer (Optional[Union[Serializer, str]], optional): Serializer to use. Defaults to None.
             death_penalty_class (Optional[Type[BaseDeathPenalty]], optional): The death penalty class. Defaults to None.
 
         Raises:

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from redis.client import Pipeline
 
     from rq.executions import Execution
+    from rq.serializers import Serializer
 
 
 logger = logging.getLogger('rq.registry')
@@ -42,7 +43,7 @@ class BaseRegistry:
         connection: Optional['Redis'] = None,
         job_class: Optional[Type['Job']] = None,
         queue: Optional['Queue'] = None,
-        serializer: Any = None,
+        serializer: Optional[Union['Serializer', str]] = None,
         death_penalty_class: Optional[Type[BaseDeathPenalty]] = None,
     ):
         if queue:

--- a/rq/serializers.py
+++ b/rq/serializers.py
@@ -1,21 +1,22 @@
 import json
 import pickle
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Optional, Type, Union
+from typing import Any, Callable, ClassVar, Optional, Protocol, Union, runtime_checkable
 
 from .utils import import_attribute
 
-if TYPE_CHECKING:
-    from typing_extensions import Protocol
 
-    class Serializer(Protocol):
-        dumps: Callable[..., bytes]
-        loads: Callable[..., object]
+@runtime_checkable
+class Serializer(Protocol):
+    def dumps(self, obj: Any, /) -> bytes:
+        ...  # pragma: no cover
 
+    def loads(self, data: bytes, /) -> Any:
+        ...  # pragma: no cover
 
 class DefaultSerializer:
-    dumps: Callable[..., bytes] = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)
-    loads: Callable[..., object] = pickle.loads
+    dumps: ClassVar[Callable[[Any], bytes]] = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)
+    loads: ClassVar[Callable[[bytes], Any]] = pickle.loads
 
 
 class JSONSerializer:
@@ -28,7 +29,7 @@ class JSONSerializer:
         return json.loads(s.decode('utf-8'), *args, **kwargs)
 
 
-def resolve_serializer(serializer: Optional[Union[Type['Serializer'], str]] = None) -> Type['Serializer']:
+def resolve_serializer(serializer: Optional[Union[Serializer, str]] = None) -> Serializer:
     """This function checks the user defined serializer for ('dumps', 'loads') methods
     It returns a default pickle serializer if not found else it returns a MySerializer
     The returned serializer objects implement ('dumps', 'loads') methods
@@ -47,10 +48,8 @@ def resolve_serializer(serializer: Optional[Union[Type['Serializer'], str]] = No
         serializer = import_attribute(serializer)  # type: ignore[assignment]
 
     assert not isinstance(serializer, str)
-    default_serializer_methods = ('dumps', 'loads')
 
-    for instance_method in default_serializer_methods:
-        if not hasattr(serializer, instance_method):
-            raise NotImplementedError('Serializer should have (dumps, loads) methods.')
+    if not isinstance(serializer, Serializer):
+        raise NotImplementedError('Serializer should have (dumps, loads) methods.')
 
     return serializer

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -52,7 +52,7 @@ from .logutils import blue, green, setup_loghandlers, yellow
 from .queue import Queue
 from .registry import StartedJobRegistry, clean_registries
 from .scheduler import RQScheduler
-from .serializers import resolve_serializer
+from .serializers import Serializer, resolve_serializer
 from .suspension import is_suspended
 from .timeouts import HorseMonitorTimeoutException, JobTimeoutException, UnixSignalDeathPenalty
 from .utils import (
@@ -151,7 +151,7 @@ class BaseWorker:
         job_monitoring_interval=DEFAULT_JOB_MONITORING_INTERVAL,
         disable_default_exception_handler: bool = False,
         prepare_for_work: bool = True,
-        serializer=None,
+        serializer: Optional[Union[Serializer, str]] = None,
         work_horse_killed_handler: Optional[Callable[[Job, int, int, 'struct_rusage'], None]] = None,
     ):  # noqa
         self.default_result_ttl = default_result_ttl
@@ -261,7 +261,7 @@ class BaseWorker:
         connection: 'Redis',
         job_class: Optional[Type['Job']] = None,
         queue_class: Optional[Type['Queue']] = None,
-        serializer=None,
+        serializer: Optional[Union[Serializer, str]] = None,
     ) -> Optional['BaseWorker']:
         """Returns a Worker instance, based on the naming conventions for
         naming the internal Redis keys.  Can be used to reverse-lookup Workers
@@ -272,7 +272,7 @@ class BaseWorker:
             connection (Optional[Redis], optional): Redis connection. Defaults to None.
             job_class (Optional[Type[Job]], optional): The job class if custom class is being used. Defaults to None.
             queue_class (Optional[Type[Queue]]): The queue class if a custom class is being used. Defaults to None.
-            serializer (Any, optional): The serializer to use. Defaults to None.
+            serializer (Optional[Union[Serializer, str]], optional): The serializer to use. Defaults to None.
 
         Raises:
             ValueError: If the key doesn't start with `rq:worker:`, the default worker namespace prefix.

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -45,7 +45,7 @@ class WorkerPool:
         connection: Redis,
         num_workers: int = 1,
         worker_class: Type[BaseWorker] = Worker,
-        serializer: Type['Serializer'] = DefaultSerializer,
+        serializer: 'Serializer' = DefaultSerializer,
         job_class: Type[Job] = Job,
         queue_class: Type[Queue] = Queue,
         *args,
@@ -63,7 +63,7 @@ class WorkerPool:
         self._sleep: int = 0
         self.status: self.Status = self.Status.IDLE  # type: ignore
         self.worker_class: Type[BaseWorker] = worker_class
-        self.serializer: Type['Serializer'] = serializer
+        self.serializer: 'Serializer' = serializer
         self.job_class: Type[Job] = job_class
         self.queue_class: Type[Queue] = queue_class
 
@@ -251,7 +251,7 @@ def run_worker(
     connection_pool_class,
     connection_pool_kwargs: dict,
     worker_class: Type[BaseWorker] = Worker,
-    serializer: Type['Serializer'] = DefaultSerializer,
+    serializer: 'Serializer' = DefaultSerializer,
     job_class: Type[Job] = Job,
     queue_class: Type[Queue] = Queue,
     burst: bool = True,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -87,6 +87,7 @@ class RQTestCase(unittest.TestCase):
     def tearDown(self):
         # Flush afterwards
         self.connection.flushdb()
+        self.connection.close()
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -62,8 +62,8 @@ class TestCommands(RQTestCase):
 
         with mock.patch('redis.client.PubSub.get_message', new_callable=raise_exc_mock):
             worker.subscribe()
+            worker.pubsub_thread.join()
 
-        worker.pubsub_thread.join()
         assert not worker.pubsub_thread.is_alive()
 
     def test_kill_horse_command(self):


### PR DESCRIPTION
There are two main changes here.

1. Even though several serializer variables are annotated as `Type[Serializer]`, as far as I can see, a serializer is not actually required to be a type. Change such annotations to just `Serializer` and update the `Serializer` protocol to a conventional protocol with methods.

2. Since RQ now requires Python 3.8, it can make use of `runtime_checkable`. Do that to simplify the serializer interface check.

In addition, add some more type annotations to serializer-type variables.