### PR TITLE
chore: declare Python 3.14 support in classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
   "Topic :: Internet",
   "Topic :: Scientific/Engineering",
   "Topic :: Software Development :: Libraries :: Python Modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Internet",
   "Topic :: Scientific/Engineering",
   "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Add Python 3.14 Trove classifier so packaging metadata reflects current support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Python 3.14 support to the package’s declared compatibility information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->