### PR TITLE
[FIX] - Documentation improvements for the "Grouping jobs" section in RQ

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -141,11 +141,16 @@ Multiple jobs can be added to a Group to allow them to be tracked by a single ID
 ```python
 from rq import Queue
 from rq.group import Group
+from redis import Redis
+
+# Tell RQ what Redis connection to use
+redis_conn = Redis()
+q = Queue(connection=redis_conn)  # no args implies the default queue
 
 group = Group.create(connection=redis_conn)
 jobs = group.enqueue_many(
-  queue="my_queue",
-  [
+  queue=q,
+  job_datas=[
     Queue.prepare_data(count_words_at_url, ('http://nvie.com',), job_id='my_job_id'),
     Queue.prepare_data(count_words_at_url, ('http://nvie.com',), job_id='my_other_job_id'),
   ]


### PR DESCRIPTION
## 📝 Fix docs: "Grouping jobs" example

Closes [#2311](https://github.com/rq/rq/issues/2311)

There are two issues in the current documentation at [RQ Docs – Grouping jobs](https://python-rq.org/docs/#grouping-jobs):

### ❌ Current screenshot
<img width="1006" height="408" alt="before_rq_doc" src="https://github.com/user-attachments/assets/dc0fb836-41b2-425f-9424-72c1d2946d1a" />

### Issues found
1. **SyntaxError**: positional argument follows keyword argument.  
2. `group.enqueue_many()` requires the `queue` argument to be a `Queue` instance, but the docs incorrectly show passing a string.

---

### ✅ Changes
- Updated the example to create a `Queue` object and pass it correctly to `group.enqueue_many`.  
- Fixed the "positional argument follows keyword argument" SyntaxError and refactored the example for clarity.  

---

### 📸 After this PR
<img width="1041" height="500" alt="after_rq_doc" src="https://github.com/user-attachments/assets/8aab0da4-a618-4318-bd96-2891174e5766" />

---

### 🎯 Impact
Users can now copy and run the example in “Grouping jobs” without errors.