### PR TITLE
fix: handle SentinelConnectionPool in parse_connection

### DIFF
--- a/rq/connections.py
+++ b/rq/connections.py
@@ -7,7 +7,23 @@ class NoRedisConnectionException(Exception):
 
 
 def parse_connection(connection: Redis) -> tuple[type[Redis], type[RedisConnection], dict]:
-    connection_pool_kwargs = connection.connection_pool.connection_kwargs.copy()
-    connection_pool_class = connection.connection_pool.connection_class
+    connection_pool = connection.connection_pool
+    
+    # SentinelConnectionPool has different attributes than regular ConnectionPool
+    # For sentinel connections, we need to extract the underlying connection class
+    # and use default pool kwargs since sentinel-specific ones won't work with ConnectionPool
+    if connection_pool.__class__.__name__ == 'SentinelConnectionPool':
+        # For sentinel connections, get the connection class from the pool
+        # and use minimal kwargs suitable for regular ConnectionPool
+        connection_pool_class = connection_pool.connection_class
+        # Filter out sentinel-specific kwargs that aren't valid for ConnectionPool
+        sentinel_kwargs = {'master_name', 'sentinel', 'min_other_servers'}
+        connection_pool_kwargs = {
+            k: v for k, v in connection_pool.connection_kwargs.items()
+            if k not in sentinel_kwargs
+        }
+    else:
+        connection_pool_kwargs = connection_pool.connection_kwargs.copy()
+        connection_pool_class = connection_pool.connection_class
 
     return connection.__class__, connection_pool_class, connection_pool_kwargs

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,4 +1,7 @@
+from unittest.mock import MagicMock, patch
+
 from redis import ConnectionPool, Redis, SSLConnection, UnixDomainSocketConnection
+from redis.sentinel import SentinelConnectionPool
 
 from rq.connections import parse_connection
 from tests import RQTestCase
@@ -17,3 +20,34 @@ class TestConnectionInheritance(RQTestCase):
         self.assertEqual(conn_class, Redis)
         self.assertEqual(pool_class, UnixDomainSocketConnection)
         self.assertEqual(pool_kwargs, {'path': path})
+
+    def test_parse_connection_sentinel(self):
+        """Test parsing sentinel connection - should filter out sentinel-specific kwargs"""
+        # Create a mock sentinel connection pool
+        mock_pool = MagicMock(spec=SentinelConnectionPool)
+        mock_pool.connection_class = Redis
+        mock_pool.connection_kwargs = {
+            'host': 'localhost',
+            'port': 6379,
+            'master_name': 'mymaster',
+            'sentinel': MagicMock(),
+            'min_other_servers': 0,
+            'db': 0,
+        }
+
+        # Create a mock connection using the sentinel pool
+        mock_conn = MagicMock(spec=Redis)
+        mock_conn.connection_pool = mock_pool
+        mock_conn.__class__ = Redis
+
+        conn_class, pool_class, pool_kwargs = parse_connection(mock_conn)
+
+        self.assertEqual(conn_class, Redis)
+        # Should have filtered out sentinel-specific kwargs
+        self.assertNotIn('master_name', pool_kwargs)
+        self.assertNotIn('sentinel', pool_kwargs)
+        self.assertNotIn('min_other_servers', pool_kwargs)
+        # Should still have valid kwargs
+        self.assertIn('host', pool_kwargs)
+        self.assertIn('port', pool_kwargs)
+        self.assertIn('db', pool_kwargs)


### PR DESCRIPTION
When using Redis Sentinel with `Worker(connection=master_from_sentinel, with_scheduler=True)`, the scheduler fails because `parse_connection()` passes Sentinel-specific kwargs (`master_name`, `sentinel`, `min_other_servers`) to a regular `ConnectionPool`, which doesn't understand them.

This fix detects `SentinelConnectionPool` and filters out sentinel-specific kwargs before creating a new connection pool.

## Reproduction
```python
from redis.sentinel import Sentinel
sentinel = Sentinel([('localhost', 26379)])
master = sentinel.master_for('mymaster')
worker = Worker('default', connection=master, with_scheduler=True)
worker.work()  # fails
```

## Fix
Detect SentinelConnectionPool and filter sentinel-specific kwargs:
- `master_name`
- `sentinel`  
- `min_other_servers"

## Testing
Test would involve creating a Worker with sentinel connection and `with_scheduler=True` to verify scheduler starts correctly.

Would be great to add integration tests with a real sentinel setup if possible.