### PR TITLE
Update scheduler locking to capture ownership and detect expiring locks

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -268,8 +268,16 @@ class Queue:
     def scheduler_pid(self) -> int | None:
         from rq.scheduler import RQScheduler
 
-        pid = self.connection.get(RQScheduler.get_locking_key(self.name))
-        return int(pid.decode()) if pid is not None else None
+        if (value := self.connection.get(RQScheduler.get_locking_key(self.name))) is None:
+            return None
+
+        parts = value.decode('ascii').split(':')
+        if len(parts) == 1:  # an old scheduler which hasn't been restarted
+            return int(parts[0])
+
+        ppid, pid = parts[:2]
+        # PID is only set after forking, so fall back to the parent's PID if the child has not forked yet
+        return int(ppid if not pid else pid)
 
     def acquire_maintenance_lock(self) -> bool:
         """Returns a boolean indicating whether a lock to clean this queue

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from enum import Enum
 from multiprocessing import Process, get_context
 from multiprocessing.process import BaseProcess
+from secrets import token_hex
 
 from redis import ConnectionPool, Redis
 
@@ -20,7 +21,7 @@ from .logutils import setup_loghandlers
 from .queue import Queue
 from .registry import ScheduledJobRegistry
 from .serializers import resolve_serializer
-from .utils import current_timestamp, parse_names
+from .utils import current_timestamp, parse_names, split_list
 
 ForkProcess: type[BaseProcess]
 try:
@@ -49,20 +50,25 @@ class RQScheduler:
         self,
         queues,
         connection: Redis,
+        burst: bool = False,
         interval=1,
         logging_level: str | int = logging.INFO,
         date_format=DEFAULT_LOGGING_DATE_FORMAT,
         log_format=DEFAULT_LOGGING_FORMAT,
         serializer=None,
     ):
+        self._ppid = os.getpid()
+        self._pid: int | None = None
         self._queue_names = set(parse_names(queues))
         self._acquired_locks: set[str] = set()
+        self._token = token_hex()
         self._scheduled_job_registries: list[ScheduledJobRegistry] = []
-        self.lock_acquisition_time = None
+        self.lock_acquisition_time: datetime | None = None
         self._connection_class, self._pool_class, self._pool_kwargs = parse_connection(connection)
         self.serializer = resolve_serializer(serializer)
 
         self._connection = None
+        self.burst = burst
         self.interval = interval
         self._stop_requested = False
         self._status = self.Status.STOPPED
@@ -104,23 +110,59 @@ class RQScheduler:
     def acquire_locks(self, auto_start=False):
         """Returns names of queue it successfully acquires lock on"""
         successful_locks = set()
-        pid = os.getpid()
         self.log.debug('Acquiring scheduler lock for %s', ', '.join(self._queue_names))
         for name in self._queue_names:
-            if self.connection.set(self.get_locking_key(name), pid, nx=True, ex=self.interval + 60):
+            if self.connection.set(
+                self.get_locking_key(name),
+                f'{self._ppid}:{self._pid or ""}:{self._token}',
+                nx=True,
+                ex=self.interval + 60,
+            ):
                 self.log.info('Acquired scheduler lock for %s', name)
                 successful_locks.add(name)
 
         # Always reset _scheduled_job_registries when acquiring locks
         self._scheduled_job_registries = []
-        self._acquired_locks = self._acquired_locks.union(successful_locks)
+        self._acquired_locks |= successful_locks
         self.lock_acquisition_time = datetime.now()
 
         # If auto_start is requested and scheduler is not started,
         # run self.start()
         if self._acquired_locks and auto_start:
-            if not self._process or not self._process.is_alive():
+            if self.burst:
+                self.enqueue_scheduled_jobs()
+                self.stop()
+
+            elif not self._process or not self._process.is_alive():
                 self.start()
+
+        return successful_locks
+
+    def _check_and_update_locks(self) -> set[str]:
+        """
+        Checks initial locks against the scheduler's initialization token, removes any locks that have expired
+        during start-up, updates the lock to hold the child process PID, and returns the locks that are still held.
+        """
+        successful_locks = set()
+        self.log.debug('Checking scheduler lock for %s', ', '.join(self._queue_names))
+        for name in self._queue_names:
+            value = self.connection.get(self.get_locking_key(name))
+            if value and value.decode('ascii').rpartition(':')[-1] == self._token:
+                successful_locks.add(name)
+
+        self._acquired_locks = successful_locks
+
+        if not successful_locks:
+            self.log.info('Scheduler stopping; All locks have expired.')
+            self._status = self.Status.STOPPED
+            return successful_locks
+
+        self._pid = os.getpid()
+        self.lock_acquisition_time = datetime.now()
+        for name in self._queue_names:
+            self.connection.set(
+                self.get_locking_key(name), f'{self._ppid}:{self._pid}:{self._token}', ex=self.interval + 60, xx=True
+            )
 
         return successful_locks
 
@@ -181,16 +223,28 @@ class RQScheduler:
 
     def heartbeat(self):
         """Updates the TTL on scheduler keys and the locks"""
-        self.log.debug('Scheduler sending heartbeat to %s', ', '.join(self.acquired_locks))
-        if len(self._acquired_locks) > 1:
-            with self.connection.pipeline() as pipeline:
-                for name in self._acquired_locks:
-                    key = self.get_locking_key(name)
-                    pipeline.expire(key, self.interval + 60)
-                pipeline.execute()
-        elif self._acquired_locks:
-            key = self.get_locking_key(next(iter(self._acquired_locks)))
-            self.connection.expire(key, self.interval + 60)
+        if not (locks := self._acquired_locks):
+            return
+
+        self.log.debug('Scheduler sending heartbeat to %s', ', '.join(locks))
+        with self.connection.pipeline() as pipeline:
+            for name in locks:
+                key = self.get_locking_key(name)
+                pipeline.expire(key, self.interval + 60)
+                pipeline.get(key)
+            result = pipeline.execute()
+
+        if lost := {
+            name
+            for name, (updated_expiration, value) in zip(locks, split_list(result, 2))
+            if not updated_expiration or not value or value.decode('ascii').rpartition(':')[-1] != self._token
+        }:
+            self.log.info('Scheduler lost locks for %s...', ', '.join(lost))
+            self._acquired_locks -= lost
+            self._scheduled_job_registries = []
+
+        if not self.acquired_locks:
+            self._status = self.Status.STOPPED
 
     def stop(self):
         self.log.info('Scheduler stopping, releasing locks for %s...', ', '.join(self._acquired_locks))
@@ -214,8 +268,9 @@ class RQScheduler:
 
     def work(self):
         self._install_signal_handlers()
+        self._check_and_update_locks()
 
-        while True:
+        while self.status != self.Status.STOPPED:
             if self._stop_requested:
                 self.stop()
                 break
@@ -229,10 +284,11 @@ class RQScheduler:
 
 
 def run(scheduler):
-    scheduler.log.info('Scheduler for %s started with PID %s', ', '.join(scheduler._queue_names), os.getpid())
+    pid = os.getpid()
+    scheduler.log.info('Scheduler for %s started with PID %s', ', '.join(scheduler._queue_names), pid)
     try:
         scheduler.work()
     except:  # noqa
-        scheduler.log.error('Scheduler [PID %s] raised an exception.\n%s', os.getpid(), traceback.format_exc())
+        scheduler.log.error('Scheduler [PID %s] raised an exception.\n%s', pid, traceback.format_exc())
         raise
-    scheduler.log.info('Scheduler with PID %d has stopped', os.getpid())
+    scheduler.log.info('Scheduler with PID %d has stopped', pid)

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -109,17 +109,19 @@ class RQScheduler:
 
     def acquire_locks(self, auto_start=False):
         """Returns names of queue it successfully acquires lock on"""
-        successful_locks = set()
         self.log.debug('Acquiring scheduler lock for %s', ', '.join(self._queue_names))
-        for name in self._queue_names:
-            if self.connection.set(
-                self.get_locking_key(name),
-                f'{self._ppid}:{self._pid or ""}:{self._token}',
-                nx=True,
-                ex=self.interval + 60,
-            ):
-                self.log.info('Acquired scheduler lock for %s', name)
-                successful_locks.add(name)
+        with self.connection.pipeline() as pipeline:
+            for name in self._queue_names:
+                pipeline.set(
+                    self.get_locking_key(name),
+                    f'{self._ppid}:{self._pid or ""}:{self._token}',
+                    nx=True,
+                    ex=self.interval + 60,
+                )
+            result = pipeline.execute()
+
+        if successful_locks := {name for name, locked in zip(self._queue_names, result) if locked}:
+            self.log.info('Acquired scheduler lock for %s', ', '.join(successful_locks))
 
         # Always reset _scheduled_job_registries when acquiring locks
         self._scheduled_job_registries = []
@@ -143,26 +145,37 @@ class RQScheduler:
         Checks initial locks against the scheduler's initialization token, removes any locks that have expired
         during start-up, updates the lock to hold the child process PID, and returns the locks that are still held.
         """
