### PR TITLE
Drop python39 redis8

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        redis-version: [3, 4, 5, 6, 7]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        redis-version: [5, 6, 7, 8]
         redis-py-version: [3.5.0]
 
     steps:
@@ -48,8 +48,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        redis-version: [3, 4, 5, 6, 7]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        redis-version: [5, 6, 7, 8]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,8 +37,8 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        redis-version: [5, 6, 7]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        redis-version: [5, 6, 7, 8]
         redis-py-version: [5, 6]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name = "Selwin Ong", email = "selwin.ong@gmail.com" },
   { name = "Vincent Driessen", email = "vincent@3rdcloud.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -26,7 +26,6 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -99,7 +98,7 @@ cov = "pytest --cov=rq --cov-config=.coveragerc --cov-report=xml {args:tests}"
 typing = "mypy rq"
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 # Set what ruff should check for.
 # See https://beta.ruff.rs/docs/rules/ for a list of rules.

--- a/rq/job.py
+++ b/rq/job.py
@@ -10,7 +10,7 @@ import zlib
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 from redis import WatchError
@@ -548,7 +548,7 @@ class Job:
                 self._stopped_callback = None
 
         # After deserialization, _stopped_callback is either a callable or None, never UNEVALUATED
-        return cast(Optional[Callable[['Job', 'Redis'], Any]], self._stopped_callback)
+        return cast(Callable[['Job', 'Redis'], Any] | None, self._stopped_callback)
 
     @property
     def stopped_callback_timeout(self) -> int:
@@ -1360,7 +1360,7 @@ class Job:
                 self.enqueue_at_front = self.enqueue_at_front or depends_on_item.enqueue_at_front
                 self.allow_dependency_failures = self.allow_dependency_failures or depends_on_item.allow_failure
                 depends_on_list.extend(list(depends_on_item.dependencies))
-            elif isinstance(depends_on_item, (Job, str)):
+            elif isinstance(depends_on_item, Job | str):
                 depends_on_list.append(depends_on_item)
             else:
                 raise ValueError(

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -13,7 +13,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     NamedTuple,
-    Optional,
     cast,
 )
 
@@ -1535,7 +1534,7 @@ class Queue:
                 raise DequeueTimeout(timeout, queue_key)
             return queue_key, result
         else:  # non-blocking variant
-            result = cast(Optional[Any], connection.lmove(queue_key, intermediate_queue.key))
+            result = cast(Any | None, connection.lmove(queue_key, intermediate_queue.key))
             if result is not None:
                 return queue_key, result
             return None

--- a/rq/types.py
+++ b/rq/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from typing import TypeAlias
@@ -27,5 +27,5 @@ A simple helper definition for the `depends_on` parameter when creating a job.
 
 SuccessCallbackType = Callable[['Job', 'Redis', Any], Any]
 FailureCallbackType = Callable[
-    ['Job', 'Redis', Optional[type[BaseException]], Optional[BaseException], Optional[TracebackType]], Any
+    ['Job', 'Redis', type[BaseException] | None, BaseException | None, TracebackType | None], Any
 ]

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -234,7 +234,7 @@ class BaseWorker:
             self.pid = None
             self.ip_address = 'unknown'
 
-        if isinstance(exception_handlers, (list, tuple)):
+        if isinstance(exception_handlers, list | tuple):
             for handler in exception_handlers:
                 self.push_exc_handler(handler)
         elif exception_handlers is not None:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist=py39,py310,py311,py312,py313
+envlist=py310,py311,py312,py313
 
 [testenv]
 commands=pytest --cov rq --cov-config=.coveragerc --durations=5 {posargs}
@@ -18,11 +18,6 @@ passenv=
 ;     ruff
 ; commands =
 ;     ruff check rq tests
-
-[testenv:py39]
-skipdist = True
-basepython = python3.9
-deps = {[testenv]deps}
 
 [testenv:py310]
 skipdist = True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dropped support for Python 3.9; minimum required version is now 3.10.
  * Expanded testing matrix to include Redis 8 and Python 3.13.
  * Updated CI/CD workflows and development tooling accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rq/rq/pull/2404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->