### PR TITLE
Add typechecking for exception handlers

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -1479,7 +1479,7 @@ class Job:
         with death_penalty_class(self.success_callback_timeout, JobTimeoutException, job_id=self.id):
             self.success_callback(self, self.connection, result)
 
-    def execute_failure_callback(self, death_penalty_class: type[BaseDeathPenalty], *exc_info):
+    def execute_failure_callback(self, death_penalty_class: type[BaseDeathPenalty], *exc_info: Unpack[ExcInfo]):
         """Executes failure_callback with possible timeout"""
         if not self.failure_callback:
             return

--- a/rq/types.py
+++ b/rq/types.py
@@ -1,8 +1,9 @@
-from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union
 
 if TYPE_CHECKING:
+    from _typeshed import ExcInfo
     from redis import Redis
+    from typing_extensions import Unpack
 
     from .job import Dependency, Job
 
@@ -21,6 +22,4 @@ A simple helper definition for the `depends_on` parameter when creating a job.
 """
 
 SuccessCallbackType = Callable[['Job', 'Redis', Any], Any]
-FailureCallbackType = Callable[
-    ['Job', 'Redis', Optional[type[BaseException]], Optional[BaseException], Optional[TracebackType]], Any
-]
+FailureCallbackType = Callable[['Job', 'Redis', Unpack[ExcInfo]], Any]

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from random import shuffle
 from types import FrameType
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -22,8 +22,10 @@ if TYPE_CHECKING:
         from resource import struct_rusage
     except ImportError:
         pass
+    from _typeshed import ExcInfo
     from redis import Redis
     from redis.client import Pipeline, PubSub, PubSubWorkerThread
+    from typing_extensions import Unpack
 
 from contextlib import suppress
 
@@ -211,7 +213,7 @@ class BaseWorker:
         self.queues = queues
         self.validate_queues()
         self._ordered_queues = self.queues[:]
-        self._exc_handlers: list[Callable] = []
+        self._exc_handlers: list[Callable[[Job, Unpack[ExcInfo]], Any]] = []
         self._work_horse_killed_handler = work_horse_killed_handler
         self._shutdown_requested_date: Optional[datetime] = None
 
@@ -1232,7 +1234,7 @@ class BaseWorker:
             if not fallthrough:
                 break
 
-    def push_exc_handler(self, handler_func):
+    def push_exc_handler(self, handler_func: Callable[[Job, Unpack[ExcInfo]], Any]):
         """Pushes an exception handler onto the exc handler stack."""
         self._exc_handlers.append(handler_func)
 


### PR DESCRIPTION
This attempt to address the problem described in #2229. The type checker now fails at the problem call sites where `traceback.extract_trace()` is being used. I'm not entirely sure what the appropriate fix would be since we don't really have a real traceback. We could generate a synthetic one by doing something like:

```python
try:
  raise AbandonedJobErr()
except:
  exc_info = sys.exc_info()
```

And then make the approriate changes to

https://github.com/rq/rq/blob/55ec3ac34c19fb996e477048cba8b3d991e31e3d/rq/registry.py#L278-L280

and

https://github.com/rq/rq/blob/55ec3ac34c19fb996e477048cba8b3d991e31e3d/rq/registry.py#L284-L286

It's a hack for sure, but I'm not sure what the alternative would be either.

Fix #2229

