### PR TITLE
Avoid IndexError during group cleanup

### DIFF
--- a/rq/group.py
+++ b/rq/group.py
@@ -38,6 +38,8 @@ class Group:
         We assume while running this that alive jobs have all been fetched from Redis in fetch_jobs method"""
         with self.connection.pipeline() as pipe: # Use a new pipeline
             job_ids = [as_text(job) for job in list(self.connection.smembers(self.key))]
+            if not job_ids:
+                return
             expired_job_ids = []
             for job in job_ids:
                 pipe.exists(Job.key_for(job))

--- a/rq/group.py
+++ b/rq/group.py
@@ -33,23 +33,22 @@ class Group:
         pipeline.sadd(self.REDIS_GROUP_KEY, self.name)
         pipeline.execute()
 
-    def cleanup(self, pipeline: Optional['Pipeline'] = None):
+    def cleanup(self):
         """Delete jobs from the group's job registry that have been deleted or expired from Redis.
         We assume while running this that alive jobs have all been fetched from Redis in fetch_jobs method"""
-        pipe = pipeline if pipeline else self.connection.pipeline()
-        job_ids = [as_text(job) for job in list(self.connection.smembers(self.key))]
-        expired_job_ids = []
-        for job in job_ids:
-            pipe.exists(Job.key_for(job))
-        results = pipe.execute()
-
-        for i, key_exists in enumerate(results):
-            if not key_exists:
-                expired_job_ids.append(job_ids[i])
-        if expired_job_ids:
-            pipe.srem(self.key, *expired_job_ids)
-        if pipeline is None:
-            pipe.execute()
+        with self.connection.pipeline() as pipe: # Use a new pipeline
+            job_ids = [as_text(job) for job in list(self.connection.smembers(self.key))]
+            expired_job_ids = []
+            for job in job_ids:
+                pipe.exists(Job.key_for(job))
+            results = pipe.execute()
+            
+            for i, key_exists in enumerate(results):
+                if not key_exists:
+                    expired_job_ids.append(job_ids[i])
+            if expired_job_ids:
+                pipe.srem(self.key, *expired_job_ids)
+                pipe.execute()
 
     def enqueue_many(self, queue: Queue, job_datas: Iterable['EnqueueData'], pipeline: Optional['Pipeline'] = None):
         pipe = pipeline if pipeline else self.connection.pipeline()
@@ -112,7 +111,8 @@ class Group:
         with connection.pipeline() as p:
             # Remove expired jobs from groups
             for group in groups:
-                group.cleanup(pipeline=p)
+                print(f"\n\nCleaning up group: {group.name}")
+                group.cleanup()
             p.execute()
             # Remove empty groups from group registry
             for group in groups:

--- a/rq/group.py
+++ b/rq/group.py
@@ -113,7 +113,6 @@ class Group:
         with connection.pipeline() as p:
             # Remove expired jobs from groups
             for group in groups:
-                print(f"\n\nCleaning up group: {group.name}")
                 group.cleanup()
             p.execute()
             # Remove empty groups from group registry

--- a/rq/group.py
+++ b/rq/group.py
@@ -44,7 +44,7 @@ class Group:
             for job in job_ids:
                 pipe.exists(Job.key_for(job))
             results = pipe.execute()
-            
+
             for i, key_exists in enumerate(results):
                 if not key_exists:
                     expired_job_ids.append(job_ids[i])

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -23,6 +23,14 @@ class TestGroup(RQTestCase):
         assert len(group.get_jobs()) == 2
         q.empty()
 
+    def test_group_cleanup_with_no_jobs(self):
+        q = Queue(connection=self.connection)
+        group = Group.create(connection=self.connection)
+        assert len(group.get_jobs()) == 0
+        group.cleanup()
+        assert len(group.get_jobs()) == 0
+        q.empty()
+
     def test_group_repr(self):
         group = Group.create(name='foo', connection=self.connection)
         assert group.__repr__() == 'Group(id=foo)'


### PR DESCRIPTION
https://github.com/rq/rq/issues/2269

* Use a fresh pipeline for each call to `cleanup()`
   * Should avoid the case where `job_ids` and `results` have different lengths
* Return early if no jobs are found