### PR TITLE
Add execution cleanup to spawn/fork workers on success

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -1406,6 +1406,9 @@ class Worker(BaseWorker):
         )
 
         if ret_val == os.EX_OK:  # The process exited normally.
+            with self.connection.pipeline() as pipeline:
+                self.cleanup_execution(job, pipeline=pipeline)
+                pipeline.execute()
             return
 
         try:

--- a/tests/test_spawn_worker.py
+++ b/tests/test_spawn_worker.py
@@ -6,7 +6,7 @@ from multiprocessing import Process
 
 from rq import Queue
 from rq.job import Job
-from rq.registry import FailedJobRegistry, FinishedJobRegistry
+from rq.registry import FailedJobRegistry, FinishedJobRegistry, StartedJobRegistry
 from rq.results import Result
 from rq.worker import SpawnWorker
 from tests import RQTestCase, slow
@@ -30,6 +30,9 @@ class TestWorker(RQTestCase):
 
         registry = FinishedJobRegistry(queue=queue)
         self.assertEqual(registry.get_job_ids(), [job.id])
+
+        registry = StartedJobRegistry(queue=queue)
+        self.assertEqual(registry.get_job_ids(), [])
 
     def test_work_fails(self):
         """Failing jobs are put on the failed queue."""


### PR DESCRIPTION
This fixes: https://github.com/rq/rq/issues/2290

The parent process owns the Execution object but never cleaned it up on successful completion of a job, this adds a call to cleanup_execution when the child process finished execution.

See updated test case. 