### PR TITLE
Allow retry configuration in Job.create() for parity with Queue.enqueue()

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -248,6 +248,7 @@ class Job:
         description: str | None = None,
         depends_on: JobDependencyType | None = None,
         timeout: int | None = None,
+        retry: Retry | None = None,
         id: str | None = None,
         origin: str = '',
         meta: dict[str, Any] | None = None,
@@ -364,6 +365,11 @@ class Job:
         job.timeout = parse_timeout(timeout)
         job.meta = meta or {}
         job.group_id = group_id
+
+        if retry is not None:
+            job.retries_left = retry.max
+            job.enqueue_at_front_on_retry = retry.enqueue_at_front
+            job.retry_intervals = retry.intervals
 
         # Process job dependencies
         if depends_on is not None:

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -133,6 +133,43 @@ class TestRetry(RQTestCase):
         self.assertEqual(job.retries_left, 2)
         # status should be queued
         self.assertEqual(job.get_status(), JobStatus.QUEUED)
+    
+    def test_job_create_with_retry(self):
+        """Job.create(..., retry=...) works properly"""
+        queue = Queue(connection=self.connection)
+
+        retry = Retry(max=3, interval=5)
+        job = Job.create(div_by_zero, retry=retry)
+        queue.enqueue_job(job)
+
+        with self.connection.pipeline() as pipeline:
+            job.retry(queue, pipeline)
+            pipeline.execute()
+
+        self.assertEqual(job.retries_left, 2)
+        self.assertEqual(job.get_status(), JobStatus.SCHEDULED)
+
+        retry = Retry(max=3)
+        job = Job.create(div_by_zero, retry=retry)
+        queue.enqueue_job(job)
+
+        with self.connection.pipeline() as pipeline:
+            job.retry(queue, pipeline)
+            pipeline.execute()
+
+        self.assertEqual(job.retries_left, 2)
+        self.assertEqual(job.get_status(), JobStatus.QUEUED)
+
+        retry = Retry(max=3, enqueue_at_front=True)
+        job = Job.create(div_by_zero, retry=retry)
+        queue.enqueue_job(job)
+
+        with self.connection.pipeline() as pipeline:
+            job.retry(queue, pipeline)
+            pipeline.execute()
+
+        self.assertEqual(job.retries_left, 2)
+        self.assertEqual(job.get_status(), JobStatus.QUEUED)
 
     def test_retry_interval(self):
         """Retries with intervals are scheduled"""

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -133,7 +133,7 @@ class TestRetry(RQTestCase):
         self.assertEqual(job.retries_left, 2)
         # status should be queued
         self.assertEqual(job.get_status(), JobStatus.QUEUED)
-    
+
     def test_job_create_with_retry(self):
         """Job.create(..., retry=...) works properly"""
         queue = Queue(connection=self.connection)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -138,38 +138,13 @@ class TestRetry(RQTestCase):
         """Job.create(..., retry=...) works properly"""
         queue = Queue(connection=self.connection)
 
-        retry = Retry(max=3, interval=5)
+        retry = Retry(max=3, interval=5, enqueue_at_front=True)
         job = Job.create(div_by_zero, retry=retry, connection=self.connection)
         queue.enqueue_job(job)
 
-        with self.connection.pipeline() as pipeline:
-            job.retry(queue, pipeline)
-            pipeline.execute()
-
-        self.assertEqual(job.retries_left, 2)
-        self.assertEqual(job.get_status(), JobStatus.SCHEDULED)
-
-        retry = Retry(max=3)
-        job = Job.create(div_by_zero, retry=retry, connection=self.connection)
-        queue.enqueue_job(job)
-
-        with self.connection.pipeline() as pipeline:
-            job.retry(queue, pipeline)
-            pipeline.execute()
-
-        self.assertEqual(job.retries_left, 2)
-        self.assertEqual(job.get_status(), JobStatus.QUEUED)
-
-        retry = Retry(max=3, enqueue_at_front=True)
-        job = Job.create(div_by_zero, retry=retry, connection=self.connection)
-        queue.enqueue_job(job)
-
-        with self.connection.pipeline() as pipeline:
-            job.retry(queue, pipeline)
-            pipeline.execute()
-
-        self.assertEqual(job.retries_left, 2)
-        self.assertEqual(job.get_status(), JobStatus.QUEUED)
+        self.assertEqual(job.retries_left, 3)
+        self.assertEqual(job.retry_intervals, [5])
+        self.assertTrue(job.enqueue_at_front_on_retry)
 
     def test_retry_interval(self):
         """Retries with intervals are scheduled"""

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -139,7 +139,7 @@ class TestRetry(RQTestCase):
         queue = Queue(connection=self.connection)
 
         retry = Retry(max=3, interval=5)
-        job = Job.create(div_by_zero, retry=retry)
+        job = Job.create(div_by_zero, retry=retry, connection=self.connection)
         queue.enqueue_job(job)
 
         with self.connection.pipeline() as pipeline:
@@ -150,7 +150,7 @@ class TestRetry(RQTestCase):
         self.assertEqual(job.get_status(), JobStatus.SCHEDULED)
 
         retry = Retry(max=3)
-        job = Job.create(div_by_zero, retry=retry)
+        job = Job.create(div_by_zero, retry=retry, connection=self.connection)
         queue.enqueue_job(job)
 
         with self.connection.pipeline() as pipeline:
@@ -161,7 +161,7 @@ class TestRetry(RQTestCase):
         self.assertEqual(job.get_status(), JobStatus.QUEUED)
 
         retry = Retry(max=3, enqueue_at_front=True)
-        job = Job.create(div_by_zero, retry=retry)
+        job = Job.create(div_by_zero, retry=retry, connection=self.connection)
         queue.enqueue_job(job)
 
         with self.connection.pipeline() as pipeline:


### PR DESCRIPTION
## Add Retry Configuration Support to `Job.create()` (Fixes #2362)

Currently, when manually creating a job with Job.create(...) and later enqueueing it via Queue.enqueue_job(job), retry behavior cannot be configured using retry=Retry(...). Users instead need to manually set: 

job.retries_left 
job.retry_intervals 

This change allows retry configuration directly during job creation, providing API consistency and reducing manual setup.

### Before

```python
job = Job.create(func=my_func)
job.retries_left = 3
job.retry_intervals = [10, 30, 60]

queue.enqueue_job(job)
```

### After

```python
job = Job.create(
    func=my_func,
    retry=Retry(max=3, interval=[10, 30, 60]),
)
queue.enqueue_job(job)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job creation now supports built-in retry configuration so you can specify max retry attempts, retry delay intervals, and whether retried jobs are re-enqueued at the front of the queue.

* **Tests**
  * Added automated tests validating job creation with retry parameters to ensure retry counts, delay intervals, and enqueue behavior are initialized correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rq/rq/pull/2410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->