### PR TITLE
Update `tests/Dockerfile`

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get install -y \
     stunnel \
     python3.9 \
     python3.9-dev \
+    python3.9-distutils \
     python3.10 \
     python3.10-dev \
     python3.11 \


### PR DESCRIPTION
Running `make test` does not work. This should also address the currently failing `Run SSL tests` check.

- The deadsnakes PPA does not support the version of Ubuntu specified in the Dockerfile. Commit https://github.com/rq/rq/commit/9716001ff50bf28c3bd9f5abed5e3ffa6e262f56 handles that.
- When running `RUN_SLOW_TESTS_TOO=1 RUN_SSL_TESTS=1 hatch run tox` Python 3.9 would fail because it couldn't find the `distutils` module. This was addressed in commit https://github.com/rq/rq/commit/dfce06c8aef630dccaa5c747bb7542f3167b21b1.