### PR TITLE
Create send_stop_execution_command

### DIFF
--- a/rq/command.py
+++ b/rq/command.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from .worker import BaseWorker
 
 from rq.exceptions import InvalidJobOperation
+from rq.executions import Execution
 from rq.job import Job
 
 PUBSUB_CHANNEL_TEMPLATE = 'rq:pubsub:%s'
@@ -20,6 +21,7 @@ def send_command(connection: 'Redis', worker_name: str, command: str, **kwargs):
     A command is just a string, available commands are:
         - `shutdown`: Shuts down a worker
         - `kill-horse`: Command for the worker to kill the current working horse
+        - `stop-execution`: A command for the worker to stop one execution of a job
         - `stop-job`: A command for the worker to stop the currently running job
 
     The command string will be parsed into a dictionary and send to a PubSub Topic.
@@ -67,6 +69,24 @@ def send_kill_horse_command(connection: 'Redis', worker_name: str):
     send_command(connection, worker_name, 'kill-horse')
 
 
+def send_stop_execution_command(connection: 'Redis', execution_id: str):
+    """
+    Instruct a worker to stop one execution of a job.
+
+    Args:
+        connection (Redis): A Redis Connection
+        execution_id (str): The Execution's composite key, formatted as `<job_id>:<execution_id>`
+    """
+    execution = Execution.from_composite_key(execution_id, connection=connection)
+    try:
+        execution.refresh()
+    except ValueError:
+        raise InvalidJobOperation('Execution is not running')
+    send_command(
+        connection, execution.worker_name, 'stop-execution', job_id=execution.job_id, execution_id=execution.id
+    )
+
+
 def send_stop_job_command(connection: 'Redis', job_id: str, serializer=None):
     """
     Instruct a worker to stop a job
@@ -89,7 +109,9 @@ def handle_command(worker: 'BaseWorker', payload: dict[Any, Any]):
         worker (Worker): The worker to use
         payload (Dict[Any, Any]): The Payload
     """
-    if payload['command'] == 'stop-job':
+    if payload['command'] == 'stop-execution':
+        handle_stop_execution_command(worker, payload)
+    elif payload['command'] == 'stop-job':
         handle_stop_job_command(worker, payload)
     elif payload['command'] == 'shutdown':
         handle_shutdown_command(worker)
@@ -125,6 +147,19 @@ def handle_kill_worker_command(worker: 'BaseWorker', payload: dict[Any, Any]):
         worker.log.info('Worker is not working, kill horse command ignored')
 
 
+def handle_stop_execution_command(worker: 'BaseWorker', payload: dict[Any, Any]):
+    """Handles stop execution command.
+
+    Args:
+        worker (Worker): The worker to use
+        payload (Dict[Any, Any]): The payload.
+    """
+    job_id = payload.get('job_id', '')
+    execution_id = payload.get('execution_id', '')
+    worker.log.debug('Received command to stop execution %s of job %s', execution_id, job_id)
+    worker.request_stop_execution(execution_id)
+
+
 def handle_stop_job_command(worker: 'BaseWorker', payload: dict[Any, Any]):
     """Handles stop job command.
 
@@ -140,4 +175,4 @@ def handle_stop_job_command(worker: 'BaseWorker', payload: dict[Any, Any]):
         worker._stopped_job_id = job_id
         worker.kill_horse()
     else:
-        worker.log.info('Not working on job %s, command ignored.', job_id)
+        worker.log.warning('Not working on job %s, command ignored.', job_id)

--- a/rq/command.py
+++ b/rq/command.py
@@ -69,22 +69,20 @@ def send_kill_horse_command(connection: 'Redis', worker_name: str):
     send_command(connection, worker_name, 'kill-horse')
 
 
-def send_stop_execution_command(connection: 'Redis', execution_id: str):
+def send_stop_execution_command(connection: 'Redis', job_id: str, execution_id: str):
     """
     Instruct a worker to stop one execution of a job.
 
     Args:
         connection (Redis): A Redis Connection
-        execution_id (str): The Execution's composite key, formatted as `<job_id>:<execution_id>`
+        job_id (str): The Job ID
+        execution_id (str): The Execution ID
     """
-    execution = Execution.from_composite_key(execution_id, connection=connection)
     try:
-        execution.refresh()
+        execution = Execution.fetch(id=execution_id, job_id=job_id, connection=connection)
     except ValueError:
         raise InvalidJobOperation('Execution is not running')
-    send_command(
-        connection, execution.worker_name, 'stop-execution', job_id=execution.job_id, execution_id=execution.id
-    )
+    send_command(connection, execution.worker_name, 'stop-execution', job_id=job_id, execution_id=execution_id)
 
 
 def send_stop_job_command(connection: 'Redis', job_id: str, serializer=None):

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -1705,6 +1705,19 @@ class BaseWorker:
         """Kill the work horse process. No-op for workers without child processes."""
         pass
 
+    def request_stop_execution(self, execution_id: str):
+        """Stop one of this worker's active executions. Called from the pubsub thread.
+
+        Marks the job as intentionally stopped (so `handle_job_failure` sets it to
+        STOPPED instead of FAILED) and kills the horse running it.
+        """
+        execution = self.executions.get(execution_id)
+        if not execution:
+            self.log.warning('Not running execution %s, command ignored.', execution_id)
+            return
+        self._stopped_job_id = execution.job_id
+        self.kill_horse()
+
     def wait_for_horse(self) -> tuple[int | None, int | None, struct_rusage | None]:
         """Wait for the work horse process to complete. No-op for workers without child processes."""
         return None, None, None

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -142,7 +142,7 @@ class TestCommands(RQTestCase):
 
         # An error is raised if the execution doesn't exist
         with self.assertRaises(InvalidJobOperation):
-            send_stop_execution_command(connection, execution_id=f'{job.id}:nonexistent')
+            send_stop_execution_command(connection, job_id=job.id, execution_id='nonexistent')
 
         p = Process(target=start_work_burst, args=('foo', worker.name, get_connection_kwargs(connection)))
         p.start()
@@ -158,7 +158,7 @@ class TestCommands(RQTestCase):
         worker.refresh()
         self.assertEqual(worker.get_state(), WorkerStatus.BUSY)
 
-        send_stop_execution_command(connection, execution_id=execution.composite_key)
+        send_stop_execution_command(connection, job_id=job.id, execution_id=execution.id)
         time.sleep(0.1)
 
         # Job status is set appropriately

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -6,7 +6,13 @@ from redis import Redis
 from redis.exceptions import ResponseError
 
 from rq import Queue, Worker
-from rq.command import send_command, send_kill_horse_command, send_shutdown_command, send_stop_job_command
+from rq.command import (
+    send_command,
+    send_kill_horse_command,
+    send_shutdown_command,
+    send_stop_execution_command,
+    send_stop_job_command,
+)
 from rq.connections import get_connection_kwargs
 from rq.exceptions import InvalidJobOperation, NoSuchJobError
 from rq.serializers import JSONSerializer
@@ -119,6 +125,41 @@ class TestCommands(RQTestCase):
 
         send_stop_job_command(connection, job_id=job.id, serializer=JSONSerializer)
         time.sleep(0.25)
+
+        # Job status is set appropriately
+        self.assertTrue(job.is_stopped)
+
+        # Worker has stopped working
+        worker.refresh()
+        self.assertEqual(worker.get_state(), WorkerStatus.IDLE)
+
+    def test_stop_execution_command(self):
+        """Ensure that stop-execution targets one specific execution."""
+        connection = self.connection
+        queue = Queue('foo', connection=connection, serializer=JSONSerializer)
+        job = queue.enqueue(long_running_job, 3)
+        worker = Worker('foo', connection=connection, serializer=JSONSerializer)
+
+        # An error is raised if the execution doesn't exist
+        with self.assertRaises(InvalidJobOperation):
+            send_stop_execution_command(connection, execution_id=f'{job.id}:nonexistent')
+
+        p = Process(target=start_work_burst, args=('foo', worker.name, get_connection_kwargs(connection)))
+        p.start()
+        p.join(1)
+
+        time.sleep(0.1)
+
+        execution = job.get_executions()[0]
+
+        # A non-matching execution id is ignored by the worker
+        send_command(connection, worker.name, 'stop-execution', job_id=job.id, execution_id='nonexistent')
+        time.sleep(0.1)
+        worker.refresh()
+        self.assertEqual(worker.get_state(), WorkerStatus.BUSY)
+
+        send_stop_execution_command(connection, execution_id=execution.composite_key)
+        time.sleep(0.1)
 
         # Job status is set appropriately
         self.assertTrue(job.is_stopped)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `stop-execution` worker command to stop a specific active execution by job and execution identifiers.
  * Workers now route and process stop requests for executions, returning to idle after termination.
* **Bug Fixes**
  * Improved visibility for ignored `stop-job` requests by emitting a warning instead of an informational message.
  * Nonexistent or non-running executions now raise clear errors rather than silently failing.
* **Tests**
  * Added coverage for `stop-execution`, including error cases, ignored mismatches, and successful stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->