### PR TITLE
Refactor how deferred jobs are enqueued

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### RQ 2.11.0 (unreleased)
+* Refactored how job dependencies are handled. Introduced `READY_TO_ENQUEUE` job status and ReadyJobRegistry. Thanks @selwin!
+
 ### RQ 2.10.0 (2026-06-20)
 * Added [webhook notifications](https://python-rq.org/docs/#webhooks) to notify external end points when a job finishes or fails. Thanks @selwin!
 * RQScheduler now has a stable identity and persisted metadata. Thanks @selwin!

--- a/docs/docs/jobs.md
+++ b/docs/docs/jobs.md
@@ -32,6 +32,7 @@ The status of a job can be one of the following:
 * `failed`: Jobs that encountered errors during execution or expired before being executed.
 * `started`: The job has started execution. This status includes the job execution support mechanisms, such as setting the worker name and setting up heartbeat information.
 * `deferred`: The job is not ready for execution because its dependencies have not finished successfully yet.
+* `ready_to_enqueue`: An internal, transient status for a job whose dependencies have completed and that is about to be enqueued. Jobs pass through it briefly during dependency resolution and crash recovery; it is not user-actionable.
 * `scheduled`: Jobs created to run at a future date or jobs that are retried after a retry interval.
 * `stopped`: The job was stopped because the worker was stopped.
 * `canceled`: The job has been manually canceled and will not be executed, even if it is part of a dependency chain.

--- a/rq/job.py
+++ b/rq/job.py
@@ -1192,14 +1192,16 @@ class Job:
         without worrying about the internals required to implement job
         cancellation.
 
-        You can enqueue the jobs dependents optionally,
-        Same pipelining behavior as Queue.enqueue_dependents on whether or not a pipeline is passed in.
+        You can optionally enqueue the job's dependents. When ``enqueue_dependents`` is
+        True, eligible dependents are moved deferred→ready atomically with this job's
+        CANCELED status, then enqueued onto their queues.
 
-        When called with ``pipeline=external_pipe`` AND ``enqueue_dependents=True``,
-        the caller owns the EXEC and is responsible for draining the returned mapping
-        via ``Queue.enqueue_ready_jobs_by_queue(mapping)`` after their EXEC. If skipped,
-        ``ReadyJobRegistry.cleanup()`` recovers the dependents later. On the no-pipeline
-        path, the drain happens internally before return.
+        On the no-pipeline path, the whole thing runs in cancel's own WATCH/MULTI/EXEC and
+        the dependents are enqueued before this method returns. When called with
+        ``pipeline=external_pipe``, the deferred→ready ops are appended to the caller's
+        transaction; the caller owns the EXEC and is responsible for draining the returned
+        mapping via ``Queue.enqueue_ready_jobs_by_queue(mapping)`` afterwards (otherwise
+        ``ReadyJobRegistry.cleanup()`` recovers the dependents later).
 
         Args:
             pipeline (Optional[Pipeline], optional): The Redis' pipeline to use. Defaults to None.
@@ -1226,24 +1228,22 @@ class Job:
                     name=self.origin, connection=self.connection, job_class=self.__class__, serializer=self.serializer
                 )
 
-                self.set_status(JobStatus.CANCELED, pipeline=pipe)
                 if enqueue_dependents:
                     # Only WATCH if no pipeline passed, otherwise caller is responsible
                     if pipeline is None:
                         pipe.watch(self.dependents_key)
-                    # Phase 1 — move dependents to ready.
-                    dependent_job_ids_by_queue = q.move_dependents_to_ready(
-                        self, pipeline=pipeline, exclude_job_id=self.id
-                    )
-                    # Phase 2 (no-pipeline path only) — drain immediately, because
-                    # move_dependents_to_ready committed its own transaction here and
-                    # this cancel may WATCH-retry below (which would reset the returned
-                    # mapping). Draining now mirrors the old single-call behavior; it is
-                    # safe across retries since enqueue_jobs skips already-queued jobs.
-                    # On the caller-owned pipeline path the external caller drains the
-                    # returned mapping after their EXEC.
-                    if pipeline is None:
-                        q.enqueue_ready_jobs_by_queue(dependent_job_ids_by_queue)
+                    # Move dependents to ready inside THIS transaction (pass pipe, not the
+                    # original pipeline arg) so the deferred→ready transition commits
+                    # atomically with the CANCELED status below. Reads run immediately while
+                    # watching; move() calls multi() once it has dependents to write.
+                    dependent_job_ids_by_queue = q.move_dependents_to_ready(self, pipeline=pipe, exclude_job_id=self.id)
+
+                # Ensure a transaction is open before buffering cancel's own writes. move()
+                # only calls multi() when there are dependents, so guard like the worker does.
+                if pipeline is None and not pipe.explicit_transaction:
+                    pipe.multi()
+
+                self.set_status(JobStatus.CANCELED, pipeline=pipe)
 
                 if remove_from_dependencies:
                     # Go through all dependencies and remove the current job from each dependency's dependents_key
@@ -1261,12 +1261,19 @@ class Job:
                 break
             except WatchError:
                 if pipeline is None:
+                    dependent_job_ids_by_queue = {}
                     continue
                 else:
                     # if the pipeline comes from the caller, we re-raise the
                     # exception as it is the responsibility of the caller to
                     # handle it
                     raise
+
+        # Drain ready dependents onto their queues only after the cancel transaction has
+        # committed. On the caller-owned pipeline path the external caller drains the
+        # returned mapping after their own EXEC.
+        if pipeline is None and enqueue_dependents:
+            q.enqueue_ready_jobs_by_queue(dependent_job_ids_by_queue)
 
         return dependent_job_ids_by_queue
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -1196,11 +1196,10 @@ class Job:
         Same pipelining behavior as Queue.enqueue_dependents on whether or not a pipeline is passed in.
 
         When called with ``pipeline=external_pipe`` AND ``enqueue_dependents=True``,
-        the caller owns the EXEC and is responsible for draining the returned
-        ``dependent_job_ids_by_queue`` via
-        ``Queue(origin).ready_job_registry.enqueue_jobs(ids)`` after their EXEC.
-        If skipped, ``ReadyJobRegistry.cleanup()`` recovers the dependents later.
-        On the no-pipeline path, the drain happens internally before return.
+        the caller owns the EXEC and is responsible for draining the returned mapping
+        via ``Queue.enqueue_ready_jobs_by_queue(mapping)`` after their EXEC. If skipped,
+        ``ReadyJobRegistry.cleanup()`` recovers the dependents later. On the no-pipeline
+        path, the drain happens internally before return.
 
         Args:
             pipeline (Optional[Pipeline], optional): The Redis' pipeline to use. Defaults to None.
@@ -1232,7 +1231,19 @@ class Job:
                     # Only WATCH if no pipeline passed, otherwise caller is responsible
                     if pipeline is None:
                         pipe.watch(self.dependents_key)
-                    dependent_job_ids_by_queue = q.enqueue_dependents(self, pipeline=pipeline, exclude_job_id=self.id)
+                    # Phase 1 — move dependents to ready.
+                    dependent_job_ids_by_queue = q.move_dependents_to_ready(
+                        self, pipeline=pipeline, exclude_job_id=self.id
+                    )
+                    # Phase 2 (no-pipeline path only) — drain immediately, because
+                    # move_dependents_to_ready committed its own transaction here and
+                    # this cancel may WATCH-retry below (which would reset the returned
+                    # mapping). Draining now mirrors the old single-call behavior; it is
+                    # safe across retries since enqueue_jobs skips already-queued jobs.
+                    # On the caller-owned pipeline path the external caller drains the
+                    # returned mapping after their EXEC.
+                    if pipeline is None:
+                        q.enqueue_ready_jobs_by_queue(dependent_job_ids_by_queue)
 
                 if remove_from_dependencies:
                     # Go through all dependencies and remove the current job from each dependency's dependents_key

--- a/rq/job.py
+++ b/rq/job.py
@@ -1268,6 +1268,13 @@ class Job:
                     # exception as it is the responsibility of the caller to
                     # handle it
                     raise
