### PR TITLE
Replace assertFalse and assertTrue with more specific asserts

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -295,7 +295,7 @@ class TestRQCli(CLITestCase):
         pid = self.tmpdir.join('rq.pid')
         runner = CliRunner()
         result = runner.invoke(main, ['worker', '-u', self.redis_url, '-b', '--pid', str(pid)])
-        self.assertTrue(len(pid.read()) > 0)
+        self.assertGreater(len(pid.read()), 0)
         self.assert_normal_execution(result)
 
     def test_worker_with_scheduler(self):
@@ -351,19 +351,19 @@ class TestRQCli(CLITestCase):
         job = q.enqueue(div_by_zero)
         runner.invoke(main, ['worker', '-u', self.redis_url, '-b'])
         registry = FailedJobRegistry(queue=q)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         # If disable-default-exception-handler is given, job is not moved to FailedJobRegistry
         job = q.enqueue(div_by_zero)
         runner.invoke(main, ['worker', '-u', self.redis_url, '-b', '--disable-default-exception-handler'])
         registry = FailedJobRegistry(queue=q)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
 
         # Both default and custom exception handler is run
         job = q.enqueue(div_by_zero)
         runner.invoke(main, ['worker', '-u', self.redis_url, '-b', '--exception-handler', 'tests.fixtures.add_meta'])
         registry = FailedJobRegistry(queue=q)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
         job.refresh()
         self.assertEqual(job.meta, {'foo': 1})
 
@@ -382,7 +382,7 @@ class TestRQCli(CLITestCase):
             ],
         )
         registry = FailedJobRegistry(queue=q)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
         job.refresh()
         self.assertEqual(job.meta, {'foo': 1})
 
@@ -518,8 +518,8 @@ class TestRQCli(CLITestCase):
         worker = Worker(queue, connection=self.connection)
         scheduler = RQScheduler(queue, self.connection)
 
-        self.assertTrue(len(queue) == 0)
-        self.assertTrue(len(registry) == 0)
+        self.assertEqual(len(queue), 0)
+        self.assertEqual(len(registry), 0)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -530,8 +530,8 @@ class TestRQCli(CLITestCase):
         scheduler.acquire_locks()
         scheduler.enqueue_scheduled_jobs()
 
-        self.assertTrue(len(queue) == 0)
-        self.assertTrue(len(registry) == 1)
+        self.assertEqual(len(queue), 0)
+        self.assertEqual(len(registry), 1)
 
         self.assertFalse(worker.work(True))
 
@@ -539,8 +539,8 @@ class TestRQCli(CLITestCase):
 
         scheduler.enqueue_scheduled_jobs()
 
-        self.assertTrue(len(queue) == 1)
-        self.assertTrue(len(registry) == 0)
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(len(registry), 0)
 
         self.assertTrue(worker.work(True))
 
@@ -555,8 +555,8 @@ class TestRQCli(CLITestCase):
         worker = Worker(queue, connection=self.connection)
         scheduler = RQScheduler(queue, self.connection)
 
