### PR TITLE
Remove worker.current_job_working_time

### DIFF
--- a/rq/executions.py
+++ b/rq/executions.py
@@ -50,6 +50,11 @@ class Execution:
     def composite_key(self):
         return f'{self.job_id}:{self.id}'
 
+    @property
+    def working_time(self) -> float:
+        """Seconds elapsed since this execution was created."""
+        return (now() - self.created_at).total_seconds()
+
     @classmethod
     def fetch(cls, id: str, job_id: str, connection: Redis) -> Execution:
         """Fetch an execution from Redis."""

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -222,7 +222,6 @@ class BaseWorker:
         self.successful_job_count: int = 0
         self.failed_job_count: int = 0
         self.total_working_time: float = 0
-        self.current_job_working_time: float = 0
         self.birth_date: datetime | None = None
         self.last_heartbeat: datetime | None = None
         self.scheduler: RQScheduler | None = None
@@ -402,9 +401,6 @@ class BaseWorker:
         self.failed_job_count = int(data['failed_job_count']) if data.get('failed_job_count') else 0
         self.successful_job_count = int(data['successful_job_count']) if data.get('successful_job_count') else 0
         self.total_working_time = float(data['total_working_time']) if data.get('total_working_time') else 0
-        self.current_job_working_time = (
-            float(data['current_job_working_time']) if data.get('current_job_working_time') else 0
-        )
 
         if data.get('queues'):
             self.queues = [
@@ -780,17 +776,6 @@ class BaseWorker:
                     e,
                 )
 
-    def set_current_job_working_time(self, current_job_working_time: float, pipeline: Pipeline | None = None):
-        """Sets the current job working time in seconds
-
-        Args:
-            current_job_working_time (float): The current job working time in seconds
-            pipeline (Optional[Pipeline], optional): Pipeline to use. Defaults to None.
-        """
-        self.current_job_working_time = current_job_working_time
-        connection = pipeline if pipeline is not None else self.connection
-        connection.hset(self.key, 'current_job_working_time', current_job_working_time)
-
     def set_current_job_id(self, job_id: str | None = None, pipeline: Pipeline | None = None):
         """Sets the current job id.
         If `None` is used it will delete the current job key.
@@ -1067,17 +1052,19 @@ class BaseWorker:
             sleep_time=60, daemon=True, exception_handler=self._pubsub_exception_handler
         )
 
-    def get_heartbeat_ttl(self, job: Job) -> int:
+    def get_heartbeat_ttl(self, job: Job, working_time: float = 0.0) -> int:
         """Get's the TTL for the next heartbeat.
 
         Args:
             job (Job): The Job
+            working_time (float): Seconds the execution has been running,
+                derived from `Execution.created_at`. Defaults to 0.0.
 
         Returns:
             int: The heartbeat TTL.
         """
         if job.timeout and job.timeout > 0:
-            remaining_execution_time = job.timeout - self.current_job_working_time
+            remaining_execution_time = job.timeout - working_time
             return int(min(remaining_execution_time, self.job_monitoring_interval)) + 60
         else:
             return self.job_monitoring_interval + 60
@@ -1196,7 +1183,7 @@ class BaseWorker:
         """Updates worker, execution and job's last heartbeat fields."""
         with self.connection.pipeline() as pipeline:
             self.heartbeat(self.job_monitoring_interval + 60, pipeline=pipeline)
-            ttl = int(self.get_heartbeat_ttl(job))
+            ttl = int(self.get_heartbeat_ttl(job, working_time=execution.working_time))
 
             # Also need to update execution's heartbeat
             execution.heartbeat(job.started_job_registry, ttl, pipeline=pipeline)
@@ -1333,7 +1320,6 @@ class BaseWorker:
         self.log.debug('Worker %s: preparing for execution of job ID %s', self.name, job.id)
         with self.connection.pipeline() as pipeline:
             self.set_current_job_id(job.id, pipeline=pipeline)
-            self.set_current_job_working_time(0, pipeline=pipeline)
 
             heartbeat_ttl = self.get_heartbeat_ttl(job)
             self.heartbeat(heartbeat_ttl, pipeline=pipeline)