+            except Exception:
+                # Release the connection on any other error so a mid-transaction failure
+                # (after WATCH) doesn't abandon the pipeline while it still holds a
+                # connection in a WATCH state, leaking it from the pool.
+                if pipeline is None:
+                    pipe.reset()
+                raise
 
         # Drain ready dependents onto their queues only after the cancel transaction has
         # committed. On the caller-owned pipeline path the external caller drains the

--- a/rq/job.py
+++ b/rq/job.py
@@ -67,6 +67,7 @@ class JobStatus(str, Enum):
     SCHEDULED = 'scheduled'
     STOPPED = 'stopped'
     CANCELED = 'canceled'
+    READY_TO_ENQUEUE = 'ready_to_enqueue'
 
 
 def parse_job_id(job_or_execution_id: str) -> str:
@@ -466,6 +467,10 @@ class Job:
     @property
     def is_stopped(self) -> bool:
         return self.get_status() == JobStatus.STOPPED
+
+    @property
+    def is_ready_to_enqueue(self) -> bool:
+        return self.get_status() == JobStatus.READY_TO_ENQUEUE
 
     @property
     def _dependency_id(self):
@@ -1255,6 +1260,14 @@ class Job:
             from .registry import DeferredJobRegistry
 
             registry = DeferredJobRegistry(
+                self.origin, connection=self.connection, job_class=self.__class__, serializer=self.serializer
+            )
+            registry.remove(self, pipeline=pipeline)
+
+        elif self.is_ready_to_enqueue:
+            from .registry import ReadyJobRegistry
+
+            registry = ReadyJobRegistry(
                 self.origin, connection=self.connection, job_class=self.__class__, serializer=self.serializer
             )
             registry.remove(self, pipeline=pipeline)

--- a/rq/job.py
+++ b/rq/job.py
@@ -1158,7 +1158,7 @@ class Job:
         pipeline: Pipeline | None = None,
         enqueue_dependents: bool = False,
         remove_from_dependencies: bool = False,
-    ):
+    ) -> dict[str, list[str]]:
         """Cancels the given job, which will prevent the job from ever being
         ran (or inspected).
 
@@ -1169,9 +1169,20 @@ class Job:
         You can enqueue the jobs dependents optionally,
         Same pipelining behavior as Queue.enqueue_dependents on whether or not a pipeline is passed in.
 
+        When called with ``pipeline=external_pipe`` AND ``enqueue_dependents=True``,
+        the caller owns the EXEC and is responsible for draining the returned
+        ``dependent_job_ids_by_queue`` via
+        ``Queue(origin).ready_job_registry.enqueue_jobs(ids)`` after their EXEC.
+        If skipped, ``ReadyJobRegistry.cleanup()`` recovers the dependents later.
+        On the no-pipeline path, the drain happens internally before return.
+
         Args:
             pipeline (Optional[Pipeline], optional): The Redis' pipeline to use. Defaults to None.
             enqueue_dependents (bool, optional): Whether to enqueue dependents jobs. Defaults to False.
+
+        Returns:
+            Map of origin queue name → list of dependent job ids that were moved to
+            ready. Empty dict when ``enqueue_dependents=False`` or no eligible dependents.
 
         Raises:
             InvalidJobOperation: If the job has already been cancelled.
@@ -1182,6 +1193,7 @@ class Job:
         from .registry import CanceledJobRegistry
 
         pipe = pipeline or self.connection.pipeline()
+        dependent_job_ids_by_queue: dict[str, list[str]] = {}
 
         while True:
             try:
@@ -1194,7 +1206,7 @@ class Job:
                     # Only WATCH if no pipeline passed, otherwise caller is responsible
                     if pipeline is None:
                         pipe.watch(self.dependents_key)
-                    q.enqueue_dependents(self, pipeline=pipeline, exclude_job_id=self.id)
+                    dependent_job_ids_by_queue = q.enqueue_dependents(self, pipeline=pipeline, exclude_job_id=self.id)
 
                 if remove_from_dependencies:
                     # Go through all dependencies and remove the current job from each dependency's dependents_key
@@ -1218,6 +1230,8 @@ class Job:
                     # exception as it is the responsibility of the caller to
                     # handle it
                     raise
+
+        return dependent_job_ids_by_queue
 
     def requeue(self, at_front: bool = False) -> Job:
         """Requeues job

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1385,27 +1385,23 @@ class Queue:
 
         return job
 