-        self.assertTrue(len(queue) == 0)
-        self.assertTrue(len(registry) == 0)
+        self.assertEqual(len(queue), 0)
+        self.assertEqual(len(registry), 0)
 
         runner = CliRunner()
         result = runner.invoke(
@@ -566,31 +566,31 @@ class TestRQCli(CLITestCase):
 
         scheduler.acquire_locks()
 
-        self.assertTrue(len(queue) == 0)
-        self.assertTrue(len(registry) == 1)
+        self.assertEqual(len(queue), 0)
+        self.assertEqual(len(registry), 1)
 
         scheduler.enqueue_scheduled_jobs()
 
-        self.assertTrue(len(queue) == 1)
-        self.assertTrue(len(registry) == 0)
+        self.assertEqual(len(queue), 1)
+        self.assertEqual(len(registry), 0)
 
         self.assertTrue(worker.work(True))
 
-        self.assertTrue(len(queue) == 0)
-        self.assertTrue(len(registry) == 0)
+        self.assertEqual(len(queue), 0)
+        self.assertEqual(len(registry), 0)
 
         result = runner.invoke(
             main, ['enqueue', '-u', self.redis_url, 'tests.fixtures.say_hello', '--schedule-at', '2100-01-01T00:00:00']
         )
         self.assert_normal_execution(result)
 
-        self.assertTrue(len(queue) == 0)
-        self.assertTrue(len(registry) == 1)
+        self.assertEqual(len(queue), 0)
+        self.assertEqual(len(registry), 1)
 
         scheduler.enqueue_scheduled_jobs()
 
-        self.assertTrue(len(queue) == 0)
-        self.assertTrue(len(registry) == 1)
+        self.assertEqual(len(queue), 0)
+        self.assertEqual(len(registry), 1)
 
         self.assertFalse(worker.work(True))
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -80,7 +80,7 @@ class TestCommands(RQTestCase):
         worker.work(burst=True)
         p.join(1)
         job.refresh()
-        self.assertTrue(job.id in queue.failed_job_registry)
+        self.assertIn(job.id, queue.failed_job_registry)
 
         p = Process(target=start_work, args=('foo', worker.name, connection.connection_pool.connection_kwargs.copy()))
         p.start()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -27,7 +27,7 @@ class TestDecorator(RQTestCase):
         """
         self.assertTrue(hasattr(self.decorated_job, 'delay'))
         job = self.decorated_job.enqueue(1, 2)
-        self.assertTrue(isinstance(job, Job))
+        self.assertIsInstance(job, Job)
 
     def test_decorator_accepts_queue_name_as_argument(self):
         """Ensure that passing in queue name to the decorator puts the job in

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -37,7 +37,7 @@ class TestRegistry(RQTestCase):
         created_at = execution.created_at
         composite_key = execution.composite_key
         self.assertTrue(execution.composite_key.startswith(job.id))  # Composite key is prefixed by job ID
-        self.assertTrue(self.connection.ttl(execution.key) <= 100)
+        self.assertLessEqual(self.connection.ttl(execution.key), 100)
 
         execution = Execution.fetch(id=execution.id, job_id=job.id, connection=self.connection)
         self.assertEqual(execution.created_at.timestamp(), created_at.timestamp())
@@ -71,8 +71,8 @@ class TestRegistry(RQTestCase):
         job = self.queue.enqueue(say_hello, timeout=-1)
         worker = Worker([self.queue], connection=self.connection)
         execution = worker.prepare_execution(job=job)
-        self.assertTrue(self.connection.ttl(job.execution_registry.key) >= worker.get_heartbeat_ttl(job))
-        self.assertTrue(self.connection.ttl(execution.key) >= worker.get_heartbeat_ttl(job))
+        self.assertGreaterEqual(self.connection.ttl(job.execution_registry.key), worker.get_heartbeat_ttl(job))
+        self.assertGreaterEqual(self.connection.ttl(execution.key), worker.get_heartbeat_ttl(job))
 
     def test_heartbeat(self):
         """Test heartbeat should refresh execution as well as registry TTL"""

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -708,7 +708,7 @@ class TestJob(RQTestCase):
         registry.add(job, 500)
 
         job.delete()
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
 
         job = Job.create(
             func=fixtures.say_hello,
@@ -722,7 +722,7 @@ class TestJob(RQTestCase):
         registry.add(job, 500)
 
         job.delete()
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
 
         job = Job.create(
             func=fixtures.say_hello,
@@ -737,7 +737,7 @@ class TestJob(RQTestCase):
         registry.add(job, 500)
 
         job.delete()
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
 
         job = Job.create(
             func=fixtures.say_hello,
@@ -755,7 +755,7 @@ class TestJob(RQTestCase):
             pipe.execute()
 
         job.delete()
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
 
         job = Job.create(
             func=fixtures.say_hello,
@@ -770,7 +770,7 @@ class TestJob(RQTestCase):
         registry.add(job, 500)
 
         job.delete()
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
 
         job = Job.create(
             func=fixtures.say_hello,
@@ -785,7 +785,7 @@ class TestJob(RQTestCase):
         registry.add(job, 500)
 
         job.delete()
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
 
     def test_job_delete_execution_registry(self):
         """job.delete() also deletes ExecutionRegistry and all job executions"""

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -297,7 +297,7 @@ class TestQueue(RQTestCase):
 
             # Job status is still QUEUED even though it's already dequeued
             self.assertEqual(job.get_status(refresh=True), JobStatus.QUEUED)
-            self.assertFalse(job.id in queue.get_job_ids())
+            self.assertNotIn(job.id, queue.get_job_ids())
             self.assertIsNotNone(self.connection.lpos(queue.intermediate_queue_key, job.id))
 
     def test_dequeue_any_ignores_nonexisting_jobs(self):
@@ -442,9 +442,9 @@ class TestQueue(RQTestCase):
         self.assertEqual(len(Queue.all(connection=self.connection)), 3)
 
         # Verify names
-        self.assertTrue('first-queue' in names)
-        self.assertTrue('second-queue' in names)
-        self.assertTrue('third-queue' in names)
+        self.assertIn('first-queue', names)
+        self.assertIn('second-queue', names)
+        self.assertIn('third-queue', names)
 
         # Now empty two queues
         w = Worker([q2, q3], connection=self.connection)
@@ -475,8 +475,8 @@ class TestQueue(RQTestCase):
         self.assertEqual(len(Queue.all(connection=self.connection)), 2)
         names = [q.name for q in Queue.all(connection=self.connection)]
         # Verify names
-        self.assertTrue('queue_with_queued_jobs' in names)
-        self.assertTrue('queue_with_deferred_jobs' in names)
+        self.assertIn('queue_with_queued_jobs', names)
+        self.assertIn('queue_with_deferred_jobs', names)
 
     def test_from_queue_key(self):
         """Ensure being able to get a Queue instance manually from Redis"""

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -850,4 +850,4 @@ class TestJobScheduling(RQTestCase):
         job = queue.enqueue_at(scheduled_time, say_hello)
         registry = ScheduledJobRegistry(queue=queue)
         self.assertIn(job, registry)
-        self.assertTrue(registry.get_expiration_time(job), scheduled_time)
+        self.assertEqual(registry.get_expiration_time(job), scheduled_time.replace(microsecond=0))

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -54,19 +54,19 @@ class TestRegistry(RQTestCase):
 
     def test_custom_job_class(self):
         registry = BaseRegistry(job_class=CustomJob)
-        self.assertFalse(registry.job_class == self.registry.job_class)
+        self.assertIsNot(registry.job_class, self.registry.job_class)
 
     def test_contains(self):
         queue = Queue(connection=self.connection)
         job = queue.enqueue(say_hello)
 
-        self.assertFalse(job in self.registry)
-        self.assertFalse(job.id in self.registry)
+        self.assertNotIn(job, self.registry)
+        self.assertNotIn(job.id, self.registry)
 
         self.registry.add(job, 5)
 
-        self.assertTrue(job in self.registry)
-        self.assertTrue(job.id in self.registry)
+        self.assertIn(job, self.registry)
+        self.assertIn(job.id, self.registry)
 
     def test_get_expiration_time(self):
         """registry.get_expiration_time() returns correct datetime objects"""
@@ -391,10 +391,10 @@ class TestFailedJobRegistry(RQTestCase):
         worker.work(burst=True)
 
         registry = FailedJobRegistry(connection=worker.connection)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         registry.requeue(job.id)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
         self.assertIn(job.id, queue.get_job_ids())
 
         job.refresh()
@@ -403,33 +403,33 @@ class TestFailedJobRegistry(RQTestCase):
         self.assertEqual(job.ended_at, None)
 
         worker.work(burst=True)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         # Should also work with job instance
         registry.requeue(job)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
         self.assertIn(job.id, queue.get_job_ids())
 
         job.refresh()
         self.assertEqual(job.get_status(), JobStatus.QUEUED)
 
         worker.work(burst=True)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         # requeue_job should work the same way
         requeue_job(job.id, connection=self.connection)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
         self.assertIn(job.id, queue.get_job_ids())
 
         job.refresh()
         self.assertEqual(job.get_status(), JobStatus.QUEUED)
 
         worker.work(burst=True)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         # And so does job.requeue()
         job.requeue()
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
         self.assertIn(job.id, queue.get_job_ids())
 
         job.refresh()
@@ -444,10 +444,10 @@ class TestFailedJobRegistry(RQTestCase):
         worker.work(burst=True)
 
         registry = FailedJobRegistry(connection=worker.connection, serializer=JSONSerializer)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         registry.requeue(job.id)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
         self.assertIn(job.id, queue.get_job_ids())
 
         job.refresh()
@@ -456,33 +456,33 @@ class TestFailedJobRegistry(RQTestCase):
         self.assertEqual(job.ended_at, None)
 
         worker.work(burst=True)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         # Should also work with job instance
         registry.requeue(job)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
         self.assertIn(job.id, queue.get_job_ids())
 
         job.refresh()
         self.assertEqual(job.get_status(), JobStatus.QUEUED)
 
         worker.work(burst=True)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         # requeue_job should work the same way
         requeue_job(job.id, connection=self.connection, serializer=JSONSerializer)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
         self.assertIn(job.id, queue.get_job_ids())
 
         job.refresh()
         self.assertEqual(job.get_status(), JobStatus.QUEUED)
 
         worker.work(burst=True)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         # And so does job.requeue()
         job.requeue()
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
         self.assertIn(job.id, queue.get_job_ids())
 
         job.refresh()
@@ -545,31 +545,31 @@ class TestStartedJobRegistry(RQTestCase):
         because the entries in the registry are {job_id}:{execution_id} format."""
         job = self.queue.enqueue(say_hello)
 
-        self.assertFalse(job in self.registry)
-        self.assertFalse(job.id in self.registry)
+        self.assertNotIn(job, self.registry)
+        self.assertNotIn(job.id, self.registry)
 
         with self.connection.pipeline() as pipe:
             self.registry.add_execution(
                 Execution(id='execution', job_id=job.id, connection=self.connection), pipeline=pipe, ttl=5
             )
             pipe.execute()
-        self.assertTrue(job in self.registry)
-        self.assertTrue(job.id in self.registry)
+        self.assertIn(job, self.registry)
+        self.assertIn(job.id, self.registry)
 
     def test_infinite_score(self):
         """Test the StartedJobRegistry __contains__ method. It is slightly different
         because the entries in the registry are {job_id}:{execution_id} format."""
         job = self.queue.enqueue(say_hello)
 
-        self.assertFalse(job in self.registry)
-        self.assertFalse(job.id in self.registry)
+        self.assertNotIn(job, self.registry)
+        self.assertNotIn(job.id, self.registry)
 
         with self.connection.pipeline() as pipe:
             execution = Execution(id='execution', job_id=job.id, connection=self.connection)
             self.registry.add_execution(execution=execution, pipeline=pipe, ttl=-1)
             pipe.execute()
-        self.assertTrue(job in self.registry)
-        self.assertTrue(job.id in self.registry)
+        self.assertIn(job, self.registry)
+        self.assertIn(job.id, self.registry)
         self.assertTrue(self.connection.zscore(self.registry.key, execution.composite_key), '+inf')
 
     def test_remove_executions(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,3 +1,4 @@
+import math
 from datetime import timedelta
 from unittest import mock
 from unittest.mock import ANY
@@ -570,7 +571,7 @@ class TestStartedJobRegistry(RQTestCase):
             pipe.execute()
         self.assertIn(job, self.registry)
         self.assertIn(job.id, self.registry)
-        self.assertTrue(self.connection.zscore(self.registry.key, execution.composite_key), '+inf')
+        self.assertEqual(self.connection.zscore(self.registry.key, execution.composite_key), math.inf)
 
     def test_remove_executions(self):
         """Ensure all executions for a job are removed from registry."""

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -119,7 +119,7 @@ class TestScheduledJobRegistry(RQTestCase):
         worker.handle_job_success(job, queue, registry)
 
         payload = self.connection.hgetall(job.key)
-        self.assertFalse(b'result' in payload.keys())
+        self.assertNotIn(b'result', payload.keys())
         self.assertEqual(job.result, 'Success')
 
         with patch('rq.worker.Worker.supports_redis_streams', new_callable=PropertyMock) as mock:
@@ -138,7 +138,7 @@ class TestScheduledJobRegistry(RQTestCase):
 
                 worker.handle_job_success(job, queue, registry)
                 payload = self.connection.hgetall(job.key)
-                self.assertTrue(b'result' in payload.keys())
+                self.assertIn(b'result', payload.keys())
                 # Delete all new result objects so we only have result stored in job hash,
                 # this should simulate a job that was executed in an earlier RQ version
                 self.assertEqual(job.result, 'Success')
@@ -161,7 +161,7 @@ class TestScheduledJobRegistry(RQTestCase):
 
         job = Job.fetch(job.id, connection=self.connection)
         payload = self.connection.hgetall(job.key)
-        self.assertFalse(b'exc_info' in payload.keys())
+        self.assertNotIn(b'exc_info', payload.keys())
         self.assertEqual(job.exc_info, 'Error')
 
         with patch('rq.worker.Worker.supports_redis_streams', new_callable=PropertyMock) as mock:
@@ -180,7 +180,7 @@ class TestScheduledJobRegistry(RQTestCase):
 
                 worker.handle_job_failure(job, exc_string='Error', queue=queue, started_job_registry=registry)
                 payload = self.connection.hgetall(job.key)
-                self.assertTrue(b'exc_info' in payload.keys())
+                self.assertIn(b'exc_info', payload.keys())
                 # Delete all new result objects so we only have result stored in job hash,
                 # this should simulate a job that was executed in an earlier RQ version
                 Result.delete_all(job)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -441,7 +441,7 @@ class TestQueue(RQTestCase):
         self.assertEqual(len(registry), 1)
 
         # enqueue_at set job status to "scheduled"
-        self.assertTrue(job.get_status() == 'scheduled')
+        self.assertEqual(job.get_status(), 'scheduled')
 
         # After enqueue_scheduled_jobs() is called, the registry is empty
         # and job is enqueued
@@ -465,8 +465,8 @@ class TestQueue(RQTestCase):
         self.assertEqual(len(registry), 2)
 
         # enqueue_at set job status to "scheduled"
-        self.assertTrue(job_first.get_status() == 'scheduled')
-        self.assertTrue(job_second.get_status() == 'scheduled')
+        self.assertEqual(job_first.get_status(), 'scheduled')
+        self.assertEqual(job_second.get_status(), 'scheduled')
 
         # After enqueue_scheduled_jobs() is called, the registry is empty
         # and job is enqueued

--- a/tests/test_spawn_worker.py
+++ b/tests/test_spawn_worker.py
@@ -49,7 +49,7 @@ class TestWorker(RQTestCase):
         # Postconditions
         self.assertEqual(q.count, 0)
         failed_job_registry = FailedJobRegistry(queue=q)
-        self.assertTrue(job in failed_job_registry)
+        self.assertIn(job, failed_job_registry)
         self.assertEqual(w.get_current_job_id(), None)
 
         # Check the job

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,7 +91,7 @@ class TestUtils(RQTestCase):
     def test_get_redis_version(self):
         """Ensure get_version works properly"""
         redis = Redis()
-        self.assertTrue(isinstance(get_version(redis), tuple))
+        self.assertIsInstance(get_version(redis), tuple)
 
         # Parses 3 digit version numbers correctly
         class Redis4(Redis):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -135,13 +135,13 @@ class TestWorker(RQTestCase):
         self.assertEqual(worker.queues, queues)
         self.assertEqual(worker.get_state(), WorkerStatus.STARTED)
         self.assertEqual(worker._job_id, None)
-        self.assertTrue(worker.key in Worker.all_keys(worker.connection))
+        self.assertIn(worker.key, Worker.all_keys(worker.connection))
         self.assertEqual(worker.version, VERSION)
 
         # If worker is gone, its keys should also be removed
         worker.connection.delete(worker.key)
         Worker.find_by_key(worker.key, connection=self.connection)
-        self.assertFalse(worker.key in Worker.all_keys(worker.connection))
+        self.assertNotIn(worker.key, Worker.all_keys(worker.connection))
 
         self.assertRaises(ValueError, Worker.find_by_key, 'foo', connection=self.connection)
 
@@ -232,7 +232,7 @@ class TestWorker(RQTestCase):
         self.assertEqual(q.count, 0)
 
         failed_job_registry = FailedJobRegistry(queue=q)
-        self.assertTrue(job in failed_job_registry)
+        self.assertIn(job, failed_job_registry)
 
     def test_meta_is_unserializable(self):
         """Unserializable jobs are put on the failed job registry."""
@@ -249,7 +249,7 @@ class TestWorker(RQTestCase):
         self.connection.hset(job.key, 'meta', invalid_meta)
         job.refresh()
         self.assertIsInstance(job.meta, dict)
-        self.assertTrue('unserialized' in job.meta.keys())
+        self.assertIn('unserialized', job.meta.keys())
 
     @mock.patch('rq.worker.logger.error')
     def test_deserializing_failure_is_handled(self, mock_logger_error):
@@ -293,7 +293,7 @@ class TestWorker(RQTestCase):
         self.assertEqual(w.hostname, as_text(self.connection.hget(w.key, 'hostname')))
         last_heartbeat = self.connection.hget(w.key, 'last_heartbeat')
         self.assertIsNotNone(self.connection.hget(w.key, 'birth'))
-        self.assertTrue(last_heartbeat is not None)
+        self.assertIsNotNone(last_heartbeat)
         w = Worker.find_by_key(w.key, connection=self.connection)
         self.assertIsInstance(w.last_heartbeat, datetime)
 
@@ -376,7 +376,7 @@ class TestWorker(RQTestCase):
         # Postconditions
         self.assertEqual(q.count, 0)
         failed_job_registry = FailedJobRegistry(queue=q)
-        self.assertTrue(job in failed_job_registry)
+        self.assertIn(job, failed_job_registry)
         self.assertEqual(w.get_current_job_id(), None)
 
         # Check the job
@@ -410,7 +410,7 @@ class TestWorker(RQTestCase):
         # Postconditions
         self.assertEqual(q.count, 0)
         failed_job_registry = FailedJobRegistry(queue=q)
-        self.assertTrue(job in failed_job_registry)
+        self.assertIn(job, failed_job_registry)
         self.assertEqual(w.get_current_job_id(), None)
 
         # Check the job
@@ -470,7 +470,7 @@ class TestWorker(RQTestCase):
         job.refresh()
         self.assertEqual(job.retries_left, 1)
         self.assertEqual([job.id], queue.job_ids)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
 
         # First retry
         queue.empty()
@@ -486,7 +486,7 @@ class TestWorker(RQTestCase):
         self.assertEqual(job.retries_left, 0)
         self.assertEqual([], queue.job_ids)
         # If a job is no longer retries, it's put in FailedJobRegistry
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
     def test_total_working_time(self):
         """worker.total_working_time is stored properly"""
@@ -526,14 +526,14 @@ class TestWorker(RQTestCase):
         worker.work(burst=True)
 
         registry = FailedJobRegistry(queue=queue)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
 
         # Job is not added to FailedJobRegistry if
         # disable_default_exception_handler is True
         job = queue.enqueue(div_by_zero)
         worker = Worker([queue], disable_default_exception_handler=True)
         worker.work(burst=True)
-        self.assertFalse(job in registry)
+        self.assertNotIn(job, registry)
 
     def test_custom_exc_handling(self):
         """Custom exception handling."""
@@ -886,8 +886,11 @@ class TestWorker(RQTestCase):
 
         # Updates working queue, job execution should be there
         registry = StartedJobRegistry(connection=self.connection)
-        self.assertTrue(job.id in registry.get_job_ids())
-        self.assertTrue((worker.execution.job_id, worker.execution.id) in registry.get_job_and_execution_ids())
+        self.assertIn(job.id, registry.get_job_ids())
+        self.assertIn(
+            (worker.execution.job_id, worker.execution.id),
+            registry.get_job_and_execution_ids(),
+        )
 
         # Updates worker's current job
         self.assertEqual(worker.get_current_job_id(), job.id)
@@ -1161,7 +1164,7 @@ class TestWorker(RQTestCase):
         # Postconditions
         self.assertEqual(q.count, 0)
         failed_job_registry = FailedJobRegistry(queue=q)
-        self.assertTrue(job in failed_job_registry)
+        self.assertIn(job, failed_job_registry)
         self.assertEqual(w.get_current_job_id(), None)
 
         job_check = Job.fetch(job.id, connection=self.connection)
@@ -1461,7 +1464,7 @@ class WorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
         p.join(1)
         self.assertEqual(job_status, JobStatus.FAILED)
         failed_job_registry = FailedJobRegistry(queue=fooq)
-        self.assertTrue(job in failed_job_registry)
+        self.assertIn(job, failed_job_registry)
         self.assertEqual(fooq.count, 0)
 
     @slow
@@ -1497,10 +1500,10 @@ class WorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
         total_time = w.job_monitoring_interval + 65 + fudge_factor
 
         right_now = now()
-        self.assertTrue((now() - right_now).total_seconds() < total_time)
+        self.assertLess((now() - right_now).total_seconds(), total_time)
         self.assertEqual(job.get_status(), JobStatus.FAILED)
         failed_job_registry = FailedJobRegistry(queue=fooq)
-        self.assertTrue(job in failed_job_registry)
+        self.assertIn(job, failed_job_registry)
         self.assertEqual(fooq.count, 0)
         self.assertFalse(psutil.pid_exists(subprocess_pid))
 
@@ -1527,7 +1530,7 @@ class TestWorkerSubprocess(RQTestCase):
         job = q.enqueue(access_self)
         subprocess.check_call(['rqworker', '-u', self.redis_url, '-b'])
         registry = FinishedJobRegistry(queue=q)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
         assert q.count == 0
 
     @skipIf('pypy' in sys.version.lower(), 'often times out with pypy')
@@ -1537,7 +1540,7 @@ class TestWorkerSubprocess(RQTestCase):
         job = q.enqueue(schedule_access_self)
         subprocess.check_call(['rqworker', '-u', self.redis_url, '-b'])
         registry = FinishedJobRegistry(queue=q)
-        self.assertTrue(job in registry)
+        self.assertIn(job, registry)
         assert q.count == 0
 
 


### PR DESCRIPTION
While making my previous PR, I sometimes saw failed tests with unhelpful messages like "False is not true". To make debugging easier, I replaced `assertTrue` and `assertFalse` with more specific assert methods like `assertEqual` and `assertIn`.

While doing this, I also found a couple assertions that were not actually testing the correct condition. I fixed those too; for reviewing convenience I put those fixes in a separate commit.