--- a/rq/worker/worker_classes.py
+++ b/rq/worker/worker_classes.py
@@ -91,11 +91,10 @@ class Worker(BaseWorker):
                 break
             except HorseMonitorTimeoutException:
                 # Horse has not exited yet and is still running.
-                # Send a heartbeat to keep the worker alive.
-                self.set_current_job_working_time((now() - job.started_at).total_seconds())
+                working_time = execution.working_time
 
                 # Kill the job from this side if something is really wrong (interpreter lock/etc).
-                if job.timeout != -1 and self.current_job_working_time > (job.timeout + 60):  # type: ignore
+                if job.timeout != -1 and working_time > (job.timeout + 60):  # type: ignore
                     self.heartbeat(self.job_monitoring_interval + 60)
                     self.kill_horse()
                     self.wait_for_horse()
@@ -115,7 +114,6 @@ class Worker(BaseWorker):
                 # Send a heartbeat to keep the worker alive.
                 self.heartbeat()
 
-        self.set_current_job_working_time(0)
         self._horse_pid = 0  # Set horse PID to 0, horse has finished working
 
         self.log.debug(
@@ -234,12 +232,13 @@ class SimpleWorker(BaseWorker):
         self.perform_job(job, queue, execution)
         self.set_state(WorkerStatus.IDLE)
 
-    def get_heartbeat_ttl(self, job: Job) -> int:
+    def get_heartbeat_ttl(self, job: Job, working_time: float = 0.0) -> int:
         """-1" means that jobs never timeout. In this case, we should _not_ do -1 + 60 = 59.
         We should just stick to DEFAULT_WORKER_TTL.
 
         Args:
             job (Job): The Job
+            working_time (float): Unused; accepted for signature compatibility.
 
         Returns:
             ttl (int): TTL

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from time import sleep
 from unittest.mock import patch
 
@@ -54,6 +55,16 @@ class TestRegistry(RQTestCase):
         pipeline.execute()
 
         self.assertFalse(self.connection.exists(execution.key))
+
+    def test_working_time(self):
+        """Execution.working_time is the seconds elapsed since created_at"""
+        job = self.queue.enqueue(say_hello)
+        pipeline = self.connection.pipeline()
+        execution = Execution.create(job=job, ttl=100, pipeline=pipeline)
+        pipeline.execute()
+
+        with patch('rq.executions.now', return_value=execution.created_at + timedelta(seconds=5)):
+            self.assertEqual(execution.working_time, 5.0)
 
     def test_execution_registry(self):
         """Test the ExecutionRegistry class"""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -348,6 +348,22 @@ class TestWorker(RQTestCase):
         self.connection.hdel(w.key, 'birth')
         w.refresh()
 
+    def test_get_heartbeat_ttl(self):
+        """get_heartbeat_ttl() derives the TTL from the working_time argument"""
+        queue = Queue(connection=self.connection)
+        worker = Worker([queue], connection=self.connection)
+        job = queue.enqueue(say_hello, job_timeout=100)
+
+        self.assertEqual(
+            worker.get_heartbeat_ttl(job, working_time=0),
+            min(100, worker.job_monitoring_interval) + 60,
+        )
+        self.assertEqual(worker.get_heartbeat_ttl(job, working_time=95), 65)
+
+        job.timeout = None
+        self.assertEqual(worker.get_heartbeat_ttl(job, working_time=0), worker.job_monitoring_interval + 60)
+        self.assertEqual(worker.get_heartbeat_ttl(job, working_time=95), worker.job_monitoring_interval + 60)
+
     def test_maintain_heartbeats(self):
         """worker.maintain_heartbeats() shouldn't create new job keys"""
         queue = Queue(connection=self.connection)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution duration tracking so running jobs can report how long they’ve been active.

* **Bug Fixes**
  * Improved heartbeat and timeout handling for workers, making job monitoring more accurate and consistent during long-running tasks.

* **Tests**
  * Added coverage for execution time reporting and heartbeat TTL calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->