-        successful_locks = set()
         self.log.debug('Checking scheduler lock for %s', ', '.join(self._queue_names))
-        for name in self._queue_names:
-            value = self.connection.get(self.get_locking_key(name))
-            if value and value.decode('ascii').rpartition(':')[-1] == self._token:
-                successful_locks.add(name)
+        with self.connection.pipeline() as pipeline:
+            for name in self._queue_names:
+                pipeline.get(self.get_locking_key(name))
 
-        self._acquired_locks = successful_locks
+            result = pipeline.execute()
+
+        self._acquired_locks = successful_locks = {
+            name
+            for name, value in zip(self._queue_names, result)
+            if value and value.decode('ascii').rpartition(':')[-1] == self._token
+        }
 
         if not successful_locks:
             self.log.info('Scheduler stopping; All locks have expired.')
             self._status = self.Status.STOPPED
             return successful_locks
 
+        # update locks with scheduler PID now that it has launched
         self._pid = os.getpid()
         self.lock_acquisition_time = datetime.now()
-        for name in self._queue_names:
-            self.connection.set(
-                self.get_locking_key(name), f'{self._ppid}:{self._pid}:{self._token}', ex=self.interval + 60, xx=True
-            )
+        with self.connection.pipeline() as pipeline:
+            for name in successful_locks:
+                pipeline.set(
+                    self.get_locking_key(name),
+                    f'{self._ppid}:{self._pid}:{self._token}',
+                    ex=self.interval + 60,
+                    xx=True,
+                )
+
+            pipeline.execute()
 
         return successful_locks
 
