### PR TITLE
Worker should be able to track multiple executions

### DIFF
--- a/rq/executions.py
+++ b/rq/executions.py
@@ -203,10 +203,11 @@ def prepare_execution(worker: BaseWorker, job: Job) -> Execution:
 
     with worker.connection.pipeline() as pipeline:
         heartbeat_ttl = worker.get_heartbeat_ttl(job)
-        worker.execution = Execution.create(job, heartbeat_ttl, pipeline=pipeline, worker_name=worker.name)
+        execution = Execution.create(job, heartbeat_ttl, pipeline=pipeline, worker_name=worker.name)
+        worker.executions[execution.id] = execution
         worker.set_state(WorkerStatus.BUSY, pipeline=pipeline)
         pipeline.execute()
-    return worker.execution
+    return execution
 
 
 def cleanup_execution(worker: BaseWorker, job: Job, pipeline: Pipeline, execution: Execution | None = None) -> None:
@@ -223,5 +224,4 @@ def cleanup_execution(worker: BaseWorker, job: Job, pipeline: Pipeline, executio
     worker.set_current_job_id(None, pipeline=pipeline)
     if execution:
         execution.delete(job=job, pipeline=pipeline)
-    if worker.execution is execution:
-        worker.execution = None
+        worker.executions.pop(execution.id, None)

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -185,7 +185,7 @@ class BaseWorker:
         else:
             self._serializer_arg = f'{serializer.__module__}.{serializer.__qualname__}'  # type: ignore[attr-defined]
         self.serializer = resolve_serializer(serializer)
-        self.execution: Execution | None = None
+        self.executions: dict[str, Execution] = {}
 
         queues = [
             (
@@ -433,6 +433,25 @@ class BaseWorker:
             timeout_config = {'socket_timeout': self.connection_timeout}
             connection.connection_pool.connection_kwargs.update(timeout_config)
         return connection
+
+    @property
+    def execution(self) -> Execution | None:
+        """One of the worker's active executions, `None` when idle."""
+        if not self.executions:
+            return None
+        return next(iter(self.executions.values()))
+
+    @execution.setter
+    def execution(self, execution: Execution | None):
+        if execution is None:
+            if len(self.executions) > 1:
+                raise ValueError(
+                    'Cannot clear worker.execution when multiple executions are active, '
+                    'remove the entry from worker.executions instead'
+                )
+            self.executions.clear()
+        else:
+            self.executions[execution.id] = execution
 
     @property
     def dequeue_timeout(self) -> int:

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -66,6 +66,23 @@ class TestRegistry(RQTestCase):
         with patch('rq.executions.now', return_value=execution.created_at + timedelta(seconds=5)):
             self.assertEqual(execution.working_time, 5.0)
 
+    def test_worker_executions_tracking(self):
+        """prepare_execution registers executions; cleanup_execution removes exactly its entry"""
+        job = self.queue.enqueue(say_hello)
+        worker = Worker([self.queue], connection=self.connection)
+
+        first_execution = worker.prepare_execution(job)
+        second_execution = worker.prepare_execution(job)
+        self.assertEqual(
+            worker.executions,
+            {first_execution.id: first_execution, second_execution.id: second_execution},
+        )
+
+        pipeline = self.connection.pipeline()
+        worker.cleanup_execution(job, pipeline=pipeline, execution=first_execution)
+        pipeline.execute()
+        self.assertEqual(worker.executions, {second_execution.id: second_execution})
+
     def test_execution_registry(self):
         """Test the ExecutionRegistry class"""
         job = self.queue.enqueue(say_hello)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -959,6 +959,31 @@ class TestWorker(RQTestCase):
         job.refresh()
         self.assertGreater(job.meta['ttl'], job_timeout)
 
+    def test_execution_property(self):
+        """worker.execution is a read/write view over worker.executions"""
+        queue = Queue(connection=self.connection)
+        worker = Worker([queue], connection=self.connection)
+        job = queue.enqueue(say_hello)
+
+        self.assertIsNone(worker.execution)
+
+        first_execution = worker.prepare_execution(job)
+        self.assertEqual(worker.execution, first_execution)
+        self.assertEqual(worker.executions, {first_execution.id: first_execution})
+
+        # Assigning None clears the sole execution
+        worker.execution = None
+        self.assertEqual(worker.executions, {})
+
+        # Assigning an execution registers it alongside existing ones
+        worker.execution = first_execution
+        second_execution = worker.prepare_execution(job)
+        self.assertIn(worker.execution, (first_execution, second_execution))
+
+        # Clearing is ambiguous when more than one execution is active
+        with self.assertRaises(ValueError):
+            worker.execution = None
+
     def test_prepare_job_execution(self):
         """Prepare job execution does the necessary bookkeeping."""
         queue = Queue(connection=self.connection)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking of active job runs so multiple executions can be managed safely at once.
  * Cleaning up a finished job now removes only that specific execution, reducing the chance of interrupting other active work.
  * The current execution view now stays consistent even when more than one job is active.

* **Tests**
  * Added coverage for execution tracking and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->