### PR TITLE
Modify ShutDownImminentException inheritance

### DIFF
--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -26,7 +26,9 @@ class DequeueTimeout(Exception):
     pass
 
 
-class ShutDownImminentException(Exception):
+class ShutDownImminentException(BaseException):
+    # Inherit from BaseException as this is used specifically as a
+    # 'shutdown' signal and should not be caught by except Exception.
     def __init__(self, msg, extra_info):
         self.extra_info = extra_info
         super().__init__(msg)


### PR DESCRIPTION
Change ShutDownImminentException to inherit from BaseException instead of Exception. Consider the difference:

```
try:
  foo = do_long_task()
except Exception:
  foo = "fallback"
```

If ShutDownImminentException is raised during `do_long_task()`, then code will continue to execute which is against the spirit of ShutDownImminentException. It is semantically similar to something like a KeyboardInterupt, and so should be modelled like one. 