### PR TITLE
job.perform() no longer changes job key TTL.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ### RQ 3.0 (unreleased)
+* `Job.perform()` no longer removes the job key's TTL. Job key TTL changes are now handled by workers. Thanks @selwin!
 * Refactored how job dependencies are handled. Introduced `READY_TO_ENQUEUE` job status and ReadyJobRegistry. Thanks @selwin!
 * `get_current_job()` now uses `contextvars` instead of thread-locals; gevent-based custom workers need `greenlet` >= 0.4.17. Thanks @selwin!
 * `Worker.handle_job_success()` now requires an `execution` argument, a breaking change for subclasses that override or call this method. Thanks @selwin!

--- a/rq/job.py
+++ b/rq/job.py
@@ -1446,7 +1446,6 @@ class Job:
         Returns:
             result (Any): The job result
         """
-        self.connection.persist(self.key)
         token = _current_job.set(self)
         try:
             self._result = self._execute()

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -1373,6 +1373,7 @@ class BaseWorker:
             job.heartbeat(now(), heartbeat_ttl, pipeline=pipeline)
 
             job.prepare_for_execution(self.name, pipeline=pipeline)
+            pipeline.persist(job.key)
             if remove_from_intermediate_queue:
                 from ..queue import Queue
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -592,18 +592,6 @@ class TestJob(RQTestCase):
         job = queue.enqueue(fixtures.say_hello, ttl=ttl)
         self.assertEqual(job.get_ttl(), ttl)
 
-    def test_never_expire_during_execution(self):
-        """Test what happens when job expires during execution"""
-        ttl = 1
-        queue = Queue(connection=self.connection)
-        job = queue.enqueue(fixtures.long_running_job, args=(2,), ttl=ttl)
-        self.assertEqual(job.get_ttl(), ttl)
-        job.save()
-        job.perform()
-        self.assertEqual(job.get_ttl(), ttl)
-        self.assertTrue(job.exists(job.id, connection=self.connection))
-        self.assertEqual(job.result, 'Done sleeping...')
-
     def test_cleanup(self):
         """Test that jobs and results are expired properly."""
         job = Job.create(func=fixtures.say_hello, connection=self.connection, status=JobStatus.QUEUED)
@@ -890,7 +878,7 @@ class TestJob(RQTestCase):
         self.assertLess(blocked_for, block_seconds)
 
     def test_should_enqueue_at_front(self):
-        job = Job.create(fixtures.say_hello,connection=self.connection)
+        job = Job.create(fixtures.say_hello, connection=self.connection)
 
         job.enqueue_at_front_on_retry = True
         job.enqueue_at_front = False

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1037,6 +1037,7 @@ class TestWorker(RQTestCase):
         job = queue.enqueue(say_hello)
         worker = Worker([queue])
         worker.prepare_execution(job)
+        self.connection.expire(job.key, 60)
         worker.prepare_job_execution(job)
 
         # Updates working queue, job execution should be there
@@ -1053,6 +1054,7 @@ class TestWorker(RQTestCase):
         # job status is also updated
         self.assertEqual(job._status, JobStatus.STARTED)
         self.assertEqual(job.worker_name, worker.name)
+        self.assertEqual(self.connection.ttl(job.key), -1)
 
     @min_redis_version((6, 2, 0))
     def test_prepare_job_execution_removes_key_from_intermediate_queue(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job keys now remain available while work is being prepared and executed, preventing unexpected expiration.
  * Improved job cleanup behavior for immediate, delayed, and disabled expiration settings.
  * Job execution context is reliably restored even when execution encounters an error.

* **Documentation**
  * Updated the unreleased changelog with the revised job expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->