### PR TITLE
Improved table formatting

### DIFF
--- a/docs/css/screen.css
+++ b/docs/css/screen.css
@@ -279,6 +279,22 @@ li {
     /* IE7 spacing */
 }
 
+table {
+    margin-bottom: 1em;
+}
+
+table, td, th {
+    border: 1px solid #555555;
+}
+
+thead {
+    background-color: #f3f3f0;
+}
+
+th, td {
+    padding: 10px;
+}
+
 /*
 @media screen and (max-width: 1400px)
 {


### PR DESCRIPTION
fixes #2206

Let me know if it could be improved somehow

Before:
<img width="651" height="166" alt="Screenshot 2025-07-28 at 15 09 53" src="https://github.com/user-attachments/assets/17fd9b58-c553-42ae-b20b-331d24b9fb33" />

After:
<img width="617" height="242" alt="Screenshot 2025-07-28 at 15 20 56" src="https://github.com/user-attachments/assets/23039fbc-ef10-4005-aac9-e589d246dcc9" />
