### PR TITLE
Fix ruff CLI option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ force_release: clean
 	twine upload dist/*
 
 lint:
-	@ ruff check --show-source rq tests
+	@ ruff check --output-format=full rq tests


### PR DESCRIPTION
The `--show-source` CLI option was deprecated in 0.2.x and removed completely in 0.5.x. It was replaced by `--output-format=full`.

See also:

* https://github.com/astral-sh/ruff/blob/4bd454f9b5481d741216a383cc7b03e327bc3ec9/changelogs/0.5.x.md?plain=1#L89