### PR TITLE
Register pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,3 +135,7 @@ ignore_missing_imports = true
 [tool.pyright]
 reportOptionalMemberAccess = false
 reportOptionalOperand = false
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = ["slow", "ssl_test"]


### PR DESCRIPTION
This fixes warnings such as "Unknown pytest.mark.slow - is this a typo?".

I also enabled strict markers by default, so that any typos in marker names will fail the tests.