### PR TITLE
WorkerPool: single pool-level scheduler
  option + CLI flag

### DIFF
--- a/rq/cli/workers.py
+++ b/rq/cli/workers.py
@@ -185,6 +185,11 @@ def worker(
 @click.option('--date-format', type=str, default=DEFAULT_LOGGING_DATE_FORMAT, help='Set the date format of the logs')
 @click.argument('queues', nargs=-1)
 @click.option('--num-workers', '-n', type=int, default=1, help='Number of workers to start')
+@click.option(
+    '--with-scheduler/--without-scheduler',
+    default=True,
+    help='Run workers with scheduler (acquires lock to ensure single scheduler)',
+)
 @pass_cli_config
 def worker_pool(
     cli_config,
@@ -197,6 +202,7 @@ def worker_pool(
     log_format,
     date_format,
     num_workers,
+    with_scheduler,
     **options,
 ):
     """Starts a RQ worker pool"""
@@ -225,4 +231,4 @@ def worker_pool(
         worker_class=cli_config.worker_class,
         job_class=cli_config.job_class,
     )
-    pool.start(burst=burst, logging_level=logging_level)
+    pool.start(burst=burst, logging_level=logging_level, with_scheduler=with_scheduler)

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -58,7 +58,7 @@ class RQScheduler:
         self.interval = interval
         self._stop_requested = False
         self._status = self.Status.STOPPED
-        self._process = None
+        self._process: Optional[Process] = None
         self.log = logging.getLogger(__name__)
         setup_loghandlers(
             level=logging_level,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -294,6 +294,23 @@ class TestRQCli(CLITestCase):
         result = runner.invoke(main, ['worker', '-u', self.redis_url, '-b'])
         self.assert_normal_execution(result)
 
+    def test_worker_pool_cli_burst_without_scheduler(self):
+        """rq worker-pool -u <url> -b --num-workers 1 --without-scheduler"""
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                'worker-pool',
+                '-u',
+                self.redis_url,
+                '-b',
+                '--num-workers',
+                '1',
+                '--without-scheduler',
+            ],
+        )
+        self.assert_normal_execution(result)
+
     def test_worker_pid(self):
         """rq worker -u <url> /tmp/.."""
         pid = self.tmpdir.join('rq.pid')

--- a/tests/test_worker_pool.py
+++ b/tests/test_worker_pool.py
@@ -1,7 +1,7 @@
 import os
 import signal
-from multiprocessing import Process
 from datetime import datetime, timedelta, timezone
+from multiprocessing import Process
 from time import sleep
 
 from rq.connections import parse_connection


### PR DESCRIPTION
Add with_scheduler to WorkerPool.start() (default: True) to manage a single pool-level RQScheduler.
  Spawn workers with with_scheduler=False when enabled. CLI: add --with-scheduler/--without-scheduler to rq worker-pool. Tests added:
  test_worker_pool_starts_single_scheduler_non_burst; test_worker_pool_scheduler_burst_no_process; test_worker_pool_without_scheduler.