### PR TITLE
Support DICT_CONFIG config file setting in rq worker-pool

### DIFF
--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -578,3 +578,4 @@ Options:
 * `-P` or `--path <path>`: multiple import paths are supported (e.g `rq worker --path foo --path bar`).
 * `-j` or `--job-class <path.to.Job>`: defaults to `rq.job.Job`.
 * `--exception-handler`: path to exception handler class. Multiple exception handlers are supported (e.g `rq worker-pool --exception-handler 'path.to.my.ErrorHandler' --exception-handler 'another.ErrorHandler'`).
+* `-c` or `--config <module>`: module containing RQ settings, in the same format as [`rq worker`](#using-a-config-file). `rq worker-pool` honors the connection settings (`REDIS_URL`, `REDIS_HOST`, `SENTINEL`, etc.), `QUEUES` and `DICT_CONFIG`. Command line arguments take precedence over settings read from the config file.

--- a/rq/cli/workers.py
+++ b/rq/cli/workers.py
@@ -201,6 +201,10 @@ def worker_pool(
     settings = read_config_file(cli_config.config) if cli_config.config else {}
     # Worker specific default arguments
     queue_names: list[str] = queues or settings.get('QUEUES', ['default'])
+    dict_config = settings.get('DICT_CONFIG')
+
+    if dict_config:
+        logging.config.dictConfig(dict_config)
 
     setup_loghandlers_from_args(verbose, quiet, date_format, log_format)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from datetime import datetime, timedelta, timezone
 from time import sleep
@@ -822,6 +823,17 @@ class TestRQCli(CLITestCase):
 
 
 class WorkerPoolCLITestCase(CLITestCase):
+    def test_config_file_logging(self):
+        """rq worker-pool -u <url> -b -c tests.config_files.dummy_logging"""
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ['worker-pool', '-u', self.redis_url, '-b', '-c', 'tests.config_files.dummy_logging']
+        )
+        self.assert_normal_execution(result)
+        # DICT_CONFIG from the config file should have been applied
+        formats = [handler.formatter._fmt for handler in logging.getLogger().handlers if handler.formatter]
+        self.assertTrue(any('MY_LOG_FMT' in fmt for fmt in formats))
+
     def test_worker_pool_burst_and_num_workers(self):
         """rq worker-pool -u <url> -b -n 3"""
         runner = CliRunner()


### PR DESCRIPTION
Fixes #2051

`rq worker-pool` accepts `-c/--config` and already picks up the Redis connection settings and `QUEUES` from the settings module, but it silently ignores `DICT_CONFIG` — so there is no way to configure logging for the pool via a config file, which is exactly what #2051 asks for.

This applies `logging.config.dictConfig(settings['DICT_CONFIG'])` in `worker_pool` the same way the `worker` (and `cron`) commands do. Since `WorkerPool` forks its workers, the logging configuration is inherited by the pooled workers as well, and `setup_loghandlers` already respects pre-existing handlers, so a root-logger `DICT_CONFIG` isn't clobbered.

Also documents the `-c/--config` option (and which settings `worker-pool` honors) in the Worker Pool section of `docs/docs/workers.md`, and adds a CLI test. The test asserts on the installed root handler's formatter rather than captured output because the test suite globally disables sub-ERROR logging (`RQTestCase.setUpClass`).

Context: we run an RQ worker pool in production and configure it (worker count, logging) from settings rather than CLI flags, so config-file parity between `worker` and `worker-pool` scratches a real itch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring worker-pool logging through the `-c` / `--config` option.
  * Worker pools now honor dictionary-based logging settings from configuration files.
  * Command-line options take precedence over configuration file values.

* **Documentation**
  * Documented the worker-pool configuration option and supported settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->