### PR TITLE
Change log level from debug to info for lock acquisition

### DIFF
--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -100,7 +100,7 @@ class RQScheduler:
         self.log.debug('Acquiring scheduler lock for %s', ', '.join(self._queue_names))
         for name in self._queue_names:
             if self.connection.set(self.get_locking_key(name), pid, nx=True, ex=self.interval + 60):
-                self.log.debug('Acquired scheduler lock for %s', name)
+                self.log.info('Acquired scheduler lock for %s', name)
                 successful_locks.add(name)
 
         # Always reset _scheduled_job_registries when acquiring locks


### PR DESCRIPTION
In a situation like I have, there are many RQ workers (each running with --with-scheduler) across many containers which sometimes have overlapping queue names to work on. As such, it's not obvious to see which scheduler acquired the locks on which queues -- only when the lock is released do you see what was _actually_ locked by any given scheduler.

For example, we have one heroku 'service' that works on queues a, b with x containers and another 'service' working on b, c with y containers. In this case, one container from the first locks a and b, and the latter c, so there are two scheduler instances -- but the locks for the latter are not complete over the set of queues they manage.

Making this line 'info' allows people to see that much more clearly, without the fuss of all the other extra 'debug' level lines.