@@ -243,12 +256,12 @@ class RQScheduler:
             self._acquired_locks -= lost
             self._scheduled_job_registries = []
 
-        if not self.acquired_locks:
-            self._status = self.Status.STOPPED
-
     def stop(self):
-        self.log.info('Scheduler stopping, releasing locks for %s...', ', '.join(self._acquired_locks))
-        self.release_locks()
+        if locks := self._acquired_locks:
+            self.log.info('Scheduler stopping, releasing locks for %s...', ', '.join(locks))
+            self.release_locks()
+        else:
+            self.log.info('Scheduler stopping, no locks to release')
         self._status = self.Status.STOPPED
 
     def release_locks(self):
@@ -280,6 +293,13 @@ class RQScheduler:
 
             self.enqueue_scheduled_jobs()
             self.heartbeat()
+
+            # if all locks were lost, try to re-obtain a lock or shutdown
+            if not self.acquired_locks:
+                if not self.acquire_locks():
+                    self.stop()
+                    break
+
             time.sleep(self.interval)
 
 

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -20,7 +20,7 @@ from .job import Job
 from .logutils import setup_loghandlers
 from .queue import Queue
 from .registry import ScheduledJobRegistry
-from .scripts import delete_scheduler_locks
+from .scripts import scheduler_delete_locks, scheduler_update_locks
 from .serializers import resolve_serializer
 from .utils import current_timestamp, parse_names, split_list
 
