### PR TITLE
Remove worker._current_job_id

### DIFF
--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -182,7 +182,6 @@ print('Total working time: '+ worker.total_working_time)  # In seconds
 * `pid` - worker's process ID
 * `queues` - queues on which this worker is listening for jobs
 * `state` - possible states are `suspended`, `started`, `busy` and `idle`
-* `current_job` - the job it's currently executing (if any)
 * `last_heartbeat` - the last time this worker was seen
 * `birth_date` - time of worker's instantiation
 * `successful_job_count` - number of jobs finished successfully

--- a/rq/executions.py
+++ b/rq/executions.py
@@ -82,6 +82,7 @@ class Execution:
         """Save execution data to Redis."""
         id = uuid4().hex
         execution = cls(id=id, job_id=job.id, connection=job.connection, worker_name=worker_name)
+        execution._job = job
         execution.save(ttl=ttl, pipeline=pipeline)
         ExecutionRegistry(job_id=job.id, connection=pipeline).add(execution=execution, ttl=ttl, pipeline=pipeline)
         job.started_job_registry.add_execution(execution, pipeline=pipeline, ttl=ttl, xx=False)
@@ -221,7 +222,6 @@ def cleanup_execution(worker: BaseWorker, job: Job, pipeline: Pipeline, executio
         execution: The execution to clean up
     """
     logger.debug('Cleaning up execution of job %s', job.id)
-    worker.set_current_job_id(None, pipeline=pipeline)
     if execution:
         execution.delete(job=job, pipeline=pipeline)
         worker.executions.pop(execution.id, None)

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -435,10 +435,12 @@ class BaseWorker:
 
     @property
     def execution(self) -> Execution | None:
-        """One of the worker's active executions, `None` when idle."""
-        if not self.executions:
-            return None
-        return next(iter(self.executions.values()))
+        """One of the worker's active executions, `None` when idle. Falls back to the
+        persisted execution index so hydrated workers (`Worker.all()`) also see it."""
+        if self.executions:
+            return next(iter(self.executions.values()))
+        executions = self.get_current_executions()
+        return executions[0] if executions else None
 
     @execution.setter
     def execution(self, execution: Execution | None):

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -386,7 +386,6 @@ class BaseWorker:
         self.version = data.get('version') or VERSION
         self.python_version = data.get('python_version') or sys.version
         self._state = data.get('state', '?')
-        self._job_id = data.get('current_job')
 
         if data.get('last_heartbeat'):
             self.last_heartbeat = utcparse(data['last_heartbeat'])
@@ -795,45 +794,27 @@ class BaseWorker:
                     e,
                 )
 
-    def set_current_job_id(self, job_id: str | None = None, pipeline: Pipeline | None = None):
-        """Sets the current job id.
-        If `None` is used it will delete the current job key.
-
-        Args:
-            job_id (Optional[str], optional): The job id. Defaults to None.
-            pipeline (Optional[Pipeline], optional): The pipeline to use. Defaults to None.
-        """
-        connection = pipeline if pipeline is not None else self.connection
-        if job_id is None:
-            connection.hdel(self.key, 'current_job')
-        else:
-            connection.hset(self.key, 'current_job', job_id)
-
-    def get_current_job_id(self, pipeline: Pipeline | None = None) -> str | None:
-        """Retrieves the current job id.
-
-        Args:
-            pipeline (Optional[&#39;Pipeline&#39;], optional): The pipeline to use. Defaults to None.
+    def get_current_job_id(self) -> str | None:
+        """Job id of one of this worker's active executions, `None` when idle.
 
         Returns:
