### PR TITLE
tests: clean up Redis connections deterministically

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,8 @@ import unittest
 import pytest
 from redis import Redis
 
+from rq.utils import get_version
+
 
 def find_empty_redis_database(ssl=False):
     """Tries to connect to a random Redis database (starting from 4), and
@@ -21,8 +23,15 @@ def find_empty_redis_database(ssl=False):
         empty = testconn.dbsize() == 0
         if empty:
             return testconn
+        testconn.close()
     assert False, 'No empty Redis database found to run tests in.'
 
+def min_redis_version(ver: tuple[int, ...]):
+    ver_str = ".".join(map(str, ver))
+    with Redis() as conn:
+        redis_version = get_version(conn)
+
+    return unittest.skipIf(redis_version < ver, f'Skip if Redis server < {ver_str}')
 
 def slow(f):
     f = pytest.mark.slow(f)
@@ -34,42 +43,12 @@ def ssl_test(f):
     return unittest.skipUnless(os.environ.get('RUN_SSL_TESTS'), 'SSL tests disabled')(f)
 
 
-class TestCase(unittest.TestCase):
-    """Base class to inherit test cases from for RQ.
-
-    It sets up the Redis connection (available via self.connection), turns off
-    logging to the terminal and flushes the Redis database before and after
-    running each test.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        # Set up connection to Redis
-        cls.connection = find_empty_redis_database()
-        # Shut up logging
-        logging.disable(logging.ERROR)
-
-    def setUp(self):
-        # Flush beforewards (we like our hygiene)
-        self.connection.flushdb()
-
-    def tearDown(self):
-        # Flush afterwards
-        self.connection.flushdb()
-
-    @classmethod
-    def tearDownClass(cls):
-        logging.disable(logging.NOTSET)
-
-
 class RQTestCase(unittest.TestCase):
     """Base class to inherit test cases from for RQ.
 
     It sets up the Redis connection (available via self.connection), turns off
     logging to the terminal and flushes the Redis database before and after
     running each test.
-
-    Also offers assertQueueContains(queue, that_func) assertion method.
     """
 
     @classmethod
@@ -87,8 +66,8 @@ class RQTestCase(unittest.TestCase):
     def tearDown(self):
         # Flush afterwards
         self.connection.flushdb()
-        self.connection.close()
 
     @classmethod
     def tearDownClass(cls):
         logging.disable(logging.NOTSET)
+        cls.connection.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,9 @@ class CLITestCase(RQTestCase):
         self.redis_url = 'redis://127.0.0.1:6379/%d' % db_num
         self.connection = Redis.from_url(self.redis_url)
 
+    def tearDown(self):
+        self.connection.close()
+
     def assert_normal_execution(self, result):
         if result.exit_code == 0:
             return True

--- a/tests/test_intermediate_queue.py
+++ b/tests/test_intermediate_queue.py
@@ -1,20 +1,17 @@
-import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
-from redis import Redis
 
 from rq import Queue, Worker
 from rq.intermediate_queue import IntermediateQueue
 from rq.job import JobStatus
 from rq.maintenance import clean_intermediate_queue
-from rq.utils import get_version
-from tests import RQTestCase
+from tests import RQTestCase, min_redis_version
 from tests.fixtures import say_hello
 
 
