### PR TITLE
Actually check if using class based function

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -316,7 +316,7 @@ class Job:
             job._func_name = f'{func.__module__}.{func.__qualname__}'
         elif isinstance(func, str):
             job._func_name = as_text(func)
-        elif not inspect.isclass(func) and hasattr(func, '__call__'):  # a callable class instance
+        elif inspect.isclass(func) and hasattr(func, '__call__'):  # a callable class instance
             job._instance = func
             job._func_name = '__call__'
         else:


### PR DESCRIPTION
During development I noticed you cannot use class based callables anymore. After some debugging I found the check for class based callables that checks if the function is NOT a class. This should not behave this way in my opinion

Problematic function:
```python
class testfunction:
  def __call__(self):
    print("This is a test")
    return True
```

By removing the not statement, classes that are callable are actually be able to be executed