### PR TITLE
Remove deferred jobs from DeferredJobRegistry when enqueued

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -74,8 +74,7 @@ class EnqueueData(
 
 
 class QueueArgs(NamedTuple):
-    """Helper type to use when calling Queue.parse_args
-    """
+    """Helper type to use when calling Queue.parse_args"""
 
     func: str | Callable[..., Any]
     timeout: int | str | None
@@ -1270,6 +1269,7 @@ class Queue:
         """
         self.log.debug('Enqueueing job %s to queue %s (at_front=%s)', job.id, self.name, at_front)
 
+        is_deferred = job.get_status(refresh=False) == JobStatus.DEFERRED
         self._prepare_for_queue(job)
 
         if unique:
@@ -1279,6 +1279,8 @@ class Queue:
         else:
             pipe = pipeline if pipeline is not None else self.connection.pipeline()
 
+            if is_deferred:
+                self.deferred_job_registry.remove(job, pipeline=pipe)
             self._persist_job(job, pipe)
             self.push_job_id(job.id, pipeline=pipe, at_front=at_front)
 
@@ -1301,6 +1303,7 @@ class Queue:
         """
         self.log.debug('Enqueueing job %s to queue %s (sync execution)', job.id, self.name)
 
+        is_deferred = job.get_status(refresh=False) == JobStatus.DEFERRED
         self._prepare_for_queue(job)
 
         if unique:
@@ -1309,6 +1312,8 @@ class Queue:
         else:
             pipe = pipeline if pipeline is not None else self.connection.pipeline()
 
+            if is_deferred:
+                self.deferred_job_registry.remove(job, pipeline=pipe)
             self._persist_job(job, pipe)
 
             if pipeline is None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -561,6 +561,19 @@ class TestQueue(RQTestCase):
         self.assertEqual(job.timeout, Queue.DEFAULT_TIMEOUT)
         self.assertEqual(job.get_status(), JobStatus.QUEUED)
 
+    def test_enqueue_deferred_job_removes_it_from_deferred_registry(self):
+        """Enqueueing a deferred job removes it from DeferredJobRegistry."""
+        q = Queue(connection=self.connection)
+        job = Job.create(func=say_hello, connection=self.connection, origin=q.name, status=JobStatus.DEFERRED)
+        job.save()
+        q.deferred_job_registry.add(job)
+
+        q._enqueue_job(job)
+
+        self.assertEqual(q.job_ids, [job.id])
+        self.assertEqual(job.get_status(), JobStatus.QUEUED)
+        self.assertNotIn(job, q.deferred_job_registry)
+
     def test_enqueue_job_with_dependency_and_pipeline(self):
         """Jobs are enqueued only when their dependencies are finished, and by the caller when passing a pipeline."""
         # Job with unfinished dependency is not immediately enqueued


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The queue now properly handles the transition of deferred jobs to active queued jobs by automatically removing them from the deferred registry during the enqueue operation.

* **Tests**
  * Added comprehensive test coverage to validate that deferred jobs are correctly converted to queued jobs and subsequently removed from the deferred registry.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rq/rq/pull/2402)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->