-@unittest.skipIf(get_version(Redis()) < (6, 2, 0), 'Skip if Redis server < 6.2.0')
+@min_redis_version((6, 2, 0))
 class TestIntermediateQueue(RQTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -1,13 +1,10 @@
 import json
 import queue
 import time
-import unittest
 import zlib
 from datetime import datetime, timezone
 from pickle import dumps, loads
 from uuid import uuid4
-
-from redis import Redis
 
 from rq.defaults import CALLBACK_TIMEOUT
 from rq.exceptions import DeserializationError, InvalidJobOperation, NoSuchJobError
@@ -23,9 +20,9 @@ from rq.registry import (
     StartedJobRegistry,
 )
 from rq.serializers import JSONSerializer
-from rq.utils import as_text, get_version, now, utcformat
+from rq.utils import as_text, now, utcformat
 from rq.worker import Worker
-from tests import RQTestCase, fixtures
+from tests import RQTestCase, fixtures, min_redis_version
 
 
 class TestJob(RQTestCase):
@@ -832,7 +829,7 @@ class TestJob(RQTestCase):
 
         assert key == (Job.redis_job_namespace_prefix + job_id).encode('utf-8')
 
-    @unittest.skipIf(get_version(Redis()) < (5, 0, 0), 'Skip if Redis server < 5.0')
+    @min_redis_version((5, 0, 0))
     def test_blocking_result_fetch(self):
         # Ensure blocking waits for the time to run the job, but not right up until the timeout.
         job_sleep_seconds = 2

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,9 +1,6 @@
 import json
-import unittest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
-
-from redis import Redis
 
 from rq import Queue, Retry
 from rq.job import Job, JobStatus
@@ -16,9 +13,8 @@ from rq.registry import (
     StartedJobRegistry,
 )
 from rq.serializers import JSONSerializer
-from rq.utils import get_version
 from rq.worker import Worker
-from tests import RQTestCase
+from tests import RQTestCase, min_redis_version
 from tests.fixtures import echo, say_hello
 
 
@@ -259,7 +255,7 @@ class TestQueue(RQTestCase):
         self.assertEqual(job.origin, barq.name)
         self.assertEqual(job.args[0], 'for Bar', 'Bar should be dequeued second.')
 
-    @unittest.skipIf(get_version(Redis()) < (6, 2, 0), 'Skip if Redis server < 6.2.0')
+    @min_redis_version((6, 2, 0))
     def test_dequeue_any_reliable(self):
         """Dequeueing job from a single queue moves job to intermediate queue."""
         foo_queue = Queue('foo', connection=self.connection)
@@ -282,7 +278,7 @@ class TestQueue(RQTestCase):
         # After job is dequeued, the job ID is in the intermediate queue
         self.assertEqual(self.connection.lpos(foo_queue.intermediate_queue_key, job.id), 1)
 
-    @unittest.skipIf(get_version(Redis()) < (6, 2, 0), 'Skip if Redis server < 6.2.0')
+    @min_redis_version((6, 2, 0))
     def test_intermediate_queue(self):
         """Job should be stuck in intermediate queue if execution fails after dequeued."""
         queue = Queue('foo', connection=self.connection)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,24 +1,21 @@
 import tempfile
 import time
-import unittest
 from datetime import timedelta
 from unittest.mock import PropertyMock, patch
-
-from redis import Redis
 
 from rq.defaults import UNSERIALIZABLE_RETURN_VALUE_PAYLOAD
 from rq.job import Job
 from rq.queue import Queue
 from rq.registry import StartedJobRegistry
 from rq.results import Result, get_key
-from rq.utils import get_version, now
+from rq.utils import now
 from rq.worker import Worker
-from tests import RQTestCase
+from tests import RQTestCase, min_redis_version
 
 from .fixtures import div_by_zero, say_hello
 
 
-@unittest.skipIf(get_version(Redis()) < (5, 0, 0), 'Skip if Redis server < 5.0')
+@min_redis_version((5, 0, 0))
 class TestScheduledJobRegistry(RQTestCase):
     def test_save_and_get_result(self):
         """Ensure data is saved properly"""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -16,7 +16,6 @@ from unittest.mock import Mock
 import psutil
 import pytest
 import redis.exceptions
-from redis import Redis
 
 from rq import Queue, SimpleWorker, Worker
 from rq.defaults import DEFAULT_MAINTENANCE_TASK_INTERVAL, DEFAULT_WORKER_TTL
@@ -25,10 +24,10 @@ from rq.registry import FailedJobRegistry, FinishedJobRegistry, StartedJobRegist
 from rq.results import Result
 from rq.serializers import JSONSerializer
 from rq.suspension import resume, suspend
-from rq.utils import as_text, get_version, now
+from rq.utils import as_text, now
 from rq.version import VERSION
 from rq.worker import HerokuWorker, RandomWorker, RoundRobinWorker, WorkerStatus
-from tests import RQTestCase, find_empty_redis_database, slow
+from tests import RQTestCase, find_empty_redis_database, min_redis_version, slow
 from tests.fixtures import (
     CustomJob,
     access_self,
@@ -912,7 +911,7 @@ class TestWorker(RQTestCase):
         self.assertEqual(worker.get_current_job_id(), None)
         self.assertIsNone(worker.execution)
 
-    @skipIf(get_version(Redis()) < (6, 2, 0), 'Skip if Redis server < 6.2.0')
+    @min_redis_version((6, 2, 0))
     def test_prepare_job_execution_removes_key_from_intermediate_queue(self):
         """Prepare job execution removes job from intermediate queue."""
         queue = Queue(connection=self.connection)
@@ -925,7 +924,7 @@ class TestWorker(RQTestCase):
         self.assertIsNone(self.connection.lpos(queue.intermediate_queue_key, job.id))
         self.assertEqual(queue.count, 0)
 
-    @skipIf(get_version(Redis()) < (6, 2, 0), 'Skip if Redis server < 6.2.0')
+    @min_redis_version((6, 2, 0))
     def test_work_removes_key_from_intermediate_queue(self):
         """Worker removes job from intermediate queue."""
         queue = Queue(connection=self.connection)

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -9,7 +9,7 @@ from rq.queue import Queue
 from rq.serializers import JSONSerializer
 from rq.worker import SimpleWorker
 from rq.worker_pool import WorkerPool, run_worker
-from tests import TestCase
+from tests import RQTestCase
 from tests.fixtures import CustomJob, _send_shutdown_command, long_running_job, say_hello
 
 
@@ -18,7 +18,7 @@ def wait_and_send_shutdown_signal(pid, time_to_wait=0.0):
     os.kill(pid, signal.SIGTERM)
 
 
-class TestWorkerPool(TestCase):
+class TestWorkerPool(RQTestCase):
     def test_queues(self):
         """Test queue parsing"""
         pool = WorkerPool(['default', 'foo'], connection=self.connection)


### PR DESCRIPTION
I have found that relying on garbage collection for cleaning up Redis connections can result in deadlocks. `Redis.close` acquires a lock, so if GC runs while that lock is already acquired, it will deadlock.

In #2249, I've added _some_ deterministic cleanup, but since then I observed these deadlocks happening again. So I went through all other instances of Redis connections being created, and added deterministic cleanup for all of them. Hopefully, this fixes the problem for good.

Note that `TestCase` appears to be a duplicate of `RQTestCase`, so I just deleted it instead of adding cleanup. I also fixed a couple of minor problems in `RQTestCase`.