### PR TITLE
Execution should also store job ID

### DIFF
--- a/rq/executions.py
+++ b/rq/executions.py
@@ -81,6 +81,8 @@ class Execution:
 
     def restore(self, data: dict):
         """Restore execution attributes from raw Redis hash data."""
+        # Hashes written before job_id was serialized lack the field; keep the caller-supplied value
+        self.job_id = as_text(data.get(b'job_id', b'')) or self.job_id
         self.created_at = datetime.fromtimestamp(float(data[b'created_at']), tz=timezone.utc)
         self.last_heartbeat = datetime.fromtimestamp(float(data[b'last_heartbeat']), tz=timezone.utc)
         self.worker_name = as_text(data.get(b'worker_name', b''))
@@ -124,6 +126,7 @@ class Execution:
     def serialize(self) -> dict:
         return {
             'id': self.id,
+            'job_id': self.job_id,
             'created_at': self.created_at.timestamp(),
             'last_heartbeat': self.last_heartbeat.timestamp(),
             'worker_name': self.worker_name,

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -45,11 +45,22 @@ class TestRegistry(RQTestCase):
         self.assertEqual(execution.composite_key, composite_key)
         self.assertEqual(execution.last_heartbeat.timestamp(), created_at.timestamp())
         self.assertEqual(execution.worker_name, 'foo')
+        self.assertEqual(as_text(self.connection.hget(execution.key, 'job_id')), job.id)
+
+        # restore() reads job_id from the hash itself, not just the caller-supplied value
+        restored_execution = Execution(id=execution.id, job_id='', connection=self.connection)
+        restored_execution.restore(self.connection.hgetall(execution.key))
+        self.assertEqual(restored_execution.job_id, job.id)
 
         # Execution hashes written before worker_name existed refresh to an empty string
         self.connection.hdel(execution.key, 'worker_name')
         execution.refresh()
         self.assertEqual(execution.worker_name, '')
+
+        # Execution hashes written before job_id was serialized keep the caller-supplied value
+        self.connection.hdel(execution.key, 'job_id')
+        execution.refresh()
+        self.assertEqual(execution.job_id, job.id)
 
         execution.delete(job=job, pipeline=pipeline)
         pipeline.execute()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution restoration for records created by older versions.
  * Preserved the provided job ID when it is unavailable in stored execution data.
  * Ensured newly saved executions retain their job ID for reliable future restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->