@@ -167,16 +167,13 @@ class RQScheduler:
         # update locks with scheduler PID now that it has launched
         self._pid = os.getpid()
         self.lock_acquisition_time = datetime.now()
-        with self.connection.pipeline() as pipeline:
-            for name in successful_locks:
-                pipeline.set(
-                    self.get_locking_key(name),
-                    f'{self._ppid}:{self._pid}:{self._token}',
-                    ex=self.interval + 60,
-                    xx=True,
-                )
-
-            pipeline.execute()
+        scheduler_update_locks(
+            self.connection,
+            self._token,
+            f'{self._ppid}:{self._pid}:{self._token}',
+            self.interval + 60,
+            [self.get_locking_key(name) for name in successful_locks],
+        )
 
         return successful_locks
 
@@ -267,7 +264,7 @@ class RQScheduler:
 
     def release_locks(self):
         """Release acquired locks"""
-        delete_scheduler_locks(
+        scheduler_delete_locks(
             self.connection, self._token, [self.get_locking_key(name) for name in self._acquired_locks]
         )
         self._acquired_locks = set()

--- a/rq/scheduler.py
+++ b/rq/scheduler.py
@@ -20,6 +20,7 @@ from .job import Job
 from .logutils import setup_loghandlers
 from .queue import Queue
 from .registry import ScheduledJobRegistry
+from .scripts import delete_scheduler_locks
 from .serializers import resolve_serializer
 from .utils import current_timestamp, parse_names, split_list
 
@@ -266,8 +267,9 @@ class RQScheduler:
 
     def release_locks(self):
         """Release acquired locks"""
-        keys = [self.get_locking_key(name) for name in self._acquired_locks]
-        self.connection.delete(*keys)
+        delete_scheduler_locks(
+            self.connection, self._token, [self.get_locking_key(name) for name in self._acquired_locks]
+        )
         self._acquired_locks = set()
 
     def start(self):

--- a/rq/scripts.py
+++ b/rq/scripts.py
@@ -32,15 +32,15 @@ def get_registered_script(connection: Redis, source: str) -> Script:
 
 
 # Lua script to delete only owned scheduler locks
-DELETE_SCHEDULER_LOCKS = """
+SCHEDULER_DELETE_LOCKS = """
     -- KEYS[*] = scheduler locks to delete
     -- ARGV[1] = scheduler lock token
 
     local pattern = string.format(':%s$', ARGV[1])
     local count = 0
     for _, key in ipairs(KEYS) do
-        if string.find(redis.call('get', key) or '', pattern) then
-            count = count + redis.call('del', key)
+        if string.find(redis.call('GET', key) or '', pattern) then
+            count = count + redis.call('DEL', key)
         end
     end
 
@@ -48,8 +48,35 @@ DELETE_SCHEDULER_LOCKS = """
 """
 
 
-def delete_scheduler_locks(connection: Redis, token: str, keys: Sequence[str]) -> int:
-    return get_registered_script(connection, DELETE_SCHEDULER_LOCKS)(keys=keys, args=[token])
+def scheduler_delete_locks(connection: Redis, token: str, keys: Sequence[str]) -> int:
+    return get_registered_script(connection, SCHEDULER_DELETE_LOCKS)(keys=keys, args=[token])
+
+
+# Lua script to update only owned scheduler locks to a new value & expiration
+SCHEDULER_UPDATE_LOCKS = """
+    -- KEYS[*] = scheduler locks to update
+    -- ARGV[1] = scheduler lock token
+    -- ARGV[2] = scheduler lock updated value
+    -- ARGV[3] = scheduler lock expiration
+
+    local pattern = string.format(':%s$', ARGV[1])
+    local count = 0
+    for _, key in ipairs(KEYS) do
+        if string.find(redis.call('GET', key) or '', pattern) then
+            count = count + 1
+            redis.call('SET', key, ARGV[2], 'ex', ARGV[3])
+        end
+    end
+
+    return count
+"""
+
+
+def scheduler_update_locks(connection: Redis, token: str, value: str, ex: int, keys: Sequence[str]) -> int:
+    if not value.endswith(f':{token}'):
+        raise ValueError(f'Scheduler value {value!r} will change lock ownership!')
+
+    return get_registered_script(connection, SCHEDULER_UPDATE_LOCKS)(keys=keys, args=[token, value, ex])
 
 
 # Lua script for atomic unique enqueue: check existence, save job, push to queue

--- a/rq/scripts.py
+++ b/rq/scripts.py
@@ -36,10 +36,11 @@ SCHEDULER_DELETE_LOCKS = """
     -- KEYS[*] = scheduler locks to delete
     -- ARGV[1] = scheduler lock token
 
-    local pattern = string.format(':%s$', ARGV[1])
+    local suffix = string.format(':%s', ARGV[1])
+    local suffix_length = #suffix
     local count = 0
     for _, key in ipairs(KEYS) do
-        if string.find(redis.call('GET', key) or '', pattern) then
+        if string.sub(redis.call('GET', key) or '', -suffix_length) == suffix then
             count = count + redis.call('DEL', key)
         end
     end
@@ -59,10 +60,11 @@ SCHEDULER_UPDATE_LOCKS = """
     -- ARGV[2] = scheduler lock updated value
     -- ARGV[3] = scheduler lock expiration
 
-    local pattern = string.format(':%s$', ARGV[1])
+    local suffix = string.format(':%s', ARGV[1])
+    local suffix_length = #suffix
     local count = 0
     for _, key in ipairs(KEYS) do
-        if string.find(redis.call('GET', key) or '', pattern) then
+        if string.sub(redis.call('GET', key) or '', -suffix_length) == suffix then
             count = count + 1
             redis.call('SET', key, ARGV[2], 'ex', ARGV[3])
         end

--- a/rq/scripts.py
+++ b/rq/scripts.py
@@ -1,13 +1,56 @@
+from __future__ import annotations
+
 import calendar
 import logging
 import time
-from datetime import timedelta, timezone
-from typing import Any
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from redis import Redis
 
 from .exceptions import DuplicateJobError
 from .logutils import blue, green
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from redis.commands.core import Script
+
+    from .job import Job
+
 logger = logging.getLogger('rq.scripts')
+
+# Cache registered scripts per connection
+_registered_scripts: dict[tuple[str, Redis], Script] = {}
+
+
+def get_registered_script(connection: Redis, source: str) -> Script:
+    """Get or register a Lua script."""
+    if (script := _registered_scripts.get(key := (source, connection))) is None:
+        _registered_scripts[key] = script = connection.register_script(source)
+    return script
+
+
+# Lua script to delete only owned scheduler locks
+DELETE_SCHEDULER_LOCKS = """
+    -- KEYS[*] = scheduler locks to delete
+    -- ARGV[1] = scheduler lock token
+
+    local pattern = string.format(':%s$', ARGV[1])
+    local count = 0
+    for _, key in ipairs(KEYS) do
+        if string.find(redis.call('get', key) or '', pattern) then
+            count = count + redis.call('del', key)
+        end
+    end
+
+    return count
+"""
+
+
+def delete_scheduler_locks(connection: Redis, token: str, keys: Sequence[str]) -> int:
+    return get_registered_script(connection, DELETE_SCHEDULER_LOCKS)(keys=keys, args=[token])
+
 
 # Lua script for atomic unique enqueue: check existence, save job, push to queue
 UNIQUE_ENQUEUE_SCRIPT = """
@@ -44,18 +87,8 @@ UNIQUE_ENQUEUE_SCRIPT = """
     return 1  -- Success
 """
 
-# Cache registered scripts per connection
-_registered_scripts: dict[Any, Any] = {}
 
-
-def get_unique_enqueue_script(connection):
-    """Get or create the registered Lua script for unique enqueue."""
-    if connection not in _registered_scripts:
-        _registered_scripts[connection] = connection.register_script(UNIQUE_ENQUEUE_SCRIPT)
-    return _registered_scripts[connection]
-
-
-def save_unique_job(connection, queue_key, job, enqueue=True, at_front=False):
+def save_unique_job(connection: Redis, queue_key: str, job: Job, enqueue: bool = True, at_front: bool = False) -> bool:
     """Atomically check uniqueness, save job, and optionally push to queue using Lua script.
 
     Args:
@@ -72,7 +105,7 @@ def save_unique_job(connection, queue_key, job, enqueue=True, at_front=False):
     Raises:
         DuplicateJobError: If a job with the same ID already exists
     """
-    script = get_unique_enqueue_script(connection)
+    script = get_registered_script(connection, UNIQUE_ENQUEUE_SCRIPT)
 
     hset_args = _build_hset_args(job)
 
@@ -137,7 +170,7 @@ UNIQUE_SCHEDULE_SCRIPT = """
 """
 
 
-def _build_hset_args(job):
+def _build_hset_args(job: Job) -> list[bytes | str]:
     """Build flat list of field/value pairs from job.to_dict() for use in Lua HSET calls."""
     job_data = job.to_dict()
     hset_args = []
@@ -151,17 +184,9 @@ def _build_hset_args(job):
     return hset_args
 
 
-_registered_schedule_scripts: dict[Any, Any] = {}
-
-
-def get_unique_schedule_script(connection):
-    """Get or create the registered Lua script for unique schedule."""
-    if connection not in _registered_schedule_scripts:
-        _registered_schedule_scripts[connection] = connection.register_script(UNIQUE_SCHEDULE_SCRIPT)
-    return _registered_schedule_scripts[connection]
-
-
-def schedule_unique_job(connection, queue_key, registry_key, job, scheduled_datetime):
+def schedule_unique_job(
+    connection: Redis, queue_key: str, registry_key: str, job: Job, scheduled_datetime: datetime
+) -> bool:
     """Atomically check uniqueness, save job, and add to scheduled registry using Lua script.
 
     Args:
@@ -177,7 +202,7 @@ def schedule_unique_job(connection, queue_key, registry_key, job, scheduled_date
     Raises:
         DuplicateJobError: If a job with the same ID already exists
     """
-    script = get_unique_schedule_script(connection)
+    script = get_registered_script(connection, UNIQUE_SCHEDULE_SCRIPT)
 
     hset_args = _build_hset_args(job)
 

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -866,19 +866,14 @@ class BaseWorker:
         """
         self.scheduler = RQScheduler(
             self.queues,
+            burst=burst,
             connection=self.connection,
             logging_level=logging_level if logging_level is not None else self.log.level,
             date_format=date_format,
             log_format=log_format,
             serializer=self.serializer,
         )
-        self.scheduler.acquire_locks()
-        if self.scheduler.acquired_locks:
-            if burst:
-                self.scheduler.enqueue_scheduled_jobs()
-                self.scheduler.release_locks()
-            else:
-                self.scheduler.start()
+        self.scheduler.acquire_locks(auto_start=True)
 
     def serialize(self) -> dict:
         assert self.birth_date is not None and self.last_heartbeat is not None
@@ -1010,7 +1005,11 @@ class BaseWorker:
         No need to try to start scheduler on first run
         """
         if self.last_cleaned_at:
-            if self.scheduler and (not self.scheduler._process or not self.scheduler._process.is_alive()):
+            if (
+                self.scheduler
+                and not self.scheduler.burst
+                and (not self.scheduler._process or not self.scheduler._process.is_alive())
+            ):
                 self.scheduler.acquire_locks(auto_start=True)
         self.clean_registries()
         Group.clean_registries(connection=self.connection)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -198,6 +198,18 @@ class TestScheduler(RQTestCase):
         self.assertEqual(scheduler.acquire_locks(), {name_3})
         self.assertEqual(scheduler._acquired_locks, {name_2, name_3})
 
+    def test_lock_acquisition_race(self):
+        queue = 'race'
+        first = RQScheduler([queue], self.connection)
+        second = RQScheduler([queue], self.connection)
+
+        self.assertEqual(first.acquire_locks(), {queue})
+        self.connection.delete(first.get_locking_key(queue))  # simulate expiration
+        self.assertEqual(second.acquire_locks(), {queue})
+
+        self.assertFalse(first._check_and_update_locks())
+        self.assertEqual(second._check_and_update_locks(), {queue})
+
     def test_lock_acquisition_with_auto_start(self):
         """Test lock acquisition with auto_start=True"""
         scheduler = RQScheduler(['auto-start'], self.connection)
@@ -270,8 +282,10 @@ class TestScheduler(RQTestCase):
         name_3 = 'lock-test-3'
         scheduler = RQScheduler([name_3], self.connection)
         scheduler.acquire_locks()
+        self.assertEqual(scheduler.acquired_locks, {name_3})
         scheduler = RQScheduler([name_1, name_2, name_3], self.connection)
         scheduler.acquire_locks()
+        self.assertEqual(scheduler.acquired_locks, {name_1, name_2})
 
         locking_key_1 = RQScheduler.get_locking_key(name_1)
         locking_key_2 = RQScheduler.get_locking_key(name_2)
@@ -284,6 +298,7 @@ class TestScheduler(RQTestCase):
             pipeline.execute()
 
         scheduler.heartbeat()
+        self.assertEqual(scheduler.acquired_locks, {name_1, name_2})
         self.assertEqual(self.connection.ttl(locking_key_1), 61)
         self.assertEqual(self.connection.ttl(locking_key_2), 61)
         self.assertEqual(self.connection.ttl(locking_key_3), 1000)
@@ -296,12 +311,26 @@ class TestScheduler(RQTestCase):
         self.assertTrue(self.connection.exists(locking_key_3))
         self.assertEqual(scheduler.status, scheduler.Status.STOPPED)
 
-        # Heartbeat also works properly for schedulers with a single queue
-        scheduler = RQScheduler([name_1], self.connection)
+    def test_heartbeat_race(self):
+        queue = 'race'
+
+        # Heartbeat detects lock expiration
+        scheduler = RQScheduler([queue], self.connection)
         scheduler.acquire_locks()
-        self.connection.expire(locking_key_1, 1000)
+        self.connection.delete(locking_key := scheduler.get_locking_key(queue))  # simulate expiration
         scheduler.heartbeat()
-        self.assertEqual(self.connection.ttl(locking_key_1), 61)
+        self.assertFalse(scheduler.acquired_locks)
+
+        # Heartbeat detects lock ownership change
+        first = RQScheduler([queue], self.connection)
+        second = RQScheduler([queue], self.connection)
+        first.acquire_locks()
+        self.connection.delete(locking_key)  # simulate expiration
+        second.acquire_locks()
+        first.heartbeat()
+        self.assertFalse(first.acquired_locks)
+        second.heartbeat()
+        self.assertEqual(second.acquired_locks, {queue})
 
     def test_enqueue_scheduled_jobs(self):
         """Scheduler can enqueue scheduled jobs"""


### PR DESCRIPTION
This updates the RQ scheduler to store a start-up token in Redis, and check the token upon start-up and heartbeat refreshes to ensure the lock is still owned by the current scheduler.

This also changes the worker's burst mode to not start the scheduler when running the maintenance tasks.

fixes: https://github.com/rq/rq/issues/2338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "burst" scheduler mode, improved scheduler PID reporting and more accurate lock ownership resolution.
* **Bug Fixes**
  * Robust lock handling, validation and recovery to avoid lost or misattributed locks; fixes for races during acquisition, heartbeat and shutdown; scheduler auto-start behavior refined.
* **Refactor**
  * Centralized script registration/caching and targeted scheduler-lock operations; unique enqueue/schedule paths consolidated and annotated.
* **Tests**
  * Added tests for lock acquisition races and heartbeat ownership changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rq/rq/pull/2411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->