### PR TITLE
Webhook notifications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ### Unreleased
-* Added webhook job notifications. Passing `webhooks=[Webhook(url, job_status='finished'), ...]` to `enqueue`, `enqueue_at`/`enqueue_in`, `enqueue_many`, the `@job` decorator, or `cron.register` sends an HTTP request to the given URL when the job finishes or fails. Thanks @selwin!
+* Added [webhook notifications](https://python-rq.org/docs/#webhooks) to notify external end points when a job finishes or fails. Thanks @selwin!
 
 ### RQ 2.9.1 (2026-06-06)
 * `Job.create()` now supports `retry` argument. Thanks @sethuvishal!

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### Unreleased
+* Added webhook job notifications. Passing `webhooks=[Webhook(url, job_status='finished'), ...]` to `enqueue`, `enqueue_at`/`enqueue_in`, `enqueue_many`, the `@job` decorator, or `cron.register` sends an HTTP request to the given URL when the job finishes or fails. Thanks @selwin!
+
 ### RQ 2.9.1 (2026-06-06)
 * `Job.create()` now supports `retry` argument. Thanks @sethuvishal!
 * Add compatibility with `redis-py` >= 8. Thanks @selwin!

--- a/README.md
+++ b/README.md
@@ -142,6 +142,24 @@ queue.enqueue(say_hello, retry=Retry(max=3, interval=[10, 30, 60]))
 
 For a more complete example, refer to the [docs][d].  But this is the essence.
 
+## Webhooks
+
+RQ can send an HTTP request to a URL when a job finishes or fails, without writing a callback function:
+
+```python
+from rq import Webhook
+
+queue.enqueue(
+    say_hello,
+    webhooks=[
+        Webhook('https://example.com/finished', job_status='finished'),
+        Webhook('https://example.com/failed', job_status='failed', method='POST'),
+    ],
+)
+```
+
+More details can be found in the [docs](https://python-rq.org/docs/#webhooks).
+
 ## Interval and Cron Job Scheduling
 
 RQ >= 2.5 provides built-in job scheduling functionality that supports both simple interval-based scheduling and flexible cron syntax.

--- a/docs/docs/cron.md
+++ b/docs/docs/cron.md
@@ -125,13 +125,14 @@ cron.register(
     backup_database,
     queue_name='maintenance',
     cron='0 2 * * *',
-    webhooks=[Webhook('https://example.com', 'finished')],
+    webhooks=[
+        Webhook('https://example.com/finished', 'finished'),
+        Webhook('https://example.com/failed', 'failed'),
+    ],
 )
 ```
 
-If your monitoring endpoint exposes a distinct failure URL, add a second `Webhook` with
-`job_status='failed'`. See [Webhooks](/docs/#webhooks) for the full options, payload schema, and
-firing semantics.
+See [Webhooks](/docs/#webhooks) for the full options, payload schema and firing semantics.
 
 ## Configuration Files
 

--- a/docs/docs/cron.md
+++ b/docs/docs/cron.md
@@ -111,6 +111,28 @@ cron.register(frequent_task, queue_name='default', cron='*/15 * * * *')
 cron.register(weekly_report, queue_name='reports', cron='0 18 * * 0')
 ```
 
+## Webhooks
+
+__New in version 2.10__
+
+Webhooks are a convenient way to monitor scheduled jobs over HTTP — for example, pinging a
+monitoring or dead-man's-switch endpoint when a run finishes or fails:
+
+```python
+from rq import Webhook
+
+cron.register(
+    backup_database,
+    queue_name='maintenance',
+    cron='0 2 * * *',
+    webhooks=[Webhook('https://example.com', 'finished')],
+)
+```
+
+If your monitoring endpoint exposes a distinct failure URL, add a second `Webhook` with
+`job_status='failed'`. See [Webhooks](/docs/#webhooks) for the full options, payload schema, and
+firing semantics.
+
 ## Configuration Files
 
 ### Basic Configuration

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -457,8 +457,8 @@ accepted by `enqueue_call`, `enqueue_at`, `enqueue_in`, `enqueue_many` and the
 `Webhook` accepts the following arguments:
 
 * `url` (required): the `http://` or `https://` endpoint to request.
-* `job_status` (required): `'finished'` or `'failed'` (the `JobStatus` enum is also accepted). The
-  webhook fires only when the job reaches this state.
+* `job_status` (required): `'finished'` or `'failed'`. The webhook fires only when the job reaches
+  this state.
 * `method`: `'GET'` (default) or `'POST'`.
 * `headers`: an optional dict of HTTP headers.
 * `timeout`: request timeout in seconds (default `10`).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -471,13 +471,12 @@ A `GET` webhook requests `url` with no body. A `POST` webhook sends a JSON paylo
   "func_name": "myapp.say_hello",
   "status": "finished",
   "enqueued_at": "2026-06-15T12:00:00+00:00",
-  "ended_at": "2026-06-15T12:00:05+00:00",
-  "result": "..."
+  "ended_at": "2026-06-15T12:00:05+00:00"
 }
 ```
 
-`result` is included only for `finished` POST webhooks (stringified if it is not JSON-serializable);
-`exc_info` (the exception traceback) replaces it for `failed` POST webhooks. `GET` webhooks send no body.
+`failed` POST webhooks additionally include `exc_info` (the exception traceback). The job result is
+not sent. `GET` webhooks send no body.
 
 ### Firing Semantics
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -429,6 +429,72 @@ If the first character of `[value]` is `@` the subsequent path will be read.
 If the value starts with `@`, `:` or `%` or includes `=` it would be recognised as something else.
 
 
+## Webhooks
+_New in version 2.10._
+
+Webhooks notify an external HTTP endpoint when a job reaches a terminal state (`finished` or
+`failed`). They are useful for status pings, audit trails and lightweight integrations where
+writing an importable callback function is unnecessary.
+
+Pass a sequence of `Webhook` objects via the `webhooks` argument; each fires only on its
+`job_status`:
+
+```python
+from rq import Webhook
+
+queue.enqueue(say_hello,
+              webhooks=[Webhook('https://example.com/finished', job_status='finished'),
+                        Webhook('https://example.com/failed', job_status='failed', method='POST')])
+```
+
+To be notified on both outcomes, pass one `Webhook` for each. The `webhooks` argument is also
+accepted by `enqueue_call`, `enqueue_at`, `enqueue_in`, `enqueue_many` and the
+[`@job` decorator](#the-job-decorator). Cron jobs can use webhooks for heartbeat monitoring; see
+[cron jobs](/docs/cron/#webhooks).
+
+### Webhook Options
+
+`Webhook` accepts the following arguments:
+
+* `url` (required): the `http://` or `https://` endpoint to request.
+* `job_status` (required): `'finished'` or `'failed'` (the `JobStatus` enum is also accepted). The
+  webhook fires only when the job reaches this state.
+* `method`: `'GET'` (default) or `'POST'`.
+* `headers`: an optional dict of HTTP headers.
+* `timeout`: request timeout in seconds (default `10`).
+
+A `GET` webhook requests `url` with no body. A `POST` webhook sends a JSON payload describing the job:
+
+```json
+{
+  "job_id": "...",
+  "func_name": "myapp.say_hello",
+  "status": "finished",
+  "enqueued_at": "2026-06-15T12:00:00+00:00",
+  "ended_at": "2026-06-15T12:00:05+00:00",
+  "result": "..."
+}
+```
+
+`result` is included only for `finished` POST webhooks (stringified if it is not JSON-serializable);
+`exc_info` (the exception traceback) replaces it for `failed` POST webhooks. `GET` webhooks send no body.
+
+### Firing Semantics
+
+Webhooks are stored with the job as JSON-serializable data, so they don't require an importable
+function like callbacks do. The worker sends them once the job's terminal state is persisted:
+
+* A `finished` webhook fires after `on_success` runs and the job's successful result is saved.
+* A `failed` webhook fires after the failure is persisted as a terminal failure (which also runs
+  after `on_failure`). It is **not** sent for attempts that will be [retried](/docs/exceptions/#retrying-failed-jobs)
+  or for jobs that are [stopped](/docs/workers/#stopping-a-job).
+* Webhooks also fire for jobs executed synchronously (a queue created with `is_async=False`).
+
+Delivery is best-effort: send errors (an unreachable endpoint, a timeout, an HTTP error) are
+logged and swallowed, so a failing webhook never affects job execution. Sending is blocking, so a
+slow endpoint can delay the worker by up to `timeout` seconds.
+
+
 ## Working with Queues
 
 Besides enqueuing jobs, Queues have a few useful methods:

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -433,8 +433,7 @@ If the value starts with `@`, `:` or `%` or includes `=` it would be recognised 
 _New in version 2.10._
 
 Webhooks notify an external HTTP endpoint when a job reaches a terminal state (`finished` or
-`failed`). They are useful for status pings, audit trails and lightweight integrations where
-writing an importable callback function is unnecessary.
+`failed`). They are useful for monitoring, status pings and audit trails.
 
 Pass a sequence of `Webhook` objects via the `webhooks` argument; each fires only on its
 `job_status`:
@@ -448,9 +447,8 @@ queue.enqueue(say_hello,
 ```
 
 To be notified on both outcomes, pass one `Webhook` for each. The `webhooks` argument is also
-accepted by `enqueue_call`, `enqueue_at`, `enqueue_in`, `enqueue_many` and the
-[`@job` decorator](#the-job-decorator). Cron jobs can use webhooks for heartbeat monitoring; see
-[cron jobs](/docs/cron/#webhooks).
+accepted by `enqueue_call`, `enqueue_at` and `enqueue_in`, the [`@job` decorator](#the-job-decorator),
+and `Queue.prepare_data()` for `enqueue_many`. Cron jobs can use webhooks for heartbeat monitoring; see [cron jobs](/docs/cron/#webhooks).
 
 ### Webhook Options
 
@@ -463,7 +461,7 @@ accepted by `enqueue_call`, `enqueue_at`, `enqueue_in`, `enqueue_many` and the
 * `headers`: an optional dict of HTTP headers.
 * `timeout`: request timeout in seconds (default `10`).
 
-A `GET` webhook requests `url` with no body. A `POST` webhook sends a JSON payload describing the job:
+A `POST` webhook sends a JSON payload describing the job:
 
 ```json
 {
@@ -475,23 +473,17 @@ A `GET` webhook requests `url` with no body. A `POST` webhook sends a JSON paylo
 }
 ```
 
-`failed` POST webhooks additionally include `exc_info` (the exception traceback). The job result is
-not sent. `GET` webhooks send no body.
+`failed` POST webhooks additionally include `exc_info` (the exception traceback).
 
 ### Firing Semantics
 
-Webhooks are stored with the job as JSON-serializable data, so they don't require an importable
-function like callbacks do. The worker sends them once the job's terminal state is persisted:
+Webhooks are sent once the job's terminal state is persisted:
 
 * A `finished` webhook fires after `on_success` runs and the job's successful result is saved.
-* A `failed` webhook fires after the failure is persisted as a terminal failure (which also runs
-  after `on_failure`). It is **not** sent for attempts that will be [retried](/docs/exceptions/#retrying-failed-jobs)
-  or for jobs that are [stopped](/docs/workers/#stopping-a-job).
-* Webhooks also fire for jobs executed synchronously (a queue created with `is_async=False`).
+* A `failed` webhook fires after the failure is persisted as a terminal failure (which also runs after `on_failure`). It is **not** sent for attempts that will be [retried](/docs/exceptions/#retrying-failed-jobs) or for jobs that are [stopped](/docs/workers/#stopping-a-job).
 
-Delivery is best-effort: send errors (an unreachable endpoint, a timeout, an HTTP error) are
-logged and swallowed, so a failing webhook never affects job execution. Sending is blocking, so a
-slow endpoint can delay the worker by up to `timeout` seconds.
+Delivery is best-effort: send errors (unreachable endpoint, timeout, HTTP error) are
+logged and swallowed, so a failing webhook never affects job execution. Sending is blocking, so a slow endpoint can delay the worker by up to `timeout` seconds.
 
 
 ## Working with Queues

--- a/rq/__init__.py
+++ b/rq/__init__.py
@@ -3,6 +3,7 @@ from .job import Callback, Retry, cancel_job, get_current_job, requeue_job
 from .queue import Queue
 from .repeat import Repeat
 from .version import VERSION
+from .webhook import Webhook
 from .worker import SimpleWorker, SpawnWorker, Worker
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     'SpawnWorker',
     'Worker',
     'Repeat',
+    'Webhook',
 ]
 
 __version__ = VERSION

--- a/rq/cron.py
+++ b/rq/cron.py
@@ -35,6 +35,7 @@ from .utils import (
     utcparse,
     validate_absolute_path,
 )
+from .webhook import Webhook
 
 
 class CronJob:
@@ -54,11 +55,17 @@ class CronJob:
         ttl: int | None = None,
         failure_ttl: int | None = None,
         meta: dict | None = None,
+        webhooks: list[Webhook] | None = None,
     ):
         if interval and cron:
             raise ValueError('Cannot specify both interval and cron parameters')
         if not interval and not cron:
             raise ValueError('Must specify either interval or cron parameter')
+
+        if webhooks is not None and (
+            not isinstance(webhooks, list) or not all(isinstance(webhook, Webhook) for webhook in webhooks)
+        ):
+            raise TypeError('webhooks must be a list of Webhook instances')
 
         if func:
             self.func: Callable | None = func
@@ -87,6 +94,8 @@ class CronJob:
             'ttl': ttl,
             'failure_ttl': failure_ttl,
             'meta': meta,
+            # Drop an empty list so it isn't stored/serialized, matching Job (which omits empty webhooks)
+            'webhooks': webhooks or None,
         }
         # Filter out None values
         self.job_options = {k: v for k, v in self.job_options.items() if v is not None}
@@ -148,10 +157,15 @@ class CronJob:
             'next_enqueue_time': utcformat(self.next_enqueue_time) if self.next_enqueue_time else None,
         }
         # Add job options, filtering out None values
-        # meta uses safe_json_dumps, others are kept as-is (integers)
+        # meta uses safe_json_dumps and webhooks are serialized to JSON; others are kept as-is (integers)
         for k, v in self.job_options.items():
             if v is not None:
-                obj[k] = safe_json_dumps(v) if k == 'meta' else v
+                if k == 'meta':
+                    obj[k] = safe_json_dumps(v)
+                elif k == 'webhooks':
+                    obj[k] = json.dumps([webhook.to_dict() for webhook in v])
+                else:
+                    obj[k] = v
         return obj
 
     @classmethod
@@ -176,6 +190,14 @@ class CronJob:
         if meta and meta != NOT_JSON_SERIALIZABLE:
             meta = json.loads(meta)
 
+        # Restore webhooks - parse the JSON string from to_dict, else skip (missing or unserializable
+        # placeholder). Unlike meta, webhooks are validated in __init__, so the sentinel can't pass through.
+        webhooks = data.get('webhooks')
+        if webhooks and webhooks != NOT_JSON_SERIALIZABLE:
+            webhooks = [Webhook.from_dict(webhook) for webhook in json.loads(webhooks)]
+        else:
+            webhooks = None
+
         job = cls(
             queue_name=data['queue_name'],
             func_name=data['func_name'],
@@ -188,6 +210,7 @@ class CronJob:
             ttl=data.get('ttl'),
             failure_ttl=data.get('failure_ttl'),
             meta=meta,
+            webhooks=webhooks,
         )
 
         # Restore timing information if present
@@ -251,6 +274,7 @@ class CronScheduler:
         ttl: int | None = None,
         failure_ttl: int | None = None,
         meta: dict | None = None,
+        webhooks: list[Webhook] | None = None,
     ) -> CronJob:
         """Register a function to be run at regular intervals"""
         cron_job = CronJob(
@@ -265,6 +289,7 @@ class CronScheduler:
             ttl=ttl,
             failure_ttl=failure_ttl,
             meta=meta,
+            webhooks=webhooks,
         )
 
         self._cron_jobs.append(cron_job)
@@ -593,6 +618,7 @@ def register(
     ttl: int | None = None,
     failure_ttl: int | None = None,
     meta: dict | None = None,
+    webhooks: list[Webhook] | None = None,
 ) -> dict:
     """
     Register a function to be run as a cron job by adding its definition
@@ -623,6 +649,7 @@ def register(
         'ttl': ttl,
         'failure_ttl': failure_ttl,
         'meta': meta,
+        'webhooks': webhooks,
     }
     # Add to the global registry
     _job_data_registry.append(job_data)

--- a/rq/cron.py
+++ b/rq/cron.py
@@ -9,7 +9,7 @@ import socket
 import sys
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -55,17 +55,17 @@ class CronJob:
         ttl: int | None = None,
         failure_ttl: int | None = None,
         meta: dict | None = None,
-        webhooks: list[Webhook] | None = None,
+        webhooks: Sequence[Webhook] | None = None,
     ):
         if interval and cron:
             raise ValueError('Cannot specify both interval and cron parameters')
         if not interval and not cron:
             raise ValueError('Must specify either interval or cron parameter')
 
-        if webhooks is not None and (
-            not isinstance(webhooks, list) or not all(isinstance(webhook, Webhook) for webhook in webhooks)
+        if webhooks and (
+            not isinstance(webhooks, Sequence) or not all(isinstance(webhook, Webhook) for webhook in webhooks)
         ):
-            raise TypeError('webhooks must be a list of Webhook instances')
+            raise TypeError('webhooks must be a sequence of Webhook instances')
 
         if func:
             self.func: Callable | None = func
@@ -94,8 +94,9 @@ class CronJob:
             'ttl': ttl,
             'failure_ttl': failure_ttl,
             'meta': meta,
-            # Drop an empty list so it isn't stored/serialized, matching Job (which omits empty webhooks)
-            'webhooks': webhooks or None,
+            # Normalize to a list and drop an empty sequence so it isn't stored/serialized,
+            # matching Job (which omits empty webhooks)
+            'webhooks': list(webhooks) if webhooks else None,
         }
         # Filter out None values
         self.job_options = {k: v for k, v in self.job_options.items() if v is not None}
@@ -274,7 +275,7 @@ class CronScheduler:
         ttl: int | None = None,
         failure_ttl: int | None = None,
         meta: dict | None = None,
-        webhooks: list[Webhook] | None = None,
+        webhooks: Sequence[Webhook] | None = None,
     ) -> CronJob:
         """Register a function to be run at regular intervals"""
         cron_job = CronJob(
@@ -618,7 +619,7 @@ def register(
     ttl: int | None = None,
     failure_ttl: int | None = None,
     meta: dict | None = None,
-    webhooks: list[Webhook] | None = None,
+    webhooks: Sequence[Webhook] | None = None,
 ) -> dict:
     """
     Register a function to be run as a cron job by adding its definition

--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from functools import wraps
 from typing import TYPE_CHECKING, Any
 
@@ -35,7 +35,7 @@ class job:  # noqa
         on_failure: Callback | Callable[..., Any] | None = None,
         on_success: Callback | Callable[..., Any] | None = None,
         on_stopped: Callback | Callable[..., Any] | None = None,
-        webhooks: list[Webhook] | None = None,
+        webhooks: Sequence[Webhook] | None = None,
     ):
         """A decorator that adds a ``enqueue`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required
@@ -70,7 +70,7 @@ class job:  # noqa
                 to None.
             on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callable to run when stopped. Defaults
                 to None.
-            webhooks (Optional[List[Webhook]], optional): Webhooks to send on matching terminal job statuses.
+            webhooks (Optional[Sequence[Webhook]], optional): Webhooks to send on matching terminal job statuses.
                 Defaults to None.
         """
         self.queue = queue

--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 from .defaults import DEFAULT_RESULT_TTL
 from .job import Callback
 from .queue import Queue
+from .webhook import Webhook
 
 
 class job:  # noqa
@@ -34,6 +35,7 @@ class job:  # noqa
         on_failure: Callback | Callable[..., Any] | None = None,
         on_success: Callback | Callable[..., Any] | None = None,
         on_stopped: Callback | Callable[..., Any] | None = None,
+        webhooks: list[Webhook] | None = None,
     ):
         """A decorator that adds a ``enqueue`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required
@@ -68,6 +70,8 @@ class job:  # noqa
                 to None.
             on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callable to run when stopped. Defaults
                 to None.
+            webhooks (Optional[List[Webhook]], optional): Webhooks to send on matching terminal job statuses.
+                Defaults to None.
         """
         self.queue = queue
         self.queue_class = queue_class if queue_class else Queue
@@ -84,6 +88,7 @@ class job:  # noqa
         self.on_success = on_success
         self.on_failure = on_failure
         self.on_stopped = on_stopped
+        self.webhooks = webhooks
 
     def __call__(self, f):
         @wraps(f)
@@ -120,6 +125,7 @@ class job:  # noqa
                 on_failure=self.on_failure,
                 on_success=self.on_success,
                 on_stopped=self.on_stopped,
+                webhooks=self.webhooks,
             )
 
         f.delay = delay  # TODO: Remove this in 3.0

--- a/rq/job.py
+++ b/rq/job.py
@@ -261,7 +261,7 @@ class Job:
         on_success: Callback | Callable[..., Any] | None = None,  # Callable is deprecated
         on_failure: Callback | Callable[..., Any] | None = None,  # Callable is deprecated
         on_stopped: Callback | Callable[..., Any] | None = None,  # Callable is deprecated
-        webhooks: list[Webhook] | None = None,
+        webhooks: Sequence[Webhook] | None = None,
     ) -> Job:
         """Creates a new Job instance for the given function, arguments, and
         keyword arguments.
@@ -300,7 +300,7 @@ class Job:
                 fails. Defaults to None. Passing a callable is deprecated.
             on_stopped (Optional[Union['Callback', Callable[..., Any]]], optional): A callback to run when/if the Job
                 is stopped. Defaults to None. Passing a callable is deprecated.
-            webhooks (Optional[List[Webhook]], optional): Webhooks to send when the job reaches a matching
+            webhooks (Optional[Sequence[Webhook]], optional): Webhooks to send when the job reaches a matching
                 terminal state (`finished` or `failed`). Defaults to None.
             group_id (Optional[str], optional): A group ID that the job is being added to. Defaults to None.
 
@@ -364,9 +364,9 @@ class Job:
             job._stopped_callback_timeout = on_stopped.timeout
 
         if webhooks:
-            if not isinstance(webhooks, list) or not all(isinstance(webhook, Webhook) for webhook in webhooks):
-                raise TypeError('webhooks must be a list of Webhook instances')
-            job.webhooks = webhooks
+            if not isinstance(webhooks, Sequence) or not all(isinstance(webhook, Webhook) for webhook in webhooks):
+                raise TypeError('webhooks must be a sequence of Webhook instances')
+            job.webhooks = list(webhooks)
 
         # Extra meta data
         job.description = description or job.get_call_string()

--- a/rq/job.py
+++ b/rq/job.py
@@ -1557,13 +1557,14 @@ class Job:
             self.log.exception('Job %s: error while executing stopped callback', self.id)
             raise
 
-    def trigger_webhooks(self, status: str | JobStatus) -> None:
+    def send_webhooks(self, status: str | JobStatus, *, exc_string: str | None = None) -> None:
         """Sends every webhook registered for the given terminal job status.
+        `exc_string` is included in the payload of `failed` webhooks.
         Send errors are logged by `Webhook.send()`, never raised."""
         for webhook in self.webhooks:
             if webhook.job_status == status:
                 self.log.debug('Job %s: sending %s webhook to %s', self.id, webhook.job_status, webhook.url)
-                webhook.send(self)
+                webhook.send(self, exc_string=exc_string)
 
     def _handle_success(
         self,

--- a/rq/job.py
+++ b/rq/job.py
@@ -49,6 +49,7 @@ from .utils import (
     str_to_date,
     utcformat,
 )
+from .webhook import Webhook
 
 logger = logging.getLogger('rq.job')
 
@@ -195,6 +196,7 @@ class Job:
         self._failure_callback: Callable[[Job, Redis, Unpack[tuple[ExcInfo]]], Any] | UnevaluatedType = UNEVALUATED
         self._stopped_callback_name: str | None = None
         self._stopped_callback: Callable[[Job, Redis], Any] | UnevaluatedType | None = UNEVALUATED
+        self.webhooks: list[Webhook] = []
         self.description: str | None = None
         self.origin: str = ''
         self.enqueued_at: datetime | None = None
@@ -259,6 +261,7 @@ class Job:
         on_success: Callback | Callable[..., Any] | None = None,  # Callable is deprecated
         on_failure: Callback | Callable[..., Any] | None = None,  # Callable is deprecated
         on_stopped: Callback | Callable[..., Any] | None = None,  # Callable is deprecated
+        webhooks: list[Webhook] | None = None,
     ) -> Job:
         """Creates a new Job instance for the given function, arguments, and
         keyword arguments.
@@ -297,6 +300,8 @@ class Job:
                 fails. Defaults to None. Passing a callable is deprecated.
             on_stopped (Optional[Union['Callback', Callable[..., Any]]], optional): A callback to run when/if the Job
                 is stopped. Defaults to None. Passing a callable is deprecated.
+            webhooks (Optional[List[Webhook]], optional): Webhooks to send when the job reaches a matching
+                terminal state (`finished` or `failed`). Defaults to None.
             group_id (Optional[str], optional): A group ID that the job is being added to. Defaults to None.
 
         Raises:
@@ -306,6 +311,7 @@ class Job:
             ValueError: If `on_failure` is not a Callback or function or string
             ValueError: If `on_success` is not a Callback or function or string
             ValueError: If `on_stopped` is not a Callback or function or string
+            TypeError: If `webhooks` is not a list of Webhook instances
 
         Returns:
             Job: A job instance.
@@ -356,6 +362,11 @@ class Job:
                 on_stopped = Callback(on_stopped)  # backward compatibility
             job._stopped_callback_name = on_stopped.name
             job._stopped_callback_timeout = on_stopped.timeout
+
+        if webhooks:
+            if not isinstance(webhooks, list) or not all(isinstance(webhook, Webhook) for webhook in webhooks):
+                raise TypeError('webhooks must be a list of Webhook instances')
+            job.webhooks = webhooks
 
         # Extra meta data
         job.description = description or job.get_call_string()
@@ -998,6 +1009,13 @@ class Job:
         if 'stopped_callback_timeout' in obj:
             self._stopped_callback_timeout = int(obj['stopped_callback_timeout'])
 
+        if obj.get('webhooks'):
+            try:
+                self.webhooks = [Webhook.from_dict(data) for data in json.loads(obj['webhooks'].decode())]
+            except Exception:
+                self.log.warning('Job %s: failed to deserialize webhooks', self.id, exc_info=True)
+                self.webhooks = []
+
         dep_ids = obj.get('dependency_ids')
         dep_id = obj.get('dependency_id')  # for backwards compatibility
         self._dependency_ids = json.loads(dep_ids.decode()) if dep_ids else [dep_id.decode()] if dep_id else []
@@ -1105,6 +1123,8 @@ class Job:
             obj['failure_callback_timeout'] = self._failure_callback_timeout
         if self._stopped_callback_timeout is not None:
             obj['stopped_callback_timeout'] = self._stopped_callback_timeout
+        if self.webhooks:
+            obj['webhooks'] = json.dumps([webhook.to_dict() for webhook in self.webhooks])
         if self.result_ttl is not None:
             obj['result_ttl'] = self.result_ttl
         if self.failure_ttl is not None:
@@ -1536,6 +1556,14 @@ class Job:
         except Exception:  # noqa
             self.log.exception('Job %s: error while executing stopped callback', self.id)
             raise
+
+    def trigger_webhooks(self, status: str | JobStatus) -> None:
+        """Sends every webhook registered for the given terminal job status.
+        Send errors are logged by `Webhook.send()`, never raised."""
+        for webhook in self.webhooks:
+            if webhook.job_status == status:
+                self.log.debug('Job %s: sending %s webhook to %s', self.id, webhook.job_status, webhook.url)
+                webhook.send(self)
 
     def _handle_success(
         self,

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -37,6 +37,7 @@ from .scripts import save_unique_job, schedule_unique_job
 from .serializers import Serializer, resolve_serializer
 from .types import FunctionReferenceType, JobDependencyType
 from .utils import as_text, backend_class, compact, get_version, import_attribute, now, parse_timeout
+from .webhook import Webhook
 
 logger = logging.getLogger('rq.queue')
 
@@ -62,6 +63,7 @@ class EnqueueData(
             'on_failure',
             'on_stopped',
             'repeat',
+            'webhooks',
         ],
     )
 ):
@@ -94,6 +96,7 @@ class EnqueueArgs(NamedTuple):
     unique: bool
     args: tuple | list | None
     kwargs: dict | None
+    webhooks: list[Webhook] | None
 
 
 @total_ordering
@@ -554,6 +557,7 @@ class Queue:
         on_success: Callback | Callable | None = None,
         on_failure: Callback | Callable | None = None,
         on_stopped: Callback | Callable | None = None,
+        webhooks: list[Webhook] | None = None,
         group_id: str | None = None,
     ) -> Job:
         """Creates a job based on parameters given
@@ -579,6 +583,8 @@ class Queue:
                 None. Callable is deprecated.
             on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on stopped. Defaults to
                 None. Callable is deprecated.
+            webhooks (Optional[List[Webhook]], optional): Webhooks to send on matching terminal job statuses.
+                Defaults to None.
             pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
             group_id (Optional[str], optional): A group ID that the job is being added to. Defaults to None.
 
@@ -622,6 +628,7 @@ class Queue:
             on_success=on_success,
             on_failure=on_failure,
             on_stopped=on_stopped,
+            webhooks=webhooks,
             group_id=group_id,
         )
 
@@ -716,6 +723,7 @@ class Queue:
         on_stopped: Callback | Callable[..., Any] | None = None,
         pipeline: Pipeline | None = None,
         unique: bool = False,
+        webhooks: list[Webhook] | None = None,
     ) -> Job:
         """Creates a job to represent the delayed function call and enqueues it.
 
@@ -746,6 +754,8 @@ class Queue:
             pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
             unique (bool, optional): If True, raises DuplicateJobError if a job with the same ID exists.
                 Defaults to False.
+            webhooks (Optional[List[Webhook]], optional): Webhooks to send on matching terminal job statuses.
+                Defaults to None.
 
         Returns:
             Job: The enqueued Job
@@ -771,6 +781,7 @@ class Queue:
             on_success=on_success,
             on_failure=on_failure,
             on_stopped=on_stopped,
+            webhooks=webhooks,
         )
         return self.enqueue_job(job, pipeline=pipeline, at_front=at_front, unique=unique)
 
@@ -793,6 +804,7 @@ class Queue:
         on_failure: Callback | Callable | None = None,
         on_stopped: Callback | Callable | None = None,
         repeat: Repeat | None = None,
+        webhooks: list[Webhook] | None = None,
     ) -> EnqueueData:
         """Need this till support dropped for python_version < 3.7, where defaults can be specified for named tuples
         And can keep this logic within EnqueueData
@@ -818,6 +830,8 @@ class Queue:
             on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on stopped. Defaults to
                 None. Callable is deprecated.
             repeat (Optional[Repeat], optional): Repeat object. Defaults to None.
+            webhooks (Optional[List[Webhook]], optional): Webhooks to send on matching terminal job statuses.
+                Defaults to None.
 
         Returns:
             EnqueueData: The EnqueueData
@@ -840,6 +854,7 @@ class Queue:
             on_failure,
             on_stopped,
             repeat,
+            webhooks,
         )
 
     def enqueue_many(
@@ -882,6 +897,7 @@ class Queue:
                 'on_success': job_data.on_success,
                 'on_failure': job_data.on_failure,
                 'on_stopped': job_data.on_stopped,
+                'webhooks': job_data.webhooks,
                 'group_id': group_id,
                 'repeat': job_data.repeat,
             }
@@ -979,6 +995,7 @@ class Queue:
         on_success = kwargs.pop('on_success', None)
         on_failure = kwargs.pop('on_failure', None)
         on_stopped = kwargs.pop('on_stopped', None)
+        webhooks = kwargs.pop('webhooks', None)
         pipeline = kwargs.pop('pipeline', None)
         unique = kwargs.pop('unique', False)
 
@@ -1007,6 +1024,7 @@ class Queue:
             unique,
             args,
             kwargs,
+            webhooks,
         )
 
     def enqueue(self, f: FunctionReferenceType, *args, **kwargs) -> Job:
@@ -1041,6 +1059,7 @@ class Queue:
             unique,
             args,
             kwargs,
+            webhooks,
         ) = Queue.parse_args(f, *args, **kwargs)
 
         return self.enqueue_call(
@@ -1061,6 +1080,7 @@ class Queue:
             on_success=on_success,
             on_failure=on_failure,
             on_stopped=on_stopped,
+            webhooks=webhooks,
             pipeline=pipeline,
             unique=unique,
         )
@@ -1095,6 +1115,7 @@ class Queue:
             unique,  # Not used for scheduled jobs, but parsed for consistency
             args,
             kwargs,
+            webhooks,
         ) = Queue.parse_args(f, *args, **kwargs)
         job = self.create_job(
             f,
@@ -1114,6 +1135,7 @@ class Queue:
             on_success=on_success,
             on_failure=on_failure,
             on_stopped=on_stopped,
+            webhooks=webhooks,
         )
         if at_front:
             job.enqueue_at_front = True

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -1370,9 +1370,11 @@ class Queue:
 
             if job.failure_callback:
                 job.failure_callback(job, self.connection, *sys.exc_info())
+            job.send_webhooks(JobStatus.FAILED, exc_string=exc_string)
         else:
             if job.success_callback:
                 job.success_callback(job, self.connection, job.return_value())
+            job.send_webhooks(JobStatus.FINISHED)
 
         return job
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -96,7 +96,7 @@ class EnqueueArgs(NamedTuple):
     unique: bool
     args: tuple | list | None
     kwargs: dict | None
-    webhooks: list[Webhook] | None
+    webhooks: Sequence[Webhook] | None
 
 
 @total_ordering
@@ -557,7 +557,7 @@ class Queue:
         on_success: Callback | Callable | None = None,
         on_failure: Callback | Callable | None = None,
         on_stopped: Callback | Callable | None = None,
-        webhooks: list[Webhook] | None = None,
+        webhooks: Sequence[Webhook] | None = None,
         group_id: str | None = None,
     ) -> Job:
         """Creates a job based on parameters given
@@ -583,7 +583,7 @@ class Queue:
                 None. Callable is deprecated.
             on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on stopped. Defaults to
                 None. Callable is deprecated.
-            webhooks (Optional[List[Webhook]], optional): Webhooks to send on matching terminal job statuses.
+            webhooks (Optional[Sequence[Webhook]], optional): Webhooks to send on matching terminal job statuses.
                 Defaults to None.
             pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
             group_id (Optional[str], optional): A group ID that the job is being added to. Defaults to None.
@@ -723,7 +723,7 @@ class Queue:
         on_stopped: Callback | Callable[..., Any] | None = None,
         pipeline: Pipeline | None = None,
         unique: bool = False,
-        webhooks: list[Webhook] | None = None,
+        webhooks: Sequence[Webhook] | None = None,
     ) -> Job:
         """Creates a job to represent the delayed function call and enqueues it.
 
@@ -754,7 +754,7 @@ class Queue:
             pipeline (Optional[Pipeline], optional): The Redis Pipeline. Defaults to None.
             unique (bool, optional): If True, raises DuplicateJobError if a job with the same ID exists.
                 Defaults to False.
-            webhooks (Optional[List[Webhook]], optional): Webhooks to send on matching terminal job statuses.
+            webhooks (Optional[Sequence[Webhook]], optional): Webhooks to send on matching terminal job statuses.
                 Defaults to None.
 
         Returns:
@@ -804,7 +804,7 @@ class Queue:
         on_failure: Callback | Callable | None = None,
         on_stopped: Callback | Callable | None = None,
         repeat: Repeat | None = None,
-        webhooks: list[Webhook] | None = None,
+        webhooks: Sequence[Webhook] | None = None,
     ) -> EnqueueData:
         """Need this till support dropped for python_version < 3.7, where defaults can be specified for named tuples
         And can keep this logic within EnqueueData
@@ -830,7 +830,7 @@ class Queue:
             on_stopped (Optional[Union[Callback, Callable[..., Any]]], optional): Callback for on stopped. Defaults to
                 None. Callable is deprecated.
             repeat (Optional[Repeat], optional): Repeat object. Defaults to None.
-            webhooks (Optional[List[Webhook]], optional): Webhooks to send on matching terminal job statuses.
+            webhooks (Optional[Sequence[Webhook]], optional): Webhooks to send on matching terminal job statuses.
                 Defaults to None.
 
         Returns:

--- a/rq/webhook.py
+++ b/rq/webhook.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import asdict, dataclass
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 if TYPE_CHECKING:
-    from .job import Job, JobStatus
+    from .job import Job
 
 logger = logging.getLogger('rq.webhook')
 
@@ -33,7 +32,7 @@ class Webhook:
     def __init__(
         self,
         url: str,
-        job_status: Literal['finished', 'failed'] | JobStatus,
+        job_status: Literal['finished', 'failed'],
         *,
         method: Literal['GET', 'POST'] = 'GET',
         headers: dict[str, str] | None = None,
@@ -43,22 +42,20 @@ class Webhook:
         if parsed is None or parsed.scheme not in ('http', 'https') or not parsed.netloc:
             raise ValueError(f'url must be an http:// or https:// URL, got {url!r}')
 
-        status_value = job_status.value if isinstance(job_status, Enum) else job_status
-        if status_value not in ('finished', 'failed'):
+        if job_status not in ('finished', 'failed'):
             raise ValueError(f"job_status must be 'finished' or 'failed', got {job_status!r}")
 
         if method not in ('GET', 'POST'):
             raise ValueError(f"method must be 'GET' or 'POST', got {method!r}")
 
-        if headers is not None and not isinstance(headers, dict):
+        if headers and not isinstance(headers, dict):
             raise TypeError(f'headers must be a dict or None, got {type(headers).__name__}')
 
         if not isinstance(timeout, int) or timeout <= 0:
             raise ValueError(f'timeout must be a positive integer, got {timeout!r}')
 
         self.url = url
-        # Assign literal constants so the field's Literal type holds without a cast
-        self.job_status = 'finished' if status_value == 'finished' else 'failed'
+        self.job_status = job_status
         self.method = method
         self.headers = headers
         self.timeout = timeout

--- a/rq/webhook.py
+++ b/rq/webhook.py
@@ -84,13 +84,7 @@ class Webhook:
             'enqueued_at': job.enqueued_at.isoformat() if job.enqueued_at else None,
             'ended_at': job.ended_at.isoformat() if job.ended_at else None,
         }
-        if self.job_status == 'finished':
-            try:
-                json.dumps(job._result)
-                payload['result'] = job._result
-            except TypeError:
-                payload['result'] = str(job._result)
-        else:
+        if self.job_status == 'failed':
             payload['exc_info'] = exc_string
         return payload
 

--- a/rq/webhook.py
+++ b/rq/webhook.py
@@ -4,7 +4,7 @@ import json
 import logging
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
@@ -57,7 +57,8 @@ class Webhook:
             raise ValueError(f'timeout must be a positive integer, got {timeout!r}')
 
         self.url = url
-        self.job_status = cast("Literal['finished', 'failed']", status_value)
+        # Assign literal constants so the field's Literal type holds without a cast
+        self.job_status = 'finished' if status_value == 'finished' else 'failed'
         self.method = method
         self.headers = headers
         self.timeout = timeout

--- a/rq/webhook.py
+++ b/rq/webhook.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Literal, cast
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+if TYPE_CHECKING:
+    from .job import Job, JobStatus
+
+logger = logging.getLogger('rq.webhook')
+
+
+@dataclass
+class Webhook:
+    """A pure-data description of an HTTP request to perform when a job
+    reaches a terminal state (``finished`` or ``failed``).
+
+    Unlike callbacks, webhooks are JSON-serializable and don't require an
+    importable function. Send failures are logged and never raised, so an
+    unreachable endpoint cannot fail the job.
+    """
+
+    url: str
+    job_status: Literal['finished', 'failed']
+    method: Literal['GET', 'POST']
+    headers: dict[str, str] | None
+    timeout: int
+
+    def __init__(
+        self,
+        url: str,
+        job_status: Literal['finished', 'failed'] | JobStatus,
+        *,
+        method: Literal['GET', 'POST'] = 'GET',
+        headers: dict[str, str] | None = None,
+        timeout: int = 10,
+    ) -> None:
+        parsed = urlparse(url) if isinstance(url, str) else None
+        if parsed is None or parsed.scheme not in ('http', 'https') or not parsed.netloc:
+            raise ValueError(f'url must be an http:// or https:// URL, got {url!r}')
+
+        status_value = job_status.value if isinstance(job_status, Enum) else job_status
+        if status_value not in ('finished', 'failed'):
+            raise ValueError(f"job_status must be 'finished' or 'failed', got {job_status!r}")
+
+        if method not in ('GET', 'POST'):
+            raise ValueError(f"method must be 'GET' or 'POST', got {method!r}")
+
+        if headers is not None and not isinstance(headers, dict):
+            raise TypeError(f'headers must be a dict or None, got {type(headers).__name__}')
+
+        if not isinstance(timeout, int) or timeout <= 0:
+            raise ValueError(f'timeout must be a positive integer, got {timeout!r}')
+
+        self.url = url
+        self.job_status = cast("Literal['finished', 'failed']", status_value)
+        self.method = method
+        self.headers = headers
+        self.timeout = timeout
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Webhook:
+        return cls(
+            data['url'],
+            data['job_status'],
+            method=data.get('method', 'GET'),
+            headers=data.get('headers'),
+            timeout=data.get('timeout', 10),
+        )
+
+    def build_payload(self, job: Job) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            'job_id': job.id,
+            'func_name': job.func_name,
+            'status': self.job_status,
+            'enqueued_at': job.enqueued_at.isoformat() if job.enqueued_at else None,
+            'ended_at': job.ended_at.isoformat() if job.ended_at else None,
+        }
+        if self.job_status == 'finished':
+            try:
+                json.dumps(job._result)
+                payload['result'] = job._result
+            except TypeError:
+                payload['result'] = str(job._result)
+        else:
+            from .results import Result
+
+            latest_result = job.latest_result()
+            if latest_result and latest_result.type == Result.Type.FAILED:
+                payload['exc_info'] = latest_result.exc_string
+            else:
+                payload['exc_info'] = None
+        return payload
+
+    def send(self, job: Job) -> None:
+        """Performs the HTTP request. Errors are logged, never raised."""
+        try:
+            if self.method == 'GET':
+                request = Request(self.url, headers=self.headers or {}, method='GET')
+            else:
+                body = json.dumps(self.build_payload(job)).encode('utf-8')
+                headers = {'Content-Type': 'application/json', **(self.headers or {})}
+                request = Request(self.url, data=body, headers=headers, method='POST')
+            with urlopen(request, timeout=self.timeout):
+                pass
+        except Exception:
+            logger.warning('Failed to send webhook to %s for job %s', self.url, job.id, exc_info=True)

--- a/rq/webhook.py
+++ b/rq/webhook.py
@@ -75,7 +75,7 @@ class Webhook:
             timeout=data.get('timeout', 10),
         )
 
-    def build_payload(self, job: Job) -> dict[str, Any]:
+    def get_payload(self, job: Job, *, exc_string: str | None = None) -> dict[str, Any]:
         payload: dict[str, Any] = {
             'job_id': job.id,
             'func_name': job.func_name,
@@ -90,22 +90,16 @@ class Webhook:
             except TypeError:
                 payload['result'] = str(job._result)
         else:
-            from .results import Result
-
-            latest_result = job.latest_result()
-            if latest_result and latest_result.type == Result.Type.FAILED:
-                payload['exc_info'] = latest_result.exc_string
-            else:
-                payload['exc_info'] = None
+            payload['exc_info'] = exc_string
         return payload
 
-    def send(self, job: Job) -> None:
+    def send(self, job: Job, *, exc_string: str | None = None) -> None:
         """Performs the HTTP request. Errors are logged, never raised."""
         try:
             if self.method == 'GET':
                 request = Request(self.url, headers=self.headers or {}, method='GET')
             else:
-                body = json.dumps(self.build_payload(job)).encode('utf-8')
+                body = json.dumps(self.get_payload(job, exc_string=exc_string)).encode('utf-8')
                 headers = {'Content-Type': 'application/json', **(self.headers or {})}
                 request = Request(self.url, data=body, headers=headers, method='POST')
             with urlopen(request, timeout=self.timeout):

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -1404,6 +1404,9 @@ class BaseWorker:
 
                 try:
                     pipeline.execute()
+                    # Terminal failure (retries exhausted): fire failed webhooks after the failure is
+                    # persisted, before enqueue_dependents. No exception here, so exc_string is empty.
+                    job.send_webhooks(JobStatus.FAILED, exc_string='')
                     queue.enqueue_dependents(job)
                 except Exception as e:
                     self.log.error(

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -754,10 +754,13 @@ class BaseWorker:
 
             try:
                 pipeline.execute()
-                if enqueue_dependents:
-                    queue.enqueue_dependents(job)
+                # Fire failed webhooks only after the terminal failure is persisted, and
+                # skip retried/stopped jobs. Placed before enqueue_dependents (which can raise)
+                # so dispatch isn't lost if dependent enqueueing fails; send_webhooks never raises.
                 if not retry and not job_is_stopped:
                     job.send_webhooks(JobStatus.FAILED, exc_string=exc_string)
+                if enqueue_dependents:
+                    queue.enqueue_dependents(job)
             except Exception as e:
                 # Ensure that custom exception handlers are called
                 # even if Redis is down

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -756,6 +756,8 @@ class BaseWorker:
                 pipeline.execute()
                 if enqueue_dependents:
                     queue.enqueue_dependents(job)
+                if not retry and not job_is_stopped:
+                    job.send_webhooks(JobStatus.FAILED, exc_string=exc_string)
             except Exception as e:
                 # Ensure that custom exception handlers are called
                 # even if Redis is down
@@ -1563,6 +1565,7 @@ class BaseWorker:
                 job._status = JobStatus.FINISHED
                 job.execute_success_callback(self.death_penalty_class, return_value)
                 self.handle_job_success(job=job, queue=queue, started_job_registry=started_job_registry)
+                job.send_webhooks(JobStatus.FINISHED)
 
         except:  # NOQA
             self.log.debug('Worker %s: job %s raised an exception.', self.name, job.id)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -62,6 +62,14 @@ def div_by_zero(x):
     return x / 0
 
 
+def fail_while_retries_remain():
+    """Raises while retries remain, succeeds on the final attempt."""
+    job = get_current_job()
+    if job.retries_left and job.retries_left > 0:
+        raise Exception('failing while retries remain')
+    return 'success'
+
+
 def long_process():
     time.sleep(60)
     return

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -70,6 +70,13 @@ def fail_while_retries_remain():
     return 'success'
 
 
+def returns_retry():
+    """Always returns a Retry object (return-based retry)."""
+    from rq import Retry
+
+    return Retry(max=1)
+
+
 def long_process():
     time.sleep(60)
     return

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -11,11 +11,12 @@ from unittest.mock import patch
 
 from redis import Redis
 
-from rq import Queue, utils
+from rq import Queue, cron, utils
 from rq.connections import get_connection_kwargs
 from rq.cron import CronJob, CronScheduler, _job_data_registry
 from rq.cron_scheduler_registry import get_keys, get_registry_key
 from rq.exceptions import SchedulerNotFound
+from rq.webhook import Webhook
 from tests import RQTestCase
 from tests.fixtures import div_by_zero, do_nothing, say_hello
 
@@ -221,6 +222,33 @@ class TestCronScheduler(RQTestCase):
         self.assertEqual(cron_job.job_options['job_timeout'], timeout)
         self.assertEqual(cron_job.job_options['result_ttl'], result_ttl)
         self.assertEqual(cron_job.job_options['meta'], meta)
+
+    def test_register_with_webhooks(self):
+        """scheduler.register() stores webhooks and validates them immediately"""
+        scheduler = CronScheduler(connection=self.connection)
+        webhooks = [Webhook('http://example.com/done', 'finished')]
+
+        cron_job = scheduler.register(func=say_hello, queue_name=self.queue_name, interval=30, webhooks=webhooks)
+        self.assertEqual(cron_job.job_options['webhooks'], webhooks)
+
+        # Direct registration fails fast on invalid webhooks
+        with self.assertRaises(TypeError):
+            scheduler.register(func=say_hello, queue_name=self.queue_name, interval=30, webhooks=['bad'])
+
+    def test_module_register_forwards_webhooks(self):
+        """cron.register() carries webhooks into job_data and reach the enqueued job"""
+        webhooks = [Webhook('http://example.com/done', 'finished')]
+
+        job_data = cron.register(say_hello, queue_name=self.queue_name, interval=60, webhooks=webhooks)
+        self.assertEqual(job_data['webhooks'], webhooks)
+
+        scheduler = cron.create_cron(self.connection)
+        self.assertEqual(scheduler.get_jobs()[0].job_options['webhooks'], webhooks)
+
+        scheduler.enqueue_jobs()
+        jobs = Queue(self.queue_name, connection=self.connection).get_jobs()
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs[0].webhooks, webhooks)
 
     def test_load_config_from_file_method(self):  # Renamed test
         """Test loading cron configuration using the instance method"""

--- a/tests/test_cron_job.py
+++ b/tests/test_cron_job.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 from rq import Queue, utils
 from rq.cron import CronJob, CronScheduler
 from rq.utils import NOT_JSON_SERIALIZABLE
+from rq.webhook import Webhook
 from tests import RQTestCase
 from tests.fixtures import say_hello
 
@@ -60,6 +61,29 @@ class TestCronJob(RQTestCase):
         self.assertEqual(cron_job.job_options['ttl'], ttl)
         self.assertEqual(cron_job.job_options['failure_ttl'], failure_ttl)
         self.assertEqual(cron_job.job_options['meta'], meta)
+
+    def test_cron_job_with_webhooks(self):
+        """CronJob stores webhooks in job_options and validates them at registration time"""
+        webhooks = [Webhook('http://example.com/done', 'finished')]
+        cron_job = CronJob(func=say_hello, queue_name=self.queue.name, interval=60, webhooks=webhooks)
+        self.assertEqual(cron_job.job_options['webhooks'], webhooks)
+
+        # A bare Webhook (not wrapped in a list)
+        with self.assertRaises(TypeError):
+            CronJob(
+                func=say_hello,
+                queue_name=self.queue.name,
+                interval=60,
+                webhooks=Webhook('http://example.com', 'finished'),
+            )
+
+        # A list containing a non-Webhook item
+        with self.assertRaises(TypeError):
+            CronJob(func=say_hello, queue_name=self.queue.name, interval=60, webhooks=['http://example.com'])
+
+        # An empty list is dropped (not stored), matching Job's behavior
+        cron_job = CronJob(func=say_hello, queue_name=self.queue.name, interval=60, webhooks=[])
+        self.assertNotIn('webhooks', cron_job.job_options)
 
     def test_get_next_enqueue_time(self):
         """Test that get_next_enqueue_time correctly calculates the next run time"""
@@ -129,6 +153,13 @@ class TestCronJob(RQTestCase):
         self.assertEqual(job.timeout, timeout_value)
         # Verify job can be executed without TypeError
         job.perform()
+
+    def test_enqueue_with_webhooks(self):
+        """Webhooks are attached to the job produced by enqueue"""
+        webhooks = [Webhook('http://example.com/done', 'finished')]
+        cron_job = CronJob(func=say_hello, queue_name=self.queue.name, interval=60, webhooks=webhooks)
+        job = cron_job.enqueue(self.connection)
+        self.assertEqual(job.webhooks, webhooks)
 
     def test_set_enqueue_time(self):
         """Test that set_enqueue_time correctly sets latest run time and updates next run time"""
@@ -333,6 +364,20 @@ class TestCronJob(RQTestCase):
         self.assertEqual(restored_job.kwargs, original_job.kwargs)
         # Assert job_options preserved
         self.assertEqual(restored_job.job_options, original_job.job_options)
+
+    def test_webhooks_serialization_roundtrip(self):
+        """Webhooks survive to_dict/from_dict, rebuilt as Webhook instances"""
+        webhooks = [
+            Webhook('http://example.com/done', 'finished', method='POST', timeout=5),
+            Webhook('http://example.com/fail', 'failed'),
+        ]
+        job = CronJob(func=say_hello, queue_name=self.queue.name, interval=60, webhooks=webhooks)
+
+        data = job.to_dict()
+        self.assertIsInstance(data['webhooks'], str)  # serialized to a JSON string for storage
+
+        restored = CronJob.from_dict(data)
+        self.assertEqual(restored.job_options['webhooks'], webhooks)
 
     def test_non_serializable_arguments(self):
         """Test that from_dict gracefully handles the non-serializable placeholder through Redis"""

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -3,6 +3,7 @@ from unittest import mock
 from rq.decorators import job
 from rq.job import Job, Retry
 from rq.queue import Queue
+from rq.webhook import Webhook
 from rq.worker import DEFAULT_RESULT_TTL
 from tests import RQTestCase
 
@@ -192,6 +193,18 @@ class TestDecorator(RQTestCase):
         result = hello.enqueue()
         result_job = Job.fetch(id=result.id, connection=self.connection)
         self.assertEqual(result_job.success_callback, print)
+
+    def test_decorator_accepts_webhooks_as_argument(self):
+        """Ensure that passing webhooks to the decorator sets them on the job."""
+        webhooks = [Webhook('http://example.com/done', 'finished')]
+
+        @job('default', connection=self.connection, webhooks=webhooks)
+        def hello():
+            return 'Hello'
+
+        result = hello.enqueue()
+        result_job = Job.fetch(id=result.id, connection=self.connection)
+        self.assertEqual(result_job.webhooks, webhooks)
 
     def test_decorator_custom_queue_class(self):
         """Ensure that a custom queue class can be passed to the job decorator"""

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -104,9 +104,8 @@ class WebhookTestCase(RQTestCase):
         job = Job.create(say_hello, connection=self.connection)
         job.enqueued_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         job.ended_at = datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
-        job._result = {'answer': 42}
 
-        # Finished: includes the job result
+        # Finished: job metadata only (the result is intentionally not included)
         payload = Webhook('http://example.com', 'finished').get_payload(job)
         self.assertEqual(
             payload,
@@ -116,23 +115,15 @@ class WebhookTestCase(RQTestCase):
                 'status': 'finished',
                 'enqueued_at': job.enqueued_at.isoformat(),
                 'ended_at': job.ended_at.isoformat(),
-                'result': {'answer': 42},
             },
         )
         json.dumps(payload)  # the whole payload must be JSON-serializable
 
-        # Finished: results that can't be JSON-serialized fall back to str()
-        job._result = object()
-        payload = Webhook('http://example.com', 'finished').get_payload(job)
-        self.assertEqual(payload['result'], str(job._result))
-        json.dumps(payload)
-
-        # Failed: includes exc_info from the supplied exception string, never a result
+        # Failed: includes exc_info from the supplied exception string
         failed_webhook = Webhook('http://example.com', 'failed')
         payload = failed_webhook.get_payload(job, exc_string='Traceback: division by zero')
         self.assertEqual(payload['status'], 'failed')
         self.assertEqual(payload['exc_info'], 'Traceback: division by zero')
-        self.assertNotIn('result', payload)
         json.dumps(payload)
 
         # Failed: exc_info is None when no exception string is supplied

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,185 @@
+import json
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from rq.job import Job, JobStatus
+from rq.queue import Queue
+from rq.results import Result
+from rq.webhook import Webhook
+from tests import RQTestCase, min_redis_version
+
+from .fixtures import say_hello
+
+
+class WebhookTestCase(RQTestCase):
+    def test_init_defaults(self):
+        webhook = Webhook('http://example.com/hook', 'finished')
+        self.assertEqual(webhook.url, 'http://example.com/hook')
+        self.assertEqual(webhook.job_status, 'finished')
+        self.assertEqual(webhook.method, 'GET')
+        self.assertIsNone(webhook.headers)
+        self.assertEqual(webhook.timeout, 10)
+
+    def test_init_full(self):
+        webhook = Webhook(
+            'https://example.com/hook',
+            'failed',
+            method='POST',
+            headers={'Authorization': 'Bearer token'},
+            timeout=5,
+        )
+        self.assertEqual(webhook.job_status, 'failed')
+        self.assertEqual(webhook.method, 'POST')
+        self.assertEqual(webhook.headers, {'Authorization': 'Bearer token'})
+        self.assertEqual(webhook.timeout, 5)
+
+    def test_url_validation(self):
+        with self.assertRaises(ValueError):
+            Webhook('', 'finished')
+        with self.assertRaises(ValueError):
+            Webhook('example.com/hook', 'finished')
+        with self.assertRaises(ValueError):
+            Webhook('ftp://example.com', 'finished')
+        with self.assertRaises(ValueError):
+            Webhook('http://', 'finished')
+        with self.assertRaises(ValueError):
+            Webhook(None, 'finished')
+
+    def test_job_status_validation(self):
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', None)
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'stopped')
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', JobStatus.STOPPED)
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', ['finished'])
+
+    def test_method_validation(self):
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'finished', method='PUT')
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'finished', method='DELETE')
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'finished', method='get')
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'finished', method='post')
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'finished', method=None)
+
+    def test_headers_validation(self):
+        with self.assertRaises(TypeError):
+            Webhook('http://example.com', 'finished', headers=[('X-Token', 'secret')])
+
+    def test_timeout_validation(self):
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'finished', timeout=0)
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'finished', timeout=-1)
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'finished', timeout='10')
+        with self.assertRaises(ValueError):
+            Webhook('http://example.com', 'finished', timeout=1.5)
+
+    def test_to_dict(self):
+        webhook = Webhook('http://example.com', JobStatus.FAILED, method='POST', timeout=5)
+        self.assertEqual(
+            webhook.to_dict(),
+            {
+                'url': 'http://example.com',
+                'job_status': 'failed',
+                'method': 'POST',
+                'headers': None,
+                'timeout': 5,
+            },
+        )
+
+    def test_from_dict_round_trip(self):
+        webhook = Webhook('http://example.com', 'finished', method='POST', headers={'X-A': 'b'}, timeout=3)
+        self.assertEqual(Webhook.from_dict(webhook.to_dict()), webhook)
+
+    def test_from_dict_defaults(self):
+        webhook = Webhook.from_dict({'url': 'http://example.com', 'job_status': 'failed'})
+        self.assertEqual(webhook, Webhook('http://example.com', 'failed'))
+
+    def test_from_dict_revalidates(self):
+        with self.assertRaises(ValueError):
+            Webhook.from_dict({'url': 'http://example.com', 'job_status': 'stopped'})
+
+    def test_build_payload_finished(self):
+        job = Job.create(say_hello, connection=self.connection)
+        job.enqueued_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        job.ended_at = datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
+        job._result = {'answer': 42}
+
+        payload = Webhook('http://example.com', 'finished').build_payload(job)
+        self.assertEqual(
+            payload,
+            {
+                'job_id': job.id,
+                'func_name': 'tests.fixtures.say_hello',
+                'status': 'finished',
+                'enqueued_at': job.enqueued_at.isoformat(),
+                'ended_at': job.ended_at.isoformat(),
+                'result': {'answer': 42},
+            },
+        )
+        json.dumps(payload)  # the whole payload must be JSON-serializable
+
+    def test_build_payload_unserializable_result(self):
+        """Results that can't be JSON-serialized fall back to str()"""
+        job = Job.create(say_hello, connection=self.connection)
+        job._result = object()
+
+        payload = Webhook('http://example.com', 'finished').build_payload(job)
+        self.assertEqual(payload['result'], str(job._result))
+        json.dumps(payload)
+
+    @min_redis_version((5, 0, 0))
+    def test_build_payload_failed(self):
+        queue = Queue(connection=self.connection)
+        job = queue.enqueue(say_hello)
+        Result.create_failure(job, ttl=10, exc_string='Traceback: division by zero')
+
+        payload = Webhook('http://example.com', 'failed').build_payload(job)
+        self.assertEqual(payload['status'], 'failed')
+        self.assertEqual(payload['exc_info'], 'Traceback: division by zero')
+        self.assertNotIn('result', payload)
+        json.dumps(payload)
+
+    def test_send_get(self):
+        job = Job.create(say_hello, connection=self.connection)
+        webhook = Webhook('http://example.com/hook', 'finished', headers={'X-Token': 'secret'}, timeout=3)
+
+        with patch('rq.webhook.urlopen') as urlopen_mock:
+            webhook.send(job)
+
+        request = urlopen_mock.call_args.args[0]
+        self.assertEqual(request.full_url, 'http://example.com/hook')
+        self.assertEqual(request.get_method(), 'GET')
+        self.assertIsNone(request.data)
+        self.assertEqual(request.get_header('X-token'), 'secret')
+        self.assertEqual(urlopen_mock.call_args.kwargs['timeout'], 3)
+
+    def test_send_post(self):
+        job = Job.create(say_hello, connection=self.connection)
+        job._result = 'ok'
+        webhook = Webhook('http://example.com/hook', 'finished', method='POST')
+
+        with patch('rq.webhook.urlopen') as urlopen_mock:
+            webhook.send(job)
+
+        request = urlopen_mock.call_args.args[0]
+        self.assertEqual(request.get_method(), 'POST')
+        self.assertEqual(request.get_header('Content-type'), 'application/json')
+        body = json.loads(request.data.decode('utf-8'))
+        self.assertEqual(body['job_id'], job.id)
+        self.assertEqual(body['result'], 'ok')
+
+    def test_send_swallows_errors(self):
+        """A dead endpoint must never raise out of send()"""
+        job = Job.create(say_hello, connection=self.connection)
+        webhook = Webhook('http://example.com/hook', 'finished')
+
+        with patch('rq.webhook.urlopen', side_effect=ConnectionError('endpoint down')):
+            webhook.send(job)  # should not raise

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -53,18 +53,12 @@ class WebhookTestCase(RQTestCase):
             Webhook('http://example.com', 'stopped')
         with self.assertRaises(ValueError):
             Webhook('http://example.com', JobStatus.STOPPED)
-        with self.assertRaises(ValueError):
-            Webhook('http://example.com', ['finished'])
 
     def test_method_validation(self):
         with self.assertRaises(ValueError):
             Webhook('http://example.com', 'finished', method='PUT')
         with self.assertRaises(ValueError):
-            Webhook('http://example.com', 'finished', method='DELETE')
-        with self.assertRaises(ValueError):
             Webhook('http://example.com', 'finished', method='get')
-        with self.assertRaises(ValueError):
-            Webhook('http://example.com', 'finished', method='post')
         with self.assertRaises(ValueError):
             Webhook('http://example.com', 'finished', method=None)
 
@@ -73,8 +67,6 @@ class WebhookTestCase(RQTestCase):
             Webhook('http://example.com', 'finished', headers=[('X-Token', 'secret')])
 
     def test_timeout_validation(self):
-        with self.assertRaises(ValueError):
-            Webhook('http://example.com', 'finished', timeout=0)
         with self.assertRaises(ValueError):
             Webhook('http://example.com', 'finished', timeout=-1)
         with self.assertRaises(ValueError):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -3,16 +3,15 @@ from datetime import datetime, timezone
 from unittest.mock import patch
 
 from rq.job import Job, JobStatus
-from rq.queue import Queue
-from rq.results import Result
 from rq.webhook import Webhook
-from tests import RQTestCase, min_redis_version
+from tests import RQTestCase
 
 from .fixtures import say_hello
 
 
 class WebhookTestCase(RQTestCase):
-    def test_init_defaults(self):
+    def test_init(self):
+        # Defaults
         webhook = Webhook('http://example.com/hook', 'finished')
         self.assertEqual(webhook.url, 'http://example.com/hook')
         self.assertEqual(webhook.job_status, 'finished')
@@ -20,7 +19,7 @@ class WebhookTestCase(RQTestCase):
         self.assertIsNone(webhook.headers)
         self.assertEqual(webhook.timeout, 10)
 
-    def test_init_full(self):
+        # All fields set explicitly
         webhook = Webhook(
             'https://example.com/hook',
             'failed',
@@ -94,25 +93,27 @@ class WebhookTestCase(RQTestCase):
             },
         )
 
-    def test_from_dict_round_trip(self):
+    def test_from_dict(self):
+        # Round-trips a fully-specified webhook
         webhook = Webhook('http://example.com', 'finished', method='POST', headers={'X-A': 'b'}, timeout=3)
         self.assertEqual(Webhook.from_dict(webhook.to_dict()), webhook)
 
-    def test_from_dict_defaults(self):
+        # Fills defaults for missing optional fields
         webhook = Webhook.from_dict({'url': 'http://example.com', 'job_status': 'failed'})
         self.assertEqual(webhook, Webhook('http://example.com', 'failed'))
 
-    def test_from_dict_revalidates(self):
+        # Re-validates its input
         with self.assertRaises(ValueError):
             Webhook.from_dict({'url': 'http://example.com', 'job_status': 'stopped'})
 
-    def test_build_payload_finished(self):
+    def test_get_payload(self):
         job = Job.create(say_hello, connection=self.connection)
         job.enqueued_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         job.ended_at = datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
         job._result = {'answer': 42}
 
-        payload = Webhook('http://example.com', 'finished').build_payload(job)
+        # Finished: includes the job result
+        payload = Webhook('http://example.com', 'finished').get_payload(job)
         self.assertEqual(
             payload,
             {
@@ -126,25 +127,23 @@ class WebhookTestCase(RQTestCase):
         )
         json.dumps(payload)  # the whole payload must be JSON-serializable
 
-    def test_build_payload_unserializable_result(self):
-        """Results that can't be JSON-serialized fall back to str()"""
-        job = Job.create(say_hello, connection=self.connection)
+        # Finished: results that can't be JSON-serialized fall back to str()
         job._result = object()
-
-        payload = Webhook('http://example.com', 'finished').build_payload(job)
+        payload = Webhook('http://example.com', 'finished').get_payload(job)
         self.assertEqual(payload['result'], str(job._result))
         json.dumps(payload)
 
-    @min_redis_version((5, 0, 0))
-    def test_build_payload_failed(self):
-        queue = Queue(connection=self.connection)
-        job = queue.enqueue(say_hello)
-        Result.create_failure(job, ttl=10, exc_string='Traceback: division by zero')
-
-        payload = Webhook('http://example.com', 'failed').build_payload(job)
+        # Failed: includes exc_info from the supplied exception string, never a result
+        failed_webhook = Webhook('http://example.com', 'failed')
+        payload = failed_webhook.get_payload(job, exc_string='Traceback: division by zero')
         self.assertEqual(payload['status'], 'failed')
         self.assertEqual(payload['exc_info'], 'Traceback: division by zero')
         self.assertNotIn('result', payload)
+        json.dumps(payload)
+
+        # Failed: exc_info is None when no exception string is supplied
+        payload = failed_webhook.get_payload(job)
+        self.assertIsNone(payload['exc_info'])
         json.dumps(payload)
 
     def test_send_get(self):
@@ -163,18 +162,17 @@ class WebhookTestCase(RQTestCase):
 
     def test_send_post(self):
         job = Job.create(say_hello, connection=self.connection)
-        job._result = 'ok'
-        webhook = Webhook('http://example.com/hook', 'finished', method='POST')
+        webhook = Webhook('http://example.com/hook', 'failed', method='POST')
 
         with patch('rq.webhook.urlopen') as urlopen_mock:
-            webhook.send(job)
+            webhook.send(job, exc_string='boom')
 
         request = urlopen_mock.call_args.args[0]
         self.assertEqual(request.get_method(), 'POST')
         self.assertEqual(request.get_header('Content-type'), 'application/json')
         body = json.loads(request.data.decode('utf-8'))
         self.assertEqual(body['job_id'], job.id)
-        self.assertEqual(body['result'], 'ok')
+        self.assertEqual(body['exc_info'], 'boom')
 
     def test_send_swallows_errors(self):
         """A dead endpoint must never raise out of send()"""
@@ -198,11 +196,12 @@ class JobWebhookTestCase(RQTestCase):
         job = Job.create(say_hello, connection=self.connection)
         self.assertEqual(job.webhooks, [])
 
-    def test_create_rejects_bare_webhook(self):
+    def test_create_rejects_invalid_webhooks(self):
+        # A bare Webhook (not wrapped in a list)
         with self.assertRaises(TypeError):
             Job.create(say_hello, connection=self.connection, webhooks=Webhook('http://example.com', 'finished'))
 
-    def test_create_rejects_non_webhook_items(self):
+        # A list containing non-Webhook items
         with self.assertRaises(TypeError):
             Job.create(say_hello, connection=self.connection, webhooks=['http://example.com'])
 
@@ -233,15 +232,17 @@ class JobWebhookTestCase(RQTestCase):
         fetched_job = Job.fetch(job.id, connection=self.connection)
         self.assertEqual(fetched_job.webhooks, [])
 
-    def test_trigger_webhooks_sends_only_matching(self):
+    def test_send_webhooks(self):
         finished_webhook = Webhook('http://example.com/done', 'finished')
         failed_webhook = Webhook('http://example.com/fail', 'failed')
         job = Job.create(say_hello, connection=self.connection, webhooks=[finished_webhook, failed_webhook])
 
+        # Only the matching webhook is sent
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
-            job.trigger_webhooks('finished')
-        send_mock.assert_called_once_with(finished_webhook, job)
+            job.send_webhooks('finished')
+        send_mock.assert_called_once_with(finished_webhook, job, exc_string=None)
 
+        # JobStatus enum matches, and exc_string is forwarded to the matching webhook
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
-            job.trigger_webhooks(JobStatus.FAILED)
-        send_mock.assert_called_once_with(failed_webhook, job)
+            job.send_webhooks(JobStatus.FAILED, exc_string='boom')
+        send_mock.assert_called_once_with(failed_webhook, job, exc_string='boom')

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -8,7 +8,7 @@ from rq.webhook import Webhook
 from rq.worker import SimpleWorker
 from tests import RQTestCase
 
-from .fixtures import div_by_zero, fail_while_retries_remain, say_hello
+from .fixtures import div_by_zero, fail_while_retries_remain, returns_retry, say_hello
 
 
 class WebhookTestCase(RQTestCase):
@@ -328,3 +328,35 @@ class WorkerWebhookTestCase(RQTestCase):
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             self.worker.work(burst=True)
         self.assertEqual(self.fired_webhooks(send_mock), [self.finished_webhook])
+
+    def test_return_based_retry_exhaustion_fires_failed(self):
+        """A job returning Retry until exhausted fires the failed webhook on terminal failure."""
+        self.queue.enqueue(returns_retry, webhooks=[self.finished_webhook, self.failed_webhook])
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            self.worker.work(burst=True)
+        self.assertEqual(self.fired_webhooks(send_mock), [self.failed_webhook])
+
+
+class SyncWebhookTestCase(RQTestCase):
+    """Jobs executed synchronously (is_async=False) also fire webhooks, since they bypass the worker."""
+
+    def setUp(self):
+        super().setUp()
+        self.queue = Queue(connection=self.connection, is_async=False)
+        self.finished_webhook = Webhook('http://example.com/done', 'finished')
+        self.failed_webhook = Webhook('http://example.com/fail', 'failed')
+
+    @staticmethod
+    def fired_webhooks(send_mock):
+        return [call.args[0] for call in send_mock.call_args_list]
+
+    def test_finished_fires_only_finished(self):
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            self.queue.enqueue(say_hello, webhooks=[self.finished_webhook, self.failed_webhook])
+        self.assertEqual(self.fired_webhooks(send_mock), [self.finished_webhook])
+
+    def test_failed_fires_only_failed_with_exc_info(self):
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            self.queue.enqueue(div_by_zero, 1, webhooks=[self.finished_webhook, self.failed_webhook])
+        self.assertEqual(self.fired_webhooks(send_mock), [self.failed_webhook])
+        self.assertIn('ZeroDivisionError', send_mock.call_args.kwargs['exc_string'])

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from rq.job import Job, JobStatus, Retry
 from rq.queue import Queue
@@ -285,23 +285,18 @@ class WorkerWebhookTestCase(RQTestCase):
         self.finished_webhook = Webhook('http://example.com/done', 'finished')
         self.failed_webhook = Webhook('http://example.com/fail', 'failed')
 
-    @staticmethod
-    def fired_webhooks(send_mock):
-        # autospec records the bound instance as the first positional arg
-        return [call.args[0] for call in send_mock.call_args_list]
-
     def test_terminal_status_fires_only_matching_webhook(self):
         # A successful job fires only the finished webhook
         self.queue.enqueue(say_hello, webhooks=[self.finished_webhook, self.failed_webhook])
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             self.worker.work(burst=True)
-        self.assertEqual(self.fired_webhooks(send_mock), [self.finished_webhook])
+        send_mock.assert_called_once_with(self.finished_webhook, ANY, exc_string=ANY)
 
         # A failing job fires only the failed webhook, with the exception string forwarded
         self.queue.enqueue(div_by_zero, 1, webhooks=[self.finished_webhook, self.failed_webhook])
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             self.worker.work(burst=True)
-        self.assertEqual(self.fired_webhooks(send_mock), [self.failed_webhook])
+        send_mock.assert_called_once_with(self.failed_webhook, ANY, exc_string=ANY)
         self.assertIn('ZeroDivisionError', send_mock.call_args.kwargs['exc_string'])
 
     def test_retry_exhausted_fires_failed_once(self):
@@ -311,12 +306,12 @@ class WorkerWebhookTestCase(RQTestCase):
         # First attempt fails and is requeued for retry: the failed webhook must not fire
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             self.worker.work(burst=True, max_jobs=1)
-        self.assertEqual(self.fired_webhooks(send_mock), [])
+        send_mock.assert_not_called()
 
         # Draining the requeued job reaches terminal failure: now it fires exactly once
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             self.worker.work(burst=True)
-        self.assertEqual(self.fired_webhooks(send_mock), [self.failed_webhook])
+        send_mock.assert_called_once_with(self.failed_webhook, ANY, exc_string=ANY)
 
     def test_retry_then_success_skips_failed(self):
         """A job that fails then succeeds fires finished, never failed."""
@@ -327,14 +322,14 @@ class WorkerWebhookTestCase(RQTestCase):
         )
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             self.worker.work(burst=True)
-        self.assertEqual(self.fired_webhooks(send_mock), [self.finished_webhook])
+        send_mock.assert_called_once_with(self.finished_webhook, ANY, exc_string=ANY)
 
     def test_return_based_retry_exhaustion_fires_failed(self):
         """A job returning Retry until exhausted fires the failed webhook on terminal failure."""
         self.queue.enqueue(returns_retry, webhooks=[self.finished_webhook, self.failed_webhook])
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             self.worker.work(burst=True)
-        self.assertEqual(self.fired_webhooks(send_mock), [self.failed_webhook])
+        send_mock.assert_called_once_with(self.failed_webhook, ANY, exc_string=ANY)
 
 
 class SyncWebhookTestCase(RQTestCase):
@@ -346,17 +341,13 @@ class SyncWebhookTestCase(RQTestCase):
         self.finished_webhook = Webhook('http://example.com/done', 'finished')
         self.failed_webhook = Webhook('http://example.com/fail', 'failed')
 
-    @staticmethod
-    def fired_webhooks(send_mock):
-        return [call.args[0] for call in send_mock.call_args_list]
-
     def test_finished_fires_only_finished(self):
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             self.queue.enqueue(say_hello, webhooks=[self.finished_webhook, self.failed_webhook])
-        self.assertEqual(self.fired_webhooks(send_mock), [self.finished_webhook])
+        send_mock.assert_called_once_with(self.finished_webhook, ANY, exc_string=ANY)
 
     def test_failed_fires_only_failed_with_exc_info(self):
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             self.queue.enqueue(div_by_zero, 1, webhooks=[self.finished_webhook, self.failed_webhook])
-        self.assertEqual(self.fired_webhooks(send_mock), [self.failed_webhook])
+        send_mock.assert_called_once_with(self.failed_webhook, ANY, exc_string=ANY)
         self.assertIn('ZeroDivisionError', send_mock.call_args.kwargs['exc_string'])

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -51,8 +51,6 @@ class WebhookTestCase(RQTestCase):
             Webhook('http://example.com', None)
         with self.assertRaises(ValueError):
             Webhook('http://example.com', 'stopped')
-        with self.assertRaises(ValueError):
-            Webhook('http://example.com', JobStatus.STOPPED)
 
     def test_method_validation(self):
         with self.assertRaises(ValueError):
@@ -75,7 +73,7 @@ class WebhookTestCase(RQTestCase):
             Webhook('http://example.com', 'finished', timeout=1.5)
 
     def test_to_dict(self):
-        webhook = Webhook('http://example.com', JobStatus.FAILED, method='POST', timeout=5)
+        webhook = Webhook('http://example.com', 'failed', method='POST', timeout=5)
         self.assertEqual(
             webhook.to_dict(),
             {

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -183,3 +183,65 @@ class WebhookTestCase(RQTestCase):
 
         with patch('rq.webhook.urlopen', side_effect=ConnectionError('endpoint down')):
             webhook.send(job)  # should not raise
+
+
+class JobWebhookTestCase(RQTestCase):
+    def test_create_with_webhooks(self):
+        webhooks = [
+            Webhook('http://example.com/done', 'finished'),
+            Webhook('http://example.com/fail', 'failed'),
+        ]
+        job = Job.create(say_hello, connection=self.connection, webhooks=webhooks)
+        self.assertEqual(job.webhooks, webhooks)
+
+    def test_create_without_webhooks(self):
+        job = Job.create(say_hello, connection=self.connection)
+        self.assertEqual(job.webhooks, [])
+
+    def test_create_rejects_bare_webhook(self):
+        with self.assertRaises(TypeError):
+            Job.create(say_hello, connection=self.connection, webhooks=Webhook('http://example.com', 'finished'))
+
+    def test_create_rejects_non_webhook_items(self):
+        with self.assertRaises(TypeError):
+            Job.create(say_hello, connection=self.connection, webhooks=['http://example.com'])
+
+    def test_webhooks_survive_redis_round_trip(self):
+        webhooks = [
+            Webhook('http://example.com/done', 'finished', method='POST', headers={'X-A': 'b'}, timeout=5),
+            Webhook('http://example.com/fail', 'failed'),
+        ]
+        job = Job.create(say_hello, connection=self.connection, webhooks=webhooks)
+        job.save()
+
+        fetched_job = Job.fetch(job.id, connection=self.connection)
+        self.assertEqual(fetched_job.webhooks, webhooks)
+
+    def test_job_without_webhooks_restores_empty_list(self):
+        """Jobs saved without webhooks (e.g. by older RQ versions) restore with []"""
+        job = Job.create(say_hello, connection=self.connection)
+        job.save()
+
+        fetched_job = Job.fetch(job.id, connection=self.connection)
+        self.assertEqual(fetched_job.webhooks, [])
+
+    def test_corrupted_webhooks_field_restores_empty_list(self):
+        job = Job.create(say_hello, connection=self.connection)
+        job.save()
+        self.connection.hset(job.key, 'webhooks', b'not-json')
+
+        fetched_job = Job.fetch(job.id, connection=self.connection)
+        self.assertEqual(fetched_job.webhooks, [])
+
+    def test_trigger_webhooks_sends_only_matching(self):
+        finished_webhook = Webhook('http://example.com/done', 'finished')
+        failed_webhook = Webhook('http://example.com/fail', 'failed')
+        job = Job.create(say_hello, connection=self.connection, webhooks=[finished_webhook, failed_webhook])
+
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            job.trigger_webhooks('finished')
+        send_mock.assert_called_once_with(finished_webhook, job)
+
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            job.trigger_webhooks(JobStatus.FAILED)
+        send_mock.assert_called_once_with(failed_webhook, job)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,8 +1,9 @@
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from rq.job import Job, JobStatus
+from rq.queue import Queue
 from rq.webhook import Webhook
 from tests import RQTestCase
 
@@ -246,3 +247,42 @@ class JobWebhookTestCase(RQTestCase):
         with patch.object(Webhook, 'send', autospec=True) as send_mock:
             job.send_webhooks(JobStatus.FAILED, exc_string='boom')
         send_mock.assert_called_once_with(failed_webhook, job, exc_string='boom')
+
+
+class QueueWebhookTestCase(RQTestCase):
+    """Webhooks must thread through every enqueue path onto the persisted job."""
+
+    def setUp(self):
+        super().setUp()
+        self.queue = Queue(connection=self.connection)
+        self.webhooks = [
+            Webhook('http://example.com/done', 'finished'),
+            Webhook('http://example.com/fail', 'failed'),
+        ]
+
+    def test_enqueue(self):
+        job = self.queue.enqueue(say_hello, webhooks=self.webhooks)
+        self.assertEqual(job.webhooks, self.webhooks)
+
+    def test_enqueue_call(self):
+        job = self.queue.enqueue_call(say_hello, webhooks=self.webhooks)
+        self.assertEqual(job.webhooks, self.webhooks)
+
+    def test_enqueue_at(self):
+        job = self.queue.enqueue_at(datetime.now(timezone.utc), say_hello, webhooks=self.webhooks)
+        self.assertEqual(job.webhooks, self.webhooks)
+
+    def test_enqueue_in(self):
+        job = self.queue.enqueue_in(timedelta(seconds=60), say_hello, webhooks=self.webhooks)
+        self.assertEqual(job.webhooks, self.webhooks)
+
+    def test_enqueue_many(self):
+        job_data = Queue.prepare_data(say_hello, webhooks=self.webhooks)
+        job = self.queue.enqueue_many([job_data])[0]
+        self.assertEqual(job.webhooks, self.webhooks)
+
+    def test_webhooks_persisted(self):
+        """Webhooks survive enqueue + a fresh fetch from Redis."""
+        job = self.queue.enqueue(say_hello, webhooks=self.webhooks)
+        fetched_job = Job.fetch(job.id, connection=self.connection)
+        self.assertEqual(fetched_job.webhooks, self.webhooks)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -2,12 +2,13 @@ import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-from rq.job import Job, JobStatus
+from rq.job import Job, JobStatus, Retry
 from rq.queue import Queue
 from rq.webhook import Webhook
+from rq.worker import SimpleWorker
 from tests import RQTestCase
 
-from .fixtures import say_hello
+from .fixtures import div_by_zero, fail_while_retries_remain, say_hello
 
 
 class WebhookTestCase(RQTestCase):
@@ -193,10 +194,6 @@ class JobWebhookTestCase(RQTestCase):
         job = Job.create(say_hello, connection=self.connection, webhooks=webhooks)
         self.assertEqual(job.webhooks, webhooks)
 
-    def test_create_without_webhooks(self):
-        job = Job.create(say_hello, connection=self.connection)
-        self.assertEqual(job.webhooks, [])
-
     def test_create_rejects_invalid_webhooks(self):
         # A bare Webhook (not wrapped in a list)
         with self.assertRaises(TypeError):
@@ -217,21 +214,15 @@ class JobWebhookTestCase(RQTestCase):
         fetched_job = Job.fetch(job.id, connection=self.connection)
         self.assertEqual(fetched_job.webhooks, webhooks)
 
-    def test_job_without_webhooks_restores_empty_list(self):
-        """Jobs saved without webhooks (e.g. by older RQ versions) restore with []"""
+    def test_missing_or_corrupted_webhooks_field_restores_empty_list(self):
+        # Missing field (e.g. jobs saved by older RQ versions)
         job = Job.create(say_hello, connection=self.connection)
         job.save()
+        self.assertEqual(Job.fetch(job.id, connection=self.connection).webhooks, [])
 
-        fetched_job = Job.fetch(job.id, connection=self.connection)
-        self.assertEqual(fetched_job.webhooks, [])
-
-    def test_corrupted_webhooks_field_restores_empty_list(self):
-        job = Job.create(say_hello, connection=self.connection)
-        job.save()
+        # Corrupted field falls back to [] instead of raising
         self.connection.hset(job.key, 'webhooks', b'not-json')
-
-        fetched_job = Job.fetch(job.id, connection=self.connection)
-        self.assertEqual(fetched_job.webhooks, [])
+        self.assertEqual(Job.fetch(job.id, connection=self.connection).webhooks, [])
 
     def test_send_webhooks(self):
         finished_webhook = Webhook('http://example.com/done', 'finished')
@@ -286,3 +277,62 @@ class QueueWebhookTestCase(RQTestCase):
         job = self.queue.enqueue(say_hello, webhooks=self.webhooks)
         fetched_job = Job.fetch(job.id, connection=self.connection)
         self.assertEqual(fetched_job.webhooks, self.webhooks)
+
+
+class WorkerWebhookTestCase(RQTestCase):
+    """The worker dispatches matching webhooks once the job reaches a terminal state.
+
+    These tests assert which webhooks the worker hands to `Webhook.send` (and with what
+    `exc_string`); the HTTP request and error-swallowing mechanics are covered by `WebhookTestCase`.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.queue = Queue(connection=self.connection)
+        self.worker = SimpleWorker([self.queue], connection=self.connection)
+        self.finished_webhook = Webhook('http://example.com/done', 'finished')
+        self.failed_webhook = Webhook('http://example.com/fail', 'failed')
+
+    @staticmethod
+    def fired_webhooks(send_mock):
+        # autospec records the bound instance as the first positional arg
+        return [call.args[0] for call in send_mock.call_args_list]
+
+    def test_terminal_status_fires_only_matching_webhook(self):
+        # A successful job fires only the finished webhook
+        self.queue.enqueue(say_hello, webhooks=[self.finished_webhook, self.failed_webhook])
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            self.worker.work(burst=True)
+        self.assertEqual(self.fired_webhooks(send_mock), [self.finished_webhook])
+
+        # A failing job fires only the failed webhook, with the exception string forwarded
+        self.queue.enqueue(div_by_zero, 1, webhooks=[self.finished_webhook, self.failed_webhook])
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            self.worker.work(burst=True)
+        self.assertEqual(self.fired_webhooks(send_mock), [self.failed_webhook])
+        self.assertIn('ZeroDivisionError', send_mock.call_args.kwargs['exc_string'])
+
+    def test_retry_exhausted_fires_failed_once(self):
+        """Intermediate retry attempts don't fire; only the terminal failure does."""
+        self.queue.enqueue(div_by_zero, 1, retry=Retry(max=1, interval=0), webhooks=[self.failed_webhook])
+
+        # First attempt fails and is requeued for retry: the failed webhook must not fire
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            self.worker.work(burst=True, max_jobs=1)
+        self.assertEqual(self.fired_webhooks(send_mock), [])
+
+        # Draining the requeued job reaches terminal failure: now it fires exactly once
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            self.worker.work(burst=True)
+        self.assertEqual(self.fired_webhooks(send_mock), [self.failed_webhook])
+
+    def test_retry_then_success_skips_failed(self):
+        """A job that fails then succeeds fires finished, never failed."""
+        self.queue.enqueue(
+            fail_while_retries_remain,
+            retry=Retry(max=1, interval=0),
+            webhooks=[self.finished_webhook, self.failed_webhook],
+        )
+        with patch.object(Webhook, 'send', autospec=True) as send_mock:
+            self.worker.work(burst=True)
+        self.assertEqual(self.fired_webhooks(send_mock), [self.finished_webhook])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP webhook notifications for job terminal states (`finished`/`failed`) using a new `Webhook` object (GET/POST, headers, timeout).
  * Added `webhooks` support across enqueueing, the `@job` decorator, and cron jobs; included dispatch for synchronous runs.
  * Exposed `Webhook` as a top-level `rq.Webhook` import.
* **Bug Fixes**
  * Improved webhook firing rules and timing so failed webhooks trigger only for terminal failures.
* **Documentation**
  * Updated README, cron documentation, and CHANGES.md with webhook usage and payload semantics.
* **Tests**
  * Added comprehensive webhook, persistence, enqueue/decorator/cron propagation, and worker/sync dispatch coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->