### PR TITLE
Add namedtuple for `Queue.parse_args` result

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -12,6 +12,7 @@ from functools import total_ordering
 from typing import (
     TYPE_CHECKING,
     Any,
+    NamedTuple,
     Optional,
     cast,
 )
@@ -70,6 +71,31 @@ class EnqueueData(
     """
 
     __slots__ = ()
+
+
+class QueueArgs(NamedTuple):
+    """Helper type to use when calling Queue.parse_args
+    """
+
+    func: str | Callable[..., Any]
+    timeout: int | str | None
+    description: str | None
+    result_ttl: int | None
+    ttl: int | None
+    failure_ttl: int | None
+    depends_on: JobDependencyType | None
+    job_id: str | None
+    at_front: bool
+    meta: dict | None
+    retry: Retry | None
+    repeat: Repeat | None
+    on_success: Callback | Callable | None
+    on_failure: Callback | Callable | None
+    on_stopped: Callback | Callable | None
+    pipeline: Pipeline | None
+    unique: bool
+    args: tuple | list | None
+    kwargs: dict | None
 
 
 @total_ordering
@@ -960,7 +986,7 @@ class Queue:
             args = kwargs.pop('args', None)
             kwargs = kwargs.pop('kwargs', None)
 
-        return (
+        return QueueArgs(
             f,
             timeout,
             description,


### PR DESCRIPTION
This change allows `Queue.parse_args`'s result to be safely used and ensure future compatibility.

For example, in the project I'm using RQ in, I want to perform some checks over the args/kwargs before a job is enqueued. Given RQ has some "reserved" kwargs (e.g. `timeout`), I was using `Queue.parse_args` for this so far. Recently, the `unique` var was added to the result, breaking my code, and this change should make this one usable without such issues and future-proof it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Argument parsing for enqueue operations now returns a structured, named result instead of an unnamed positional tuple. Improves clarity when inspecting or passing enqueue parameters while preserving existing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->