-            job_id (Optional[str): The job id
+            job_id (Optional[str]): The job id
         """
-        connection = pipeline if pipeline is not None else self.connection
-        result = connection.hget(self.key, 'current_job')
-        if result is None:
-            return None
-        return as_text(result)
+        execution = self.execution
+        return execution.job_id if execution else None
 
     def get_current_job(self) -> Job | None:
-        """Returns the currently executing job instance.
+        """The job one of this worker's active executions is running, `None` when idle.
 
         Returns:
-            job (Job): The job instance.
+            job (Optional[Job]): The job instance.
         """
-        job_id = self.get_current_job_id()
-        if job_id is None:
+        execution = self.execution
+        if not execution:
             return None
-        return self.job_class.fetch(job_id, self.connection, self.serializer)
+        if not execution._job:
+            execution._job = self.job_class.fetch(execution.job_id, self.connection, self.serializer)
+        return execution._job
 
     def set_state(self, state: str, pipeline: Pipeline | None = None):
         """Sets the worker's state.
@@ -1338,8 +1319,6 @@ class BaseWorker:
         """
         self.log.debug('Worker %s: preparing for execution of job ID %s', self.name, job.id)
         with self.connection.pipeline() as pipeline:
-            self.set_current_job_id(job.id, pipeline=pipeline)
-
             heartbeat_ttl = self.get_heartbeat_ttl(job)
             self.heartbeat(heartbeat_ttl, pipeline=pipeline)
             job.heartbeat(now(), heartbeat_ttl, pipeline=pipeline)

--- a/rq/worker/worker_classes.py
+++ b/rq/worker/worker_classes.py
@@ -116,6 +116,10 @@ class Worker(BaseWorker):
 
         self._horse_pid = 0  # Set horse PID to 0, horse has finished working
 
+        # The horse's cleanup_execution() only popped its own copy of `executions`,
+        # so the parent process drops its entry here
+        self.executions.pop(execution.id, None)
+
         self.log.debug(
             'Worker %s: work horse finished for job %s: retpid=%s, ret_val=%s', self.name, job.id, retpid, ret_val
         )
@@ -212,6 +216,7 @@ job = Job.fetch({job.id!r}, connection=worker.connection, serializer=worker.seri
 queue = Queue({queue.name!r}, connection=worker.connection, serializer=worker.serializer)
 execution_id = os.environ["RQ_EXECUTION_ID"]
 worker.execution = Execution.fetch(execution_id, job.id, connection=worker.connection)
+worker.execution._job = job
 
 # Set up work horse
 os.setpgrp()

--- a/tests/test_intermediate_queue.py
+++ b/tests/test_intermediate_queue.py
@@ -197,8 +197,11 @@ class TestIntermediateQueue(RQTestCase):
             self.assertEqual(intermediate_queue.get_job_ids(), [job.id])
 
             self.assertIn(job.id, job.started_job_registry.get_job_ids())
+            # The worker's in-process execution is dropped once the horse exits,
+            # but the execution itself is still in Redis
+            execution = job.get_executions()[0]
             self.assertIn(
-                (worker.execution.job_id, worker.execution.id),
+                (execution.job_id, execution.id),
                 job.started_job_registry.get_job_and_execution_ids(),
             )
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -145,7 +145,6 @@ class TestWorker(RQTestCase):
         worker = Worker.find_by_key(w.key, connection=self.connection)
         self.assertEqual(worker.queues, queues)
         self.assertEqual(worker.get_state(), WorkerStatus.STARTED)
-        self.assertEqual(worker._job_id, None)
         self.assertIn(worker.key, Worker.all_keys(worker.connection))
         self.assertEqual(worker.version, VERSION)
 
@@ -878,15 +877,35 @@ class TestWorker(RQTestCase):
         self.assertEqual(job.is_failed, True)
 
     def test_get_current_job(self):
-        """Ensure worker.get_current_job() works properly"""
-        q = Queue(connection=self.connection)
-        worker = Worker([q])
-        job = q.enqueue_call(say_hello)
+        """worker.get_current_job() and get_current_job_id() derive from worker.execution"""
+        queue = Queue(connection=self.connection, job_class=CustomJob)
+        worker = Worker([queue], job_class=CustomJob)
+        job = queue.enqueue_call(say_hello)
 
-        self.assertEqual(self.connection.hget(worker.key, 'current_job'), None)
-        worker.set_current_job_id(job.id)
-        self.assertEqual(worker.get_current_job_id(), as_text(self.connection.hget(worker.key, 'current_job')))
+        self.assertIsNone(worker.get_current_job_id())
+        self.assertIsNone(worker.get_current_job())
+
+        execution = worker.prepare_execution(job)
+        self.assertEqual(worker.get_current_job_id(), job.id)
+        # The seeded in-process job instance is returned, no Redis refetch
+        self.assertIs(worker.get_current_job(), execution._job)
         self.assertEqual(worker.get_current_job(), job)
+        # The legacy current_job hash field is never written
+        self.assertIsNone(self.connection.hget(worker.key, 'current_job'))
+
+        # On a cache miss (an execution reconstructed from Redis, e.g. in the SpawnWorker
+        # child), the job is fetched with the worker's job class and hydrates the cache
+        execution._job = None
+        fetched_job = worker.get_current_job()
+        self.assertIsInstance(fetched_job, CustomJob)
+        self.assertIs(execution._job, fetched_job)
+        self.assertIs(worker.get_current_job(), fetched_job)
+
+        with self.connection.pipeline() as pipeline:
+            worker.cleanup_execution(job, pipeline=pipeline, execution=execution)
+            pipeline.execute()
+        self.assertIsNone(worker.get_current_job_id())
+        self.assertIsNone(worker.get_current_job())
 
     def test_custom_job_class(self):
         """Ensure Worker accepts custom job class."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -901,11 +901,21 @@ class TestWorker(RQTestCase):
         self.assertIs(execution._job, fetched_job)
         self.assertIs(worker.get_current_job(), fetched_job)
 
+        # A hydrated worker sees the running job through the persisted execution index
+        hydrated_worker = Worker.find_by_key(worker.key, connection=self.connection, job_class=CustomJob)
+        self.assertEqual(hydrated_worker.get_current_job_id(), job.id)
+        hydrated_job = hydrated_worker.get_current_job()
+        self.assertEqual(hydrated_job, job)
+        self.assertIsInstance(hydrated_job, CustomJob)
+
         with self.connection.pipeline() as pipeline:
             worker.cleanup_execution(job, pipeline=pipeline, execution=execution)
             pipeline.execute()
         self.assertIsNone(worker.get_current_job_id())
         self.assertIsNone(worker.get_current_job())
+
+        # The hydrated view also clears once the execution is cleaned up
+        self.assertIsNone(hydrated_worker.get_current_job())
 
     def test_custom_job_class(self):
         """Ensure Worker accepts custom job class."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker “current job” status now reflects the job associated with the running execution, improving real-time job visibility during processing.

* **Bug Fixes**
  * Prevented stale execution bookkeeping after a worker process completes a job.
  * Improved correctness of job-to-execution linkage in spawned child processes.

* **Documentation**
  * Updated worker documentation to remove the deprecated `current_job` property from the exposed worker information list.

* **Tests**
  * Expanded/adjusted worker and queue tests to validate the updated current-job behavior and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->