### PR TITLE
Preserve worker logger levels by default

### DIFF
--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -847,7 +847,7 @@ class BaseWorker:
     def _start_scheduler(
         self,
         burst: bool = False,
-        logging_level: str | None = 'INFO',
+        logging_level: str | None = None,
         date_format: str = DEFAULT_LOGGING_DATE_FORMAT,
         log_format: str = DEFAULT_LOGGING_FORMAT,
     ):
@@ -860,7 +860,7 @@ class BaseWorker:
 
         Args:
             burst (bool, optional): Whether to work on burst mode. Defaults to False.
-            logging_level (str, optional): Logging level to use. Defaults to "INFO".
+            logging_level (str, optional): Logging level to use.
             date_format (str, optional): Date Format. Defaults to DEFAULT_LOGGING_DATE_FORMAT.
             log_format (str, optional): Log Format. Defaults to DEFAULT_LOGGING_FORMAT.
         """
@@ -929,7 +929,7 @@ class BaseWorker:
 
     def bootstrap(
         self,
-        logging_level: str | None = 'INFO',
+        logging_level: str | None = None,
         date_format: str = DEFAULT_LOGGING_DATE_FORMAT,
         log_format: str = DEFAULT_LOGGING_FORMAT,
     ):
@@ -939,7 +939,7 @@ class BaseWorker:
         than the full bootstrapping process.
 
         Args:
-            logging_level (str, optional): Logging level to use. Defaults to "INFO".
+            logging_level (str, optional): Logging level to use.
             date_format (str, optional): Date Format. Defaults to DEFAULT_LOGGING_DATE_FORMAT.
             log_format (str, optional): Log Format. Defaults to DEFAULT_LOGGING_FORMAT.
         """

--- a/tests/test_worker_logging.py
+++ b/tests/test_worker_logging.py
@@ -5,6 +5,7 @@ from rq import Worker
 
 
 def test_worker_bootstrap_preserves_configured_log_level():
+    """Worker bootstrap preserves configured log levels by default."""
     connection = Mock()
     connection.connection_pool.connection_kwargs = {}
     worker = Worker(['default'], connection=connection, prepare_for_work=False)

--- a/tests/test_worker_logging.py
+++ b/tests/test_worker_logging.py
@@ -1,0 +1,30 @@
+import logging
+from unittest.mock import Mock
+
+from rq import Worker
+
+
+def test_worker_bootstrap_preserves_configured_log_level():
+    connection = Mock()
+    connection.connection_pool.connection_kwargs = {}
+    worker = Worker(['default'], connection=connection, prepare_for_work=False)
+    worker.register_birth = Mock()
+    worker.subscribe = Mock()
+    worker.set_state = Mock()
+
+    worker_logger = logging.getLogger('rq.worker')
+    job_logger = logging.getLogger('rq.job')
+    original_worker_level = worker_logger.level
+    original_job_level = job_logger.level
+
+    try:
+        worker_logger.setLevel(logging.WARNING)
+        job_logger.setLevel(logging.WARNING)
+
+        worker.bootstrap()
+
+        assert worker_logger.level == logging.WARNING
+        assert job_logger.level == logging.WARNING
+    finally:
+        worker_logger.setLevel(original_worker_level)
+        job_logger.setLevel(original_job_level)


### PR DESCRIPTION
## Summary
- make worker bootstrap and scheduler startup avoid forcing `INFO` unless a logging level is explicitly provided
- add a focused regression test proving existing `rq.worker` and `rq.job` logger levels are preserved

Fixes #1702

## Tests
- `UV_CACHE_DIR=$PWD/.uv-cache UV_PROJECT_ENVIRONMENT=$PWD/.venv uv run pytest tests/test_worker_logging.py -q`
- `UV_CACHE_DIR=$PWD/.uv-cache UV_PROJECT_ENVIRONMENT=$PWD/.venv uv run ruff check rq/worker/base.py tests/test_worker_logging.py`
- `UV_CACHE_DIR=$PWD/.uv-cache UV_PROJECT_ENVIRONMENT=$PWD/.venv uv run ruff format --check rq/worker/base.py tests/test_worker_logging.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workers now preserve configured logging levels during startup/bootstrapping instead of falling back to a hardcoded default when no level is provided.

* **Tests**
  * Added test coverage to verify that worker initialization preserves preconfigured logger levels and avoids altering them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rq/rq/pull/2409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->