-    def enqueue_dependents(
+    def move_dependents_to_ready(
         self,
         job: Job,
         pipeline: Pipeline | None = None,
         exclude_job_id: str | None = None,
         refresh_job_status: bool = True,
     ) -> dict[str, list[str]]:
-        """Move all of the given job's dependents whose dependencies are met into the
-        per-origin ReadyJobRegistry, then (on the no-pipeline path) drain them onto
-        their respective queues.
+        """Move the given job's eligible dependents from deferred to ready.
 
-        When called without a pipeline, this method uses WATCH/MULTI/EXEC and the
-        synchronous-visibility contract is preserved: by the time it returns, the
-        eligible dependents have been pushed onto their origin queues.
+        Selects dependents whose dependencies are met (and which aren't canceled) and
+        moves them into their origin ``ReadyJobRegistry`` via ``register_jobs``. This
+        does not push them onto the queue list; ``enqueue_ready_jobs_by_queue`` does that
+        with the returned mapping once the transition has committed.
 
-        When called with a caller-owned pipeline, only the deferred→ready ops are
-        appended; the caller is responsible for EXECing the pipeline and then
-        draining the returned ids via
-        ``Queue(origin).ready_job_registry.enqueue_jobs(ids)``. If the caller
-        skips the drain, ``ReadyJobRegistry.cleanup()`` recovers the dependents
-        later.
+        When ``pipeline`` is ``None`` this method runs its own WATCH/MULTI/EXEC. When a
+        pipeline is passed the ops are appended to the caller's transaction and the
+        caller is responsible for EXEC.
 
         Args:
             job: The job whose dependents to process.
@@ -1436,7 +1432,7 @@ class Queue:
                 if not dependent_job_ids:
                     break
 
-                jobs_to_enqueue = [
+                jobs_to_mark_ready = [
                     dependent_job
                     for dependent_job in self.job_class.fetch_many(
                         dependent_job_ids, connection=self.connection, serializer=self.serializer
@@ -1453,14 +1449,14 @@ class Queue:
 
                 pipe.multi()
 
-                if not jobs_to_enqueue:
+                if not jobs_to_mark_ready:
                     break
 
                 self.log.debug(
                     'Moving %d dependent jobs to ready for job %s: %s',
-                    len(jobs_to_enqueue),
+                    len(jobs_to_mark_ready),
                     job.id,
-                    [j.id for j in jobs_to_enqueue],
+                    [j.id for j in jobs_to_mark_ready],
                 )
 
                 # Group dependents by their origin queue so each lands in the correct
@@ -1468,7 +1464,7 @@ class Queue:
                 # WatchError-induced retry doesn't double-count.
                 job_ids_by_queue_name = {}
                 grouped: dict[str, list[Job]] = defaultdict(list)
-                for dependent in jobs_to_enqueue:
+                for dependent in jobs_to_mark_ready:
                     grouped[dependent.origin].append(dependent)
 
                 for queue_name, group in grouped.items():
@@ -1481,12 +1477,12 @@ class Queue:
                     target_registry.register_jobs(group, pipeline=pipe)
                     job_ids_by_queue_name[queue_name] = [j.id for j in group]
 
-                # Only delete dependents_key if all dependents have been enqueued
-                if len(jobs_to_enqueue) == len(dependent_job_ids):
+                # Only delete dependents_key if all dependents have been moved to ready
+                if len(jobs_to_mark_ready) == len(dependent_job_ids):
                     pipe.delete(dependents_key)
                 else:
-                    enqueued_job_ids = [j.id for j in jobs_to_enqueue]
-                    pipe.srem(dependents_key, *enqueued_job_ids)
+                    ready_job_ids = [j.id for j in jobs_to_mark_ready]
+                    pipe.srem(dependents_key, *ready_job_ids)
 
                 if pipeline is None:
                     pipe.execute()
@@ -1501,11 +1497,20 @@ class Queue:
                     # handle it
                     raise
 
-        # On the no-pipeline path, preserve the synchronous-visibility contract by
-        # draining the ready ids onto their origin queues before returning. On the
-        # caller-owned pipeline path, the caller does this after their EXEC.
-        if pipeline is None and job_ids_by_queue_name:
-            for queue_name, ids in job_ids_by_queue_name.items():
+        return job_ids_by_queue_name
+
+    def enqueue_ready_jobs_by_queue(self, job_ids_by_queue_name: dict[str, list[str]]) -> None:
+        """Enqueue ready dependents onto their origin queues.
+
+        Call with the mapping returned by ``move_dependents_to_ready`` once the
+        deferred→ready transition has committed. Per-queue failures are logged and left
+        for ``ReadyJobRegistry.cleanup()`` to recover; they are never lost.
+
+        Args:
+            job_ids_by_queue_name: Map of origin queue name → list of ready job ids.
+        """
+        for queue_name, ids in job_ids_by_queue_name.items():
+            try:
                 target_queue = self.__class__(
                     name=queue_name,
                     connection=self.connection,
@@ -1513,7 +1518,37 @@ class Queue:
                     serializer=self.serializer,
                 )
                 target_queue.ready_job_registry.enqueue_jobs(ids)
+            except Exception:
+                self.log.exception(
+                    'Failed to drain ready dependents for queue %s; leaving for ReadyJobRegistry.cleanup()',
+                    queue_name,
+                )
 
+    def enqueue_dependents(
+        self,
+        job: Job,
+        exclude_job_id: str | None = None,
+        refresh_job_status: bool = True,
+    ) -> dict[str, list[str]]:
+        """Move the given job's eligible dependents to ready and enqueue them.
+
+        High-level convenience that owns its transaction: it runs phase 1
+        (``move_dependents_to_ready``) and then phase 2 (``enqueue_ready_jobs_by_queue``).
+        Callers that need to bundle the deferred→ready transition into their own
+        transaction should call the two methods directly instead.
+
+        Args:
+            job: The job whose dependents to process.
+            exclude_job_id: Skip a specific dependent id.
+            refresh_job_status: Whether to refresh dependent status during dependency check.
+
+        Returns:
+            Map of origin queue name → list of dependent job ids that were moved to ready.
+        """
+        job_ids_by_queue_name = self.move_dependents_to_ready(
+            job, exclude_job_id=exclude_job_id, refresh_job_status=refresh_job_status
+        )
+        self.enqueue_ready_jobs_by_queue(job_ids_by_queue_name)
         return job_ids_by_queue_name
 
     def pop_job_id(self) -> str | None:

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -5,7 +5,7 @@ import sys
 import traceback
 import uuid
 import warnings
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from collections.abc import Callable, Iterable, Sequence
 from datetime import datetime, timedelta
 from functools import total_ordering
@@ -1364,23 +1364,37 @@ class Queue:
         pipeline: Pipeline | None = None,
         exclude_job_id: str | None = None,
         refresh_job_status: bool = True,
-    ):
-        """Enqueues all jobs in the given job's dependents set and clears it.
+    ) -> dict[str, list[str]]:
+        """Move all of the given job's dependents whose dependencies are met into the
+        per-origin ReadyJobRegistry, then (on the no-pipeline path) drain them onto
+        their respective queues.
 
-        When called without a pipeline, this method uses WATCH/MULTI/EXEC.
-        If you pass a pipeline, only MULTI is called. The rest is up to the
-        caller.
+        When called without a pipeline, this method uses WATCH/MULTI/EXEC and the
+        synchronous-visibility contract is preserved: by the time it returns, the
+        eligible dependents have been pushed onto their origin queues.
+
+        When called with a caller-owned pipeline, only the deferred→ready ops are
+        appended; the caller is responsible for EXECing the pipeline and then
+        draining the returned ids via
+        ``Queue(origin).ready_job_registry.enqueue_jobs(ids)``. If the caller
+        skips the drain, ``ReadyJobRegistry.cleanup()`` recovers the dependents
+        later.
 
         Args:
-            job (Job): The Job to enqueue the dependents
-            pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
-            exclude_job_id (Optional[str], optional): Whether to exclude the job id. Defaults to None.
-            refresh_job_status (bool): whether to refresh job status when checking for dependencies. Defaults to True.
+            job: The job whose dependents to process.
+            pipeline: Optional caller-owned pipeline.
+            exclude_job_id: Skip a specific dependent id.
+            refresh_job_status: Whether to refresh dependent status during dependency check.
+
+        Returns:
+            Map of origin queue name → list of dependent job ids that were moved to ready.
         """
-        from .registry import DeferredJobRegistry
+        from .registry import ReadyJobRegistry
 
         pipe = pipeline if pipeline is not None else self.connection.pipeline()
         dependents_key = job.dependents_key
+
+        job_ids_by_queue_name: dict[str, list[str]] = {}
 
         while True:
             try:
@@ -1416,44 +1430,35 @@ class Queue:
                     break
 
                 self.log.debug(
-                    'Enqueueing %d dependent jobs for job %s: %s',
+                    'Moving %d dependent jobs to ready for job %s: %s',
                     len(jobs_to_enqueue),
                     job.id,
                     [j.id for j in jobs_to_enqueue],
                 )
 
+                # Group dependents by their origin queue so each lands in the correct
+                # ReadyJobRegistry. Reset accumulator on each loop iteration so a
+                # WatchError-induced retry doesn't double-count.
+                job_ids_by_queue_name = {}
+                grouped: dict[str, list[Job]] = defaultdict(list)
                 for dependent in jobs_to_enqueue:
-                    enqueue_at_front = dependent.enqueue_at_front or False
+                    grouped[dependent.origin].append(dependent)
 
-                    registry = DeferredJobRegistry(
-                        dependent.origin, self.connection, job_class=self.job_class, serializer=self.serializer
+                for queue_name, group in grouped.items():
+                    target_registry = ReadyJobRegistry(
+                        name=queue_name,
+                        connection=self.connection,
+                        job_class=self.job_class,
+                        serializer=self.serializer,
                     )
-                    registry.remove(dependent, pipeline=pipe)
-                    self.log.debug('Removed job %s from DeferredJobRegistry', dependent.id)
-
-                    if dependent.origin == self.name:
-                        self.log.debug(
-                            'Enqueueing job %s to current queue %s (at_front=%s)',
-                            dependent.id,
-                            self.name,
-                            enqueue_at_front,
-                        )
-                        self._enqueue_job(dependent, pipeline=pipe, at_front=enqueue_at_front)
-                    else:
-                        self.log.debug(
-                            'Enqueueing job %s to different queue %s (at_front=%s)',
-                            dependent.id,
-                            dependent.origin,
-                            enqueue_at_front,
-                        )
-                        queue = self.__class__(name=dependent.origin, connection=self.connection)
-                        queue._enqueue_job(dependent, pipeline=pipe, at_front=enqueue_at_front)
+                    target_registry.register_jobs(group, pipeline=pipe)
+                    job_ids_by_queue_name[queue_name] = [j.id for j in group]
 
                 # Only delete dependents_key if all dependents have been enqueued
                 if len(jobs_to_enqueue) == len(dependent_job_ids):
                     pipe.delete(dependents_key)
                 else:
-                    enqueued_job_ids = [job.id for job in jobs_to_enqueue]
+                    enqueued_job_ids = [j.id for j in jobs_to_enqueue]
                     pipe.srem(dependents_key, *enqueued_job_ids)
 
                 if pipeline is None:
@@ -1461,12 +1466,28 @@ class Queue:
                 break
             except WatchError:
                 if pipeline is None:
+                    job_ids_by_queue_name = {}
                     continue
                 else:
                     # if the pipeline comes from the caller, we re-raise the
                     # exception as it it the responsibility of the caller to
                     # handle it
                     raise
+
+        # On the no-pipeline path, preserve the synchronous-visibility contract by
+        # draining the ready ids onto their origin queues before returning. On the
+        # caller-owned pipeline path, the caller does this after their EXEC.
+        if pipeline is None and job_ids_by_queue_name:
+            for queue_name, ids in job_ids_by_queue_name.items():
+                target_queue = self.__class__(
+                    name=queue_name,
+                    connection=self.connection,
+                    job_class=self.job_class,
+                    serializer=self.serializer,
+                )
+                target_queue.ready_job_registry.enqueue_jobs(ids)
+
+        return job_ids_by_queue_name
 
     def pop_job_id(self) -> str | None:
         """Pops a given job ID from this Redis queue.

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -469,6 +469,13 @@ class Queue:
         return DeferredJobRegistry(queue=self, job_class=self.job_class, serializer=self.serializer)
 
     @property
+    def ready_job_registry(self):
+        """Returns this queue's ReadyJobRegistry."""
+        from rq.registry import ReadyJobRegistry
+
+        return ReadyJobRegistry(queue=self, job_class=self.job_class, serializer=self.serializer)
+
+    @property
     def scheduled_job_registry(self):
         """Returns this queue's ScheduledJobRegistry."""
         from rq.registry import ScheduledJobRegistry

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1394,12 +1394,11 @@ class Queue:
     ) -> dict[str, list[str]]:
         """Move the given job's eligible dependents from deferred to ready.
 
-        Selects dependents whose dependencies are met (and which aren't canceled) and
-        moves them into their origin ``ReadyJobRegistry`` via ``register_jobs``. This
-        does not push them onto the queue list; ``enqueue_ready_jobs_by_queue`` does that
-        with the returned mapping once the transition has committed.
+        Move dependents whose dependencies are met (and which aren't canceled) to
+        `ReadyJobRegistry` via `register_jobs`. Usually followed up by
+        `enqueue_ready_jobs_by_queue` to enqueue the dependents.
 
-        When ``pipeline`` is ``None`` this method runs its own WATCH/MULTI/EXEC. When a
+        When `pipeline` is `None` this method runs its own WATCH/MULTI/EXEC. When a
         pipeline is passed the ops are appended to the caller's transaction and the
         caller is responsible for EXEC.
 
@@ -1502,10 +1501,6 @@ class Queue:
     def enqueue_ready_jobs_by_queue(self, job_ids_by_queue_name: dict[str, list[str]]) -> None:
         """Enqueue ready dependents onto their origin queues.
 
-        Call with the mapping returned by ``move_dependents_to_ready`` once the
-        deferred→ready transition has committed. Per-queue failures are logged and left
-        for ``ReadyJobRegistry.cleanup()`` to recover; they are never lost.
-
         Args:
             job_ids_by_queue_name: Map of origin queue name → list of ready job ids.
         """
@@ -1531,11 +1526,6 @@ class Queue:
         refresh_job_status: bool = True,
     ) -> dict[str, list[str]]:
         """Move the given job's eligible dependents to ready and enqueue them.
-
-        High-level convenience that owns its transaction: it runs phase 1
-        (``move_dependents_to_ready``) and then phase 2 (``enqueue_ready_jobs_by_queue``).
-        Callers that need to bundle the deferred→ready transition into their own
-        transaction should call the two methods directly instead.
 
         Args:
             job: The job whose dependents to process.

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -496,6 +496,28 @@ class DeferredJobRegistry(BaseRegistry):
         return connection.zadd(self.key, {job.id: score}, xx=xx)
 
 
+class ReadyJobRegistry(BaseRegistry):
+    """
+    Registry of jobs whose dependencies have been met and are awaiting
+    enqueue onto the queue list. This is a transient, internal recovery
+    state: the happy path enqueues these jobs synchronously after the
+    dependency transaction commits; if the process dies in between,
+    maintenance cleanup picks them up.
+    """
+
+    key_template = 'rq:ready:{0}'
+
+    def cleanup(self, timestamp: float | None = None, exception_handlers: list | None = None):
+        """Ready jobs don't expire based on time; recovery is wired up in a later phase."""
+        pass
+
+    def add(self, job: Job, ttl: int | None = None, pipeline: Pipeline | None = None, xx: bool = False) -> int:
+        """Adds a job to the ready registry, scored by creation time."""
+        score = current_timestamp()
+        connection = pipeline if pipeline is not None else self.connection
+        return connection.zadd(self.key, {job.id: score}, xx=xx)
+
+
 class ScheduledJobRegistry(BaseRegistry):
     """
     Registry of scheduled jobs.

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -509,7 +509,7 @@ class ReadyJobRegistry(BaseRegistry):
 
     key_template = 'rq:ready:{0}'
 
-    def cleanup(self, timestamp: float | None = None, exception_handlers: list | None = None):
+    def cleanup(self, timestamp: float | None = None, exception_handlers: list | None = None) -> list[Job]:
         """Recover any jobs that were left in the registry by enqueuing them onto the queue."""
         job_ids = [self.parse_job_id(job_id) for job_id in self.connection.zrange(self.key, 0, -1)]
         return self.enqueue_jobs(job_ids)
@@ -545,7 +545,7 @@ class ReadyJobRegistry(BaseRegistry):
             if job is None:
                 self.connection.zrem(self.key, job_id)
                 continue
-            if job.get_status() != JobStatus.READY_TO_ENQUEUE:
+            if job.get_status(refresh=False) != JobStatus.READY_TO_ENQUEUE:
                 self.connection.zrem(self.key, job_id)
                 continue
             try:
@@ -665,7 +665,7 @@ class CanceledJobRegistry(BaseRegistry):
 
 
 def clean_registries(queue: Queue, exception_handlers: list | None = None):
-    """Cleans StartedJobRegistry, FinishedJobRegistry and FailedJobRegistry, and DeferredJobRegistry of a queue.
+    """Cleans StartedJobRegistry, FinishedJobRegistry, FailedJobRegistry, DeferredJobRegistry, and ReadyJobRegistry.
 
     Args:
         queue (Queue): The queue to clean

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -8,6 +8,8 @@ import warnings
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
+from redis.exceptions import WatchError
+
 from rq.serializers import resolve_serializer
 
 from .defaults import DEFAULT_FAILURE_TTL
@@ -521,13 +523,16 @@ class ReadyJobRegistry(BaseRegistry):
     def enqueue_jobs(self, job_ids: list[str]) -> list[Job]:
         """Move jobs from the ready registry onto the queue list.
 
+        Uses optimistic locking (WATCH/MULTI) per job: if another caller mutates the
+        registry entry or the job's status between read and commit, this method skips
+        that job for now — a later cleanup pass revisits it. This guarantees no
+        duplicate enqueues at the cost of occasionally conceding a contended job.
+
         For each id:
           - if the job no longer exists, drop the stale registry entry;
-          - if the job's status is no longer READY_TO_ENQUEUE, drop the stale entry without enqueuing;
-          - otherwise remove from the registry and enqueue in one pipeline.
-
-        Failures for a single job are logged and leave that job in the registry so a
-        later cleanup can retry it; remaining jobs in the same call are still processed.
+          - if the job's status is no longer READY_TO_ENQUEUE under WATCH, remove the
+            stale entry inside the watched transaction;
+          - otherwise remove from the registry and enqueue atomically.
         """
         if not job_ids:
             return []
@@ -544,10 +549,28 @@ class ReadyJobRegistry(BaseRegistry):
                 self.connection.zrem(self.key, job_id)
                 continue
             try:
-                with self.connection.pipeline() as pipeline:
-                    self.remove(job, pipeline=pipeline)
-                    queue._enqueue_job(job, pipeline=pipeline, at_front=job.should_enqueue_at_front())
-                    pipeline.execute()
+                with self.connection.pipeline() as pipe:
+                    pipe.watch(self.key, job.key)
+
+                    # Claim check: this registry must still own the job id.
+                    if pipe.zscore(self.key, job.id) is None:
+                        pipe.unwatch()
+                        continue
+
+                    status = cast('bytes | str | None', pipe.hget(job.key, 'status'))
+                    if not status or JobStatus(as_text(status)) != JobStatus.READY_TO_ENQUEUE:
+                        pipe.multi()
+                        self.remove(job, pipeline=pipe)
+                        pipe.execute()
+                        continue
+
+                    pipe.multi()
+                    self.remove(job, pipeline=pipe)
+                    queue._enqueue_job(job, pipeline=pipe, at_front=job.should_enqueue_at_front())
+                    pipe.execute()
+            except WatchError:
+                logger.info('Ready job %s changed while enqueueing; skipping for now', job_id)
+                continue
             except Exception:
                 logger.exception('Failed to enqueue ready job %s; leaving in ReadyJobRegistry', job_id)
                 continue

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -508,14 +508,51 @@ class ReadyJobRegistry(BaseRegistry):
     key_template = 'rq:ready:{0}'
 
     def cleanup(self, timestamp: float | None = None, exception_handlers: list | None = None):
-        """Ready jobs don't expire based on time; recovery is wired up in a later phase."""
-        pass
+        """Recover any jobs that were left in the registry by enqueuing them onto the queue."""
+        job_ids = [self.parse_job_id(job_id) for job_id in self.connection.zrange(self.key, 0, -1)]
+        return self.enqueue_jobs(job_ids)
 
     def add(self, job: Job, ttl: int | None = None, pipeline: Pipeline | None = None, xx: bool = False) -> int:
         """Adds a job to the ready registry, scored by creation time."""
         score = current_timestamp()
         connection = pipeline if pipeline is not None else self.connection
         return connection.zadd(self.key, {job.id: score}, xx=xx)
+
+    def enqueue_jobs(self, job_ids: list[str]) -> list[Job]:
+        """Move jobs from the ready registry onto the queue list.
+
+        For each id:
+          - if the job no longer exists, drop the stale registry entry;
+          - if the job's status is no longer READY_TO_ENQUEUE, drop the stale entry without enqueuing;
+          - otherwise remove from the registry and enqueue in one pipeline.
+
+        Failures for a single job are logged and leave that job in the registry so a
+        later cleanup can retry it; remaining jobs in the same call are still processed.
+        """
+        if not job_ids:
+            return []
+
+        queue = Queue(name=self.name, connection=self.connection, job_class=self.job_class, serializer=self.serializer)
+        fetched = self.job_class.fetch_many(job_ids, connection=self.connection, serializer=self.serializer)
+
+        enqueued: list[Job] = []
+        for job_id, job in zip(job_ids, fetched):
+            if job is None:
+                self.connection.zrem(self.key, job_id)
+                continue
+            if job.get_status() != JobStatus.READY_TO_ENQUEUE:
+                self.connection.zrem(self.key, job_id)
+                continue
+            try:
+                with self.connection.pipeline() as pipeline:
+                    self.remove(job, pipeline=pipeline)
+                    queue._enqueue_job(job, pipeline=pipeline, at_front=job.should_enqueue_at_front())
+                    pipeline.execute()
+            except Exception:
+                logger.exception('Failed to enqueue ready job %s; leaving in ReadyJobRegistry', job_id)
+                continue
+            enqueued.append(job)
+        return enqueued
 
 
 class ScheduledJobRegistry(BaseRegistry):
@@ -623,5 +660,9 @@ def clean_registries(queue: Queue, exception_handlers: list | None = None):
     ).cleanup()
 
     DeferredJobRegistry(
+        name=queue.name, connection=queue.connection, job_class=queue.job_class, serializer=queue.serializer
+    ).cleanup()
+
+    ReadyJobRegistry(
         name=queue.name, connection=queue.connection, job_class=queue.job_class, serializer=queue.serializer
     ).cleanup()

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -5,6 +5,7 @@ import logging
 import time
 import traceback
 import warnings
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
@@ -519,6 +520,25 @@ class ReadyJobRegistry(BaseRegistry):
         score = current_timestamp()
         connection = pipeline if pipeline is not None else self.connection
         return connection.zadd(self.key, {job.id: score}, xx=xx)
+
+    def register_jobs(self, jobs: Sequence[Job], pipeline: Pipeline) -> None:
+        """Move dependents into the ready state inside the caller's watched transaction.
+
+        For each job, appends three ops to ``pipeline``:
+          1. remove from this queue's DeferredJobRegistry
+          2. set status to READY_TO_ENQUEUE
+          3. add to this ReadyJobRegistry
+
+        All jobs must belong to this registry's queue (``job.origin == self.name``).
+        The caller owns WATCH/MULTI/EXEC; this method only queues commands.
+        """
+        deferred_registry = DeferredJobRegistry(
+            name=self.name, connection=self.connection, job_class=self.job_class, serializer=self.serializer
+        )
+        for job in jobs:
+            deferred_registry.remove(job, pipeline=pipeline)
+            job.set_status(JobStatus.READY_TO_ENQUEUE, pipeline=pipeline)
+            self.add(job, pipeline=pipeline)
 
     def enqueue_jobs(self, job_ids: list[str]) -> list[Job]:
         """Move jobs from the ready registry onto the queue list.

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -1457,15 +1457,15 @@ class BaseWorker:
         with self.connection.pipeline() as pipeline:
             while True:
                 try:
-                    # if dependencies are inserted after enqueue_dependents
+                    # if dependencies are inserted after move_dependents_to_ready
                     # a WatchError is thrown by execute()
                     pipeline.watch(job.dependents_key)
-                    # enqueue_dependents might call multi() on the pipeline
-                    self.log.debug('Worker %s: enqueueing dependents of job %s', self.name, job.id)
-                    dependent_job_ids_by_queue = queue.enqueue_dependents(job, pipeline=pipeline)
+                    # move_dependents_to_ready might call multi() on the pipeline
+                    self.log.debug('Worker %s: moving dependents of job %s to ready', self.name, job.id)
+                    dependent_job_ids_by_queue = queue.move_dependents_to_ready(job, pipeline=pipeline)
 
                     if not pipeline.explicit_transaction:
-                        # enqueue_dependents didn't call multi after all!
+                        # move_dependents_to_ready didn't call multi after all!
                         # We have to do it ourselves to make sure everything runs in a transaction
                         self.log.debug('Worker %s: calling multi() on pipeline for job %s', self.name, job.id)
                         pipeline.multi()
@@ -1503,25 +1503,9 @@ class BaseWorker:
                     pipeline.execute()
 
                     # Drain ready dependents onto their origin queues now that the
-                    # deferred→ready transition has committed. Failures here fall
-                    # through to ReadyJobRegistry.cleanup() for recovery.
-                    for queue_name, ids in dependent_job_ids_by_queue.items():
-                        try:
-                            target_queue = self.queue_class(
-                                name=queue_name,
-                                connection=self.connection,
-                                job_class=self.job_class,
-                                serializer=self.serializer,
-                            )
-                            target_queue.ready_job_registry.enqueue_jobs(ids)
-                        except Exception:
-                            self.log.exception(
-                                'Worker %s: failed to drain ready dependents for queue %s (job %s); '
-                                'leaving for ReadyJobRegistry.cleanup()',
-                                self.name,
-                                queue_name,
-                                job.id,
-                            )
+                    # deferred→ready transition has committed. Per-queue failures are
+                    # logged and left for ReadyJobRegistry.cleanup() to recover.
+                    queue.enqueue_ready_jobs_by_queue(dependent_job_ids_by_queue)
 
                     assert job.started_at
                     assert job.ended_at

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -1443,7 +1443,7 @@ class BaseWorker:
                     pipeline.watch(job.dependents_key)
                     # enqueue_dependents might call multi() on the pipeline
                     self.log.debug('Worker %s: enqueueing dependents of job %s', self.name, job.id)
-                    queue.enqueue_dependents(job, pipeline=pipeline)
+                    dependent_job_ids_by_queue = queue.enqueue_dependents(job, pipeline=pipeline)
 
                     if not pipeline.explicit_transaction:
                         # enqueue_dependents didn't call multi after all!
@@ -1482,6 +1482,27 @@ class BaseWorker:
                     self.cleanup_execution(job, pipeline=pipeline)
 
                     pipeline.execute()
+
+                    # Drain ready dependents onto their origin queues now that the
+                    # deferred→ready transition has committed. Failures here fall
+                    # through to ReadyJobRegistry.cleanup() for recovery.
+                    for queue_name, ids in dependent_job_ids_by_queue.items():
+                        try:
+                            target_queue = self.queue_class(
+                                name=queue_name,
+                                connection=self.connection,
+                                job_class=self.job_class,
+                                serializer=self.serializer,
+                            )
+                            target_queue.ready_job_registry.enqueue_jobs(ids)
+                        except Exception:
+                            self.log.exception(
+                                'Worker %s: failed to drain ready dependents for queue %s (job %s); '
+                                'leaving for ReadyJobRegistry.cleanup()',
+                                self.name,
+                                queue_name,
+                                job.id,
+                            )
 
                     assert job.started_at
                     assert job.ended_at

--- a/tests/test_job_dependency.py
+++ b/tests/test_job_dependency.py
@@ -269,8 +269,7 @@ class TestJobDependency(RQTestCase):
             pipe.set('some:key', b'some:other:value')
             pipe.execute()
         # Caller-owned pipeline path: drain ready dependents now that EXEC committed
-        for queue_name, ids in dependent_job_ids_by_queue.items():
-            Queue(queue_name, connection=self.connection).ready_job_registry.enqueue_jobs(ids)
+        queue.enqueue_ready_jobs_by_queue(dependent_job_ids_by_queue)
         self.assertEqual(self.connection.get('some:key'), b'some:other:value')
         self.assertEqual(1, len(queue.get_jobs()))
         self.assertEqual(0, len(queue.deferred_job_registry))

--- a/tests/test_job_dependency.py
+++ b/tests/test_job_dependency.py
@@ -264,9 +264,12 @@ class TestJobDependency(RQTestCase):
         with self.connection.pipeline() as pipe:
             pipe.watch('some:key')
             self.assertEqual(self.connection.get('some:key'), b'some:value')
-            dependency.cancel(pipeline=pipe, enqueue_dependents=True)
+            dependent_job_ids_by_queue = dependency.cancel(pipeline=pipe, enqueue_dependents=True)
             pipe.set('some:key', b'some:other:value')
             pipe.execute()
+        # Caller-owned pipeline path: drain ready dependents now that EXEC committed
+        for queue_name, ids in dependent_job_ids_by_queue.items():
+            Queue(queue_name, connection=self.connection).ready_job_registry.enqueue_jobs(ids)
         self.assertEqual(self.connection.get('some:key'), b'some:other:value')
         self.assertEqual(1, len(queue.get_jobs()))
         self.assertEqual(0, len(queue.deferred_job_registry))

--- a/tests/test_job_dependency.py
+++ b/tests/test_job_dependency.py
@@ -1,5 +1,6 @@
 import time
 from datetime import timedelta
+from unittest import mock
 
 from redis import WatchError
 
@@ -281,6 +282,74 @@ class TestJobDependency(RQTestCase):
         # If job is deleted, it's also removed from CanceledJobRegistry
         dependency.delete()
         self.assertNotIn(dependency, registry)
+
+    def test_cancel_does_not_queue_dependents_before_cancel_commits(self):
+        """No dependent reaches the queue unless the cancel transaction commits."""
+        queue = Queue(connection=self.connection)
+        job_1 = queue.enqueue(fixtures.say_hello)
+        job_2 = queue.enqueue(fixtures.say_hello, depends_on=job_1)
+
+        # Raise on the last write before the cancel pipeline executes, so the transaction
+        # (including the buffered deferred→ready ops) never commits.
+        with mock.patch.object(CanceledJobRegistry, 'add', side_effect=RuntimeError()):
+            with self.assertRaises(RuntimeError):
+                job_1.cancel(enqueue_dependents=True)
+
+        # Parent cancellation never committed (get_status refreshes from Redis):
+        self.assertNotEqual(job_1.get_status(), JobStatus.CANCELED)
+        # Dependent was NOT prematurely advanced — still deferred, not moved to ready, not queued.
+        # Use cleanup=False on the ready registry: a cleanup-triggering accessor would drain it.
+        self.assertEqual(job_2.get_status(), JobStatus.DEFERRED)
+        self.assertIn(job_2.id, queue.deferred_job_registry.get_job_ids(cleanup=False))
+        self.assertNotIn(job_2.id, queue.ready_job_registry.get_job_ids(cleanup=False))
+        self.assertNotIn(job_2.id, queue.get_job_ids())
+
+    def test_cancel_post_commit_drain_failure_leaves_consistent_state(self):
+        """If draining fails after the cancel commits, the parent is canceled and the
+        dependent is parked in the ready registry (recovery itself is covered by the
+        ReadyJobRegistry cleanup tests)."""
+        queue = Queue(connection=self.connection)
+        job_1 = queue.enqueue(fixtures.say_hello)
+        job_2 = queue.enqueue(fixtures.say_hello, depends_on=job_1)
+
+        # Fail before any drain happens: CANCELED + deferred→ready have already committed.
+        with mock.patch.object(Queue, 'enqueue_ready_jobs_by_queue', side_effect=RuntimeError()):
+            with self.assertRaises(RuntimeError):
+                job_1.cancel(enqueue_dependents=True)
+
+        self.assertEqual(job_1.get_status(), JobStatus.CANCELED)
+        self.assertEqual(job_2.get_status(), JobStatus.READY_TO_ENQUEUE)
+        self.assertIn(job_2.id, queue.ready_job_registry.get_job_ids(cleanup=False))
+        self.assertNotIn(job_2.id, queue.get_job_ids())
+
+    def test_cancel_enqueue_dependents_retries_cleanly_on_watcherror(self):
+        """A single WatchError on the cancel transaction retries without double-enqueueing."""
+        queue = Queue(connection=self.connection)
+        job_1 = queue.enqueue(fixtures.say_hello)
+        job_2 = queue.enqueue(fixtures.say_hello, depends_on=job_1)
+
+        from redis.client import Pipeline
+
+        original_execute = Pipeline.execute
+        calls = {'n': 0}
+
+        def flaky_execute(self_pipe, *args, **kwargs):
+            if getattr(self_pipe, 'watching', False) and calls['n'] == 0:
+                calls['n'] += 1
+                # Real Pipeline.execute resets the pipe in a finally even on WatchError;
+                # mirror that so the cancel retry starts from a clean pipe.
+                self_pipe.reset()
+                raise WatchError('simulated contention')
+            return original_execute(self_pipe, *args, **kwargs)
+
+        with mock.patch('redis.client.Pipeline.execute', flaky_execute):
+            job_1.cancel(enqueue_dependents=True)
+
+        self.assertEqual(job_1.get_status(), JobStatus.CANCELED)
+        self.assertEqual(job_2.get_status(), JobStatus.QUEUED)
+        self.assertEqual(queue.get_job_ids().count(job_2.id), 1)
+        self.assertEqual(len(queue.deferred_job_registry), 0)
+        self.assertEqual(queue.ready_job_registry.get_job_ids(cleanup=False), [])
 
     def test_canceling_job_removes_it_from_dependency_dependents_key(self):
         """Cancel child jobs and verify their IDs are removed from the parent's dependents_key."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -341,13 +341,14 @@ class TestReadyJobRegistry(RQTestCase):
         """Adding/removing a job to ReadyJobRegistry."""
         queue = Queue(connection=self.connection)
         job = queue.enqueue(say_hello)
+        job.set_status(JobStatus.READY_TO_ENQUEUE)
         self.registry.add(job)
         self.assertIn(job, self.registry)
-        self.assertEqual(self.registry.get_job_ids(), [job.id])
+        self.assertEqual(self.registry.get_job_ids(cleanup=False), [job.id])
 
         self.registry.remove(job)
         self.assertNotIn(job, self.registry)
-        self.assertEqual(self.registry.get_job_ids(), [])
+        self.assertEqual(self.registry.get_job_ids(cleanup=False), [])
 
     def test_queue_property(self):
         """Queue.ready_job_registry returns a ReadyJobRegistry bound to the queue."""
@@ -374,6 +375,107 @@ class TestReadyJobRegistry(RQTestCase):
         self.assertFalse(job.is_ready_to_enqueue)
         job.set_status(JobStatus.READY_TO_ENQUEUE)
         self.assertTrue(job.is_ready_to_enqueue)
+
+    def test_enqueue_jobs_moves_ready_jobs_to_queue(self):
+        """enqueue_jobs() enqueues READY_TO_ENQUEUE jobs (respecting enqueue_at_front),
+        sets their status to QUEUED, and removes them from the registry."""
+        queue = Queue(connection=self.connection)
+        sentinel = queue.enqueue(say_hello)
+
+        back_job = queue.enqueue(say_hello)
+        queue.remove(back_job)
+        back_job.set_status(JobStatus.READY_TO_ENQUEUE)
+        self.registry.add(back_job)
+
+        enqueued_jobs = self.registry.enqueue_jobs([back_job.id])
+        self.assertEqual(enqueued_jobs, [back_job])
+        self.assertNotIn(back_job.id, self.registry.get_job_ids(cleanup=False))
+        self.assertEqual(Job.fetch(back_job.id, connection=self.connection).get_status(), JobStatus.QUEUED)
+        self.assertEqual(queue.get_job_ids(), [sentinel.id, back_job.id])
+
+        front_job = queue.enqueue(say_hello)
+        queue.remove(front_job)
+        front_job.enqueue_at_front = True
+        front_job.save()
+        front_job.set_status(JobStatus.READY_TO_ENQUEUE)
+        self.registry.add(front_job)
+
+        self.registry.enqueue_jobs([front_job.id])
+        self.assertEqual(queue.get_job_ids(), [front_job.id, sentinel.id, back_job.id])
+
+    def test_enqueue_jobs_drops_stale_entries(self):
+        """Stale entries — wrong status or missing job — are removed without enqueuing."""
+        queue = Queue(connection=self.connection)
+
+        # Wrong status: registry says ready, but job's status was changed
+        stale_status_job = queue.enqueue(say_hello)
+        queue.remove(stale_status_job)
+        self.registry.add(stale_status_job)
+        stale_status_job.set_status(JobStatus.CANCELED)
+
+        # Missing job: dangling registry entry pointing at a deleted job
+        missing_job = queue.enqueue(say_hello)
+        missing_job.delete()
+        self.connection.zadd(self.registry.key, {missing_job.id: current_timestamp()})
+
+        self.assertEqual(self.connection.zcard(self.registry.key), 2)
+
+        enqueued_jobs = self.registry.enqueue_jobs([stale_status_job.id, missing_job.id])
+
+        self.assertEqual(enqueued_jobs, [])
+        self.assertEqual(self.connection.zcard(self.registry.key), 0)
+        self.assertEqual(queue.get_job_ids(), [])
+
+    def test_enqueue_jobs_isolates_failures(self):
+        """A failure on one job leaves it in the registry; other jobs still enqueue."""
+        queue = Queue(connection=self.connection)
+        job_a = queue.enqueue(say_hello)
+        job_b = queue.enqueue(say_hello)
+        queue.remove(job_a)
+        queue.remove(job_b)
+        for job in (job_a, job_b):
+            job.set_status(JobStatus.READY_TO_ENQUEUE)
+            self.registry.add(job)
+
+        original = Queue._enqueue_job
+
+        def fake_enqueue(self_queue, job, *args, **kwargs):
+            if job.id == job_b.id:
+                raise RuntimeError('boom')
+            return original(self_queue, job, *args, **kwargs)
+
+        with mock.patch.object(Queue, '_enqueue_job', fake_enqueue):
+            enqueued_jobs = self.registry.enqueue_jobs([job_a.id, job_b.id])
+
+        self.assertEqual(enqueued_jobs, [job_a])
+        self.assertIn(job_b.id, self.registry.get_job_ids(cleanup=False))
+        self.assertNotIn(job_a.id, self.registry.get_job_ids(cleanup=False))
+
+    def test_cleanup_recovers_ready_jobs(self):
+        """ReadyJobRegistry.cleanup() enqueues anything left in the registry."""
+        queue = Queue(connection=self.connection)
+        job = queue.enqueue(say_hello)
+        queue.remove(job)
+        job.set_status(JobStatus.READY_TO_ENQUEUE)
+        self.registry.add(job)
+
+        self.registry.cleanup()
+
+        self.assertEqual(self.registry.count, 0)
+        self.assertIn(job.id, queue.get_job_ids())
+
+    def test_clean_registries_invokes_ready_cleanup(self):
+        """clean_registries(queue) recovers jobs from the ready registry."""
+        queue = Queue(connection=self.connection)
+        job = queue.enqueue(say_hello)
+        queue.remove(job)
+        job.set_status(JobStatus.READY_TO_ENQUEUE)
+        self.registry.add(job)
+
+        clean_registries(queue)
+
+        self.assertEqual(self.registry.count, 0)
+        self.assertIn(job.id, queue.get_job_ids())
 
 
 class TestFailedJobRegistry(RQTestCase):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -464,6 +464,55 @@ class TestReadyJobRegistry(RQTestCase):
         self.assertEqual(self.registry.count, 0)
         self.assertIn(job.id, queue.get_job_ids())
 
+    def test_enqueue_jobs_concedes_on_watcherror(self):
+        """On WatchError, the loser returns [] and does not enqueue the job."""
+        from redis.client import Pipeline
+        from redis.exceptions import WatchError
+
+        queue = Queue(connection=self.connection)
+        job = Job.create(say_hello, connection=self.connection, origin=queue.name, status=JobStatus.READY_TO_ENQUEUE)
+        job.save()
+        self.registry.add(job)
+
+        original_execute = Pipeline.execute
+
+        def fake_execute(self_pipe, *args, **kwargs):
+            if getattr(self_pipe, 'watching', False):
+                raise WatchError('simulated contention')
+            return original_execute(self_pipe, *args, **kwargs)
+
+        with mock.patch('redis.client.Pipeline.execute', fake_execute):
+            enqueued_jobs = self.registry.enqueue_jobs([job.id])
+
+        self.assertEqual(enqueued_jobs, [])
+        # Loser did not enqueue — no duplicate
+        self.assertEqual(queue.get_job_ids().count(job.id), 0)
+        # EXEC aborted, so the watched zrem didn't fire — entry remains for next cleanup
+        self.assertIn(job.id, self.registry.get_job_ids(cleanup=False))
+
+    def test_enqueue_jobs_drops_stale_status_under_watch(self):
+        """If the watched re-read finds non-READY status, the entry is dropped inside MULTI."""
+        from redis.client import Pipeline
+
+        queue = Queue(connection=self.connection)
+        job = Job.create(say_hello, connection=self.connection, origin=queue.name, status=JobStatus.READY_TO_ENQUEUE)
+        job.save()
+        self.registry.add(job)
+
+        original_hget = Pipeline.hget
+
+        def fake_hget(self_pipe, name, key):
+            if name == job.key and key == 'status':
+                return b'canceled'
+            return original_hget(self_pipe, name, key)
+
+        with mock.patch('redis.client.Pipeline.hget', fake_hget):
+            enqueued_jobs = self.registry.enqueue_jobs([job.id])
+
+        self.assertEqual(enqueued_jobs, [])
+        self.assertEqual(self.connection.zcard(self.registry.key), 0)
+        self.assertNotIn(job.id, queue.get_job_ids())
+
     def test_clean_registries_invokes_ready_cleanup(self):
         """clean_registries(queue) recovers jobs from the ready registry."""
         queue = Queue(connection=self.connection)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -546,6 +546,28 @@ class TestReadyJobRegistry(RQTestCase):
         self.assertEqual(self.registry.count, 0)
         self.assertIn(job.id, queue.get_job_ids())
 
+    def test_enqueue_ready_jobs_by_queue_isolates_drain_failure(self):
+        """A drain failure is swallowed; the job stays ready and is recovered by cleanup."""
+        queue = Queue(connection=self.connection)
+        job = queue.enqueue(say_hello)
+        queue.remove(job)
+        job.set_status(JobStatus.READY_TO_ENQUEUE)
+        self.registry.add(job)
+
+        # Patch scoped to ONLY the drain call — if it leaked into clean_registries below,
+        # recovery would fail for the wrong reason.
+        with mock.patch.object(ReadyJobRegistry, 'enqueue_jobs', side_effect=RuntimeError('boom')):
+            queue.enqueue_ready_jobs_by_queue({queue.name: [job.id]})  # must not raise
+
+        self.assertEqual(Job.fetch(job.id, connection=self.connection).get_status(), JobStatus.READY_TO_ENQUEUE)
+        self.assertNotIn(job.id, queue.get_job_ids())
+        self.assertIn(job.id, self.registry.get_job_ids(cleanup=False))
+
+        # Real enqueue_jobs (patch lifted) recovers the job.
+        clean_registries(queue)
+        self.assertEqual(self.registry.count, 0)
+        self.assertIn(job.id, queue.get_job_ids())
+
 
 class TestFailedJobRegistry(RQTestCase):
     def test_default_failure_ttl(self):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -16,6 +16,7 @@ from rq.registry import (
     DeferredJobRegistry,
     FailedJobRegistry,
     FinishedJobRegistry,
+    ReadyJobRegistry,
     StartedJobRegistry,
     clean_registries,
 )
@@ -329,6 +330,50 @@ class TestDeferredRegistry(RQTestCase):
         self.assertEqual(self.registry.count, 1)
         self.registry.cleanup()
         self.assertEqual(self.registry.count, 1)
+
+
+class TestReadyJobRegistry(RQTestCase):
+    def setUp(self):
+        super().setUp()
+        self.registry = ReadyJobRegistry(connection=self.connection)
+
+    def test_add_and_remove(self):
+        """Adding/removing a job to ReadyJobRegistry."""
+        queue = Queue(connection=self.connection)
+        job = queue.enqueue(say_hello)
+        self.registry.add(job)
+        self.assertIn(job, self.registry)
+        self.assertEqual(self.registry.get_job_ids(), [job.id])
+
+        self.registry.remove(job)
+        self.assertNotIn(job, self.registry)
+        self.assertEqual(self.registry.get_job_ids(), [])
+
+    def test_queue_property(self):
+        """Queue.ready_job_registry returns a ReadyJobRegistry bound to the queue."""
+        queue = Queue('foo', connection=self.connection)
+        registry = queue.ready_job_registry
+        self.assertIsInstance(registry, ReadyJobRegistry)
+        self.assertEqual(registry.key, 'rq:ready:foo')
+
+    def test_delete_removes_ready_job_from_registry(self):
+        """Deleting a READY_TO_ENQUEUE job removes it from ReadyJobRegistry."""
+        queue = Queue(connection=self.connection)
+        job = queue.enqueue(say_hello)
+        job.set_status(JobStatus.READY_TO_ENQUEUE)
+        self.registry.add(job)
+        self.assertIn(job, self.registry)
+
+        job.delete()
+        self.assertNotIn(job, self.registry)
+
+    def test_job_is_ready_to_enqueue(self):
+        """Job.is_ready_to_enqueue reflects the READY_TO_ENQUEUE status."""
+        queue = Queue(connection=self.connection)
+        job = queue.enqueue(say_hello)
+        self.assertFalse(job.is_ready_to_enqueue)
+        job.set_status(JobStatus.READY_TO_ENQUEUE)
+        self.assertTrue(job.is_ready_to_enqueue)
 
 
 class TestFailedJobRegistry(RQTestCase):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -441,7 +441,7 @@ class TestReadyJobRegistry(RQTestCase):
 
         def fake_enqueue(self_queue, job, *args, **kwargs):
             if job.id == job_b.id:
-                raise RuntimeError('boom')
+                raise RuntimeError()
             return original(self_queue, job, *args, **kwargs)
 
         with mock.patch.object(Queue, '_enqueue_job', fake_enqueue):
@@ -556,7 +556,7 @@ class TestReadyJobRegistry(RQTestCase):
 
         # Patch scoped to ONLY the drain call — if it leaked into clean_registries below,
         # recovery would fail for the wrong reason.
-        with mock.patch.object(ReadyJobRegistry, 'enqueue_jobs', side_effect=RuntimeError('boom')):
+        with mock.patch.object(ReadyJobRegistry, 'enqueue_jobs', side_effect=RuntimeError()):
             queue.enqueue_ready_jobs_by_queue({queue.name: [job.id]})  # must not raise
 
         self.assertEqual(Job.fetch(job.id, connection=self.connection).get_status(), JobStatus.READY_TO_ENQUEUE)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -513,6 +513,26 @@ class TestReadyJobRegistry(RQTestCase):
         self.assertEqual(self.connection.zcard(self.registry.key), 0)
         self.assertNotIn(job.id, queue.get_job_ids())
 
+    def test_register_jobs_moves_deferred_jobs_to_ready(self):
+        """register_jobs() appends deferred-remove + status-set + ready-add to the caller's pipeline."""
+        queue = Queue(connection=self.connection)
+        deferred_registry = DeferredJobRegistry(connection=self.connection)
+
+        job = Job.create(say_hello, connection=self.connection, origin=queue.name, status=JobStatus.DEFERRED)
+        job.save()
+        deferred_registry.add(job)
+        self.assertIn(job.id, deferred_registry.get_job_ids())
+
+        with self.connection.pipeline() as pipeline:
+            pipeline.watch(self.registry.key)
+            pipeline.multi()
+            self.registry.register_jobs([job], pipeline=pipeline)
+            pipeline.execute()
+
+        self.assertNotIn(job.id, deferred_registry.get_job_ids())
+        self.assertIn(job.id, self.registry.get_job_ids(cleanup=False))
+        self.assertEqual(Job.fetch(job.id, connection=self.connection).get_status(), JobStatus.READY_TO_ENQUEUE)
+
     def test_clean_registries_invokes_ready_cleanup(self):
         """clean_registries(queue) recovers jobs from the ready registry."""
         queue = Queue(connection=self.connection)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1150,18 +1150,19 @@ class TestWorker(RQTestCase):
     def test_job_dependency_race_condition(self):
         """Dependencies added while the job gets finished shouldn't get lost."""
 
-        # This patches the enqueue_dependents to enqueue a new dependency AFTER
-        # the original code was executed.
-        orig_enqueue_dependents = Queue.enqueue_dependents
+        # This patches move_dependents_to_ready (the method the worker calls inside its
+        # watched transaction) to enqueue a new dependency AFTER the original code ran,
+        # forcing the WatchError + retry the test exercises.
+        orig_move_dependents_to_ready = Queue.move_dependents_to_ready
 
-        def new_enqueue_dependents(self, job, *args, **kwargs):
-            result = orig_enqueue_dependents(self, job, *args, **kwargs)
+        def new_move_dependents_to_ready(self, job, *args, **kwargs):
+            result = orig_move_dependents_to_ready(self, job, *args, **kwargs)
             if hasattr(Queue, '_add_enqueue') and Queue._add_enqueue is not None and Queue._add_enqueue.id == job.id:
                 Queue._add_enqueue = None
                 Queue(connection=self.connection).enqueue_call(say_hello, depends_on=job)
             return result
 
-        Queue.enqueue_dependents = new_enqueue_dependents
+        Queue.move_dependents_to_ready = new_move_dependents_to_ready
 
         q = Queue(connection=self.connection)
         w = Worker([q])

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1154,10 +1154,11 @@ class TestWorker(RQTestCase):
         orig_enqueue_dependents = Queue.enqueue_dependents
 
         def new_enqueue_dependents(self, job, *args, **kwargs):
-            orig_enqueue_dependents(self, job, *args, **kwargs)
+            result = orig_enqueue_dependents(self, job, *args, **kwargs)
             if hasattr(Queue, '_add_enqueue') and Queue._add_enqueue is not None and Queue._add_enqueue.id == job.id:
                 Queue._add_enqueue = None
                 Queue(connection=self.connection).enqueue_call(say_hello, depends_on=job)
+            return result
 
         Queue.enqueue_dependents = new_enqueue_dependents
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new internal `READY_TO_ENQUEUE` job status and a readiness registry to track, enqueue, and recover dependency-satisfied jobs.
  * Added `Queue.ready_job_registry` plus new queue helpers to move dependents into “ready” and later enqueue them per queue.
* **Behavior Changes / API Updates**
  * `Job.cancel(..., enqueue_dependents=True)` now returns `dict[str, list[str]]` of dependent job IDs grouped by queue.
  * `Queue.enqueue_dependents(...)` no longer accepts a pipeline argument and now returns `dict[str, list[str]]`.
  * Worker dependent enqueueing is now a two-phase “mark ready” then “enqueue after commit” flow.
* **Tests / Documentation**
  * Expanded coverage for the new readiness behavior and updated job status docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->