### PR TITLE
SpawnWorker should use user specified serializer

### DIFF
--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 import math
 import os
@@ -177,6 +178,12 @@ class BaseWorker:
 
         self.version: str = VERSION
         self.python_version: str = sys.version
+        if serializer is None or isinstance(serializer, str):
+            self._serializer_arg: str | None = serializer
+        elif inspect.ismodule(serializer):
+            self._serializer_arg = serializer.__name__
+        else:
+            self._serializer_arg = f'{serializer.__module__}.{serializer.__qualname__}'  # type: ignore[attr-defined]
         self.serializer = resolve_serializer(serializer)
         self.execution: Execution | None = None
 

--- a/rq/worker/worker_classes.py
+++ b/rq/worker/worker_classes.py
@@ -189,13 +189,13 @@ from rq.executions import Execution
 
 # Recreate worker instance
 redis = Redis(**{redis_kwargs!r})
-worker = Worker.find_by_key({self.key!r}, connection=redis)
+worker = Worker.find_by_key({self.key!r}, connection=redis, serializer={self._serializer_arg!r})
 if not worker:
     sys.exit(1)
 
 # Reconstruct job, queue and execution objects
-job = Job.fetch({job.id!r}, connection=worker.connection)
-queue = Queue({queue.name!r}, connection=worker.connection)
+job = Job.fetch({job.id!r}, connection=worker.connection, serializer=worker.serializer)
+queue = Queue({queue.name!r}, connection=worker.connection, serializer=worker.serializer)
 execution_id = os.environ["RQ_EXECUTION_ID"]
 worker.execution = Execution.fetch(execution_id, job.id, connection=worker.connection)
 

--- a/tests/test_spawn_worker.py
+++ b/tests/test_spawn_worker.py
@@ -8,6 +8,7 @@ from rq import Queue
 from rq.job import Job
 from rq.registry import FailedJobRegistry, FinishedJobRegistry
 from rq.results import Result
+from rq.serializers import JSONSerializer
 from rq.worker import SpawnWorker
 from tests import RQTestCase, slow
 from tests.fixtures import (
@@ -53,6 +54,30 @@ class TestWorker(RQTestCase):
 
         self.assertNotIn('driver_info', redis_kwargs)
         self.assertIn('driver_info', worker.connection.connection_pool.connection_kwargs)
+
+    def test_worker_normalizes_serializer_arg_for_spawn(self):
+        """_serializer_arg is normalized to str|None so it can be safely embedded in the child source."""
+        import json
+
+        from rq.serializers import PickleSerializer, resolve_serializer
+
+        queue = Queue('foo', connection=self.connection)
+
+        worker = SpawnWorker([queue])
+        self.assertIsNone(worker._serializer_arg)
+        self.assertIs(resolve_serializer(worker._serializer_arg), PickleSerializer)
+
+        worker = SpawnWorker([queue], serializer='json')
+        self.assertEqual(worker._serializer_arg, 'json')
+        self.assertIs(resolve_serializer(worker._serializer_arg), JSONSerializer)
+
+        worker = SpawnWorker([queue], serializer=JSONSerializer)
+        self.assertEqual(worker._serializer_arg, 'rq.serializers.JSONSerializer')
+        self.assertIs(resolve_serializer(worker._serializer_arg), JSONSerializer)
+
+        worker = SpawnWorker([queue], serializer=json)
+        self.assertEqual(worker._serializer_arg, 'json')
+        self.assertIs(resolve_serializer(worker._serializer_arg), JSONSerializer)
 
     def test_invalid_job_id_is_rejected_before_spawn(self):
         queue = Queue('foo', connection=self.connection)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spawned worker processes now correctly apply the parent worker's serializer configuration when processing jobs and queues.

* **Tests**
  * Added verification tests for serializer configuration in spawned worker processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rq/rq/pull/2407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->