### PR TITLE
SpawnWorker should use !r when interpolating strings

### DIFF
--- a/rq/worker/worker_classes.py
+++ b/rq/worker/worker_classes.py
@@ -188,14 +188,14 @@ from rq.job import Job
 from rq.executions import Execution
 
 # Recreate worker instance
-redis = Redis(**{redis_kwargs})
-worker = Worker.find_by_key("{self.key}", connection=redis)
+redis = Redis(**{redis_kwargs!r})
+worker = Worker.find_by_key({self.key!r}, connection=redis)
 if not worker:
     sys.exit(1)
 
 # Reconstruct job, queue and execution objects
-job = Job.fetch("{job.id}", connection=worker.connection)
-queue = Queue("{queue.name}", connection=worker.connection)
+job = Job.fetch({job.id!r}, connection=worker.connection)
+queue = Queue({queue.name!r}, connection=worker.connection)
 execution_id = os.environ["RQ_EXECUTION_ID"]
 worker.execution = Execution.fetch(execution_id, job.id, connection=worker.connection)
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -25,17 +25,8 @@ RUN apt-get install -y \
     redis-server \
     python3-pip \
     stunnel \
-    python3.9 \
-    python3.9-dev \
-    python3.9-distutils \
     python3.10 \
-    python3.10-dev \
-    python3.11 \
-    python3.11-dev \
-    python3.12 \
-    python3.12-dev \
-    python3.13 \
-    python3.13-dev
+    python3.10-dev
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed worker spawn behavior so spawned processes reconstruct Redis connections and related objects from full configuration parameters, improving reliability when spawning workers.
* **Chores**
  * Simplified build image by pinning the Python runtime to 3.10 for consistent test/build environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->