### PR TITLE
Fix double logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### RQ 2.11.0 (unreleased)
 * Refactored how job dependencies are handled. Introduced `READY_TO_ENQUEUE` job status and ReadyJobRegistry. Thanks @selwin!
+* RQ now disables propagation on loggers it configures itself to prevent double logging when applications configure logging afterwards. Thanks @selwin!
 
 ### RQ 2.10.0 (2026-06-20)
 * Added [webhook notifications](https://python-rq.org/docs/#webhooks) to notify external end points when a job finishes or fails. Thanks @selwin!

--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -320,6 +320,10 @@ $ rq worker -c settings
 
 Alternatively, you can also pass in these options via environment variables.
 
+## Logging
+
+RQ logs to the `rq.worker`, `rq.job`, `rq.queue`, `rq.scheduler`, `rq.cron` and `rq.worker_pool` loggers. RQ only sets up its own log handlers when no handler is configured anywhere in the logger hierarchy, so if your application configures logging first, RQ leaves it untouched.
+
 ## Custom Worker Classes
 
 There are times when you want to customize the worker's behavior. Some of the

--- a/rq/cron.py
+++ b/rq/cron.py
@@ -250,7 +250,6 @@ class CronScheduler:
                 log_format=DEFAULT_LOGGING_FORMAT,
                 date_format=DEFAULT_LOGGING_DATE_FORMAT,
             )
-            self.log.propagate = False
 
     def __eq__(self, other) -> bool:
         """Equality does not take the database/connection into account"""

--- a/rq/logutils.py
+++ b/rq/logutils.py
@@ -134,6 +134,9 @@ def setup_loghandlers(
         error_handler.addFilter(lambda record: record.levelno >= logging.ERROR)
         logger.addHandler(handler)
         logger.addHandler(error_handler)
+        # Stop propagation so records aren't duplicated by handlers the
+        # application attaches to an ancestor logger later on
+        logger.propagate = False
 
     if level is not None:
         # The level may be a numeric value (e.g. when using the logging module constants)

--- a/rq/worker_pool.py
+++ b/rq/worker_pool.py
@@ -62,9 +62,7 @@ class WorkerPool:
     ):
         self.num_workers: int = num_workers
         self._workers: list[Worker] = []
-        setup_loghandlers('INFO', DEFAULT_LOGGING_DATE_FORMAT, DEFAULT_LOGGING_FORMAT, name=__name__)
         self.log: logging.Logger = logging.getLogger(__name__)
-        # self.log: logging.Logger = logger
         self._queue_names: list[str] = parse_names(queues)
         self.connection = connection
         self.name: str = uuid4().hex
@@ -281,7 +279,7 @@ def run_worker(
         serializer=serializer,
         job_class=job_class,
         queue_class=queue_class,
-        exception_handlers=exception_handlers
+        exception_handlers=exception_handlers,
     )
     worker.log.info('Starting worker started with PID %s', os.getpid())
     time.sleep(_sleep)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate log messages when applications configure logging after the app starts.
  * Improved logging behavior for workers, schedulers, cron jobs, and worker pools so RQ’s own logging is only applied when appropriate.

* **Documentation**
  * Added a new logging section to the workers docs explaining which RQ loggers are used and how logging handlers are configured.

* **Chores**
  * Updated the changelog with the latest logging behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->