### PR TITLE
Simplified GitHub Action lint job in CI pipeline by using the official plugin

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,19 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - name: 📥 Checkout Repository
+      uses: actions/checkout@v5
 
-    - name: Set up Python
-      uses: actions/setup-python@v5.6.0
+    - name: 📝 Run Lint Check
+      uses: astral-sh/ruff-action@v3
       with:
-        python-version: 3.9
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install ruff
-
-    - name: Lint with ruff
-      run: |
-        # stop the build if there are Python syntax errors.
-        ruff check --output-format=full rq tests
+        src: "rq tests"


### PR DESCRIPTION
# PR: Simplify Ruff Lint Workflow in CI Pipeline

This PR refactors the linting job in the GitHub Actions CI pipeline to make it **simpler, faster, and more reliable**.

---

### 🔄 Changes Made

- 🐍 **Removed Python installation** (no longer needed for Ruff action).  
- 📦 **Removed manual Ruff installation via pip**.  
- ⚙️ **Removed redundant `--output-format=full`** argument (it's the default).  
- 🔌 **Added official [`astral-sh/ruff-action@v3`](https://github.com/astral-sh/ruff-action)** for linting.  
- ✅ **Rely on the action’s default behavior** (`ruff check` is already the default).  

---

### 🎯 Benefits

- 🚀 Faster pipeline execution (fewer setup steps).  
- 🧹 Cleaner and more maintainable workflow file.  
- 🔒 Reduced risk of version mismatch by using the official action.  
