### PR TITLE
Fix an issue where calling `create_cron` multiple times duplicate jobs

### DIFF
--- a/rq/cron.py
+++ b/rq/cron.py
@@ -666,8 +666,10 @@ def create_cron(connection: Redis) -> CronScheduler:
     """Create a CronScheduler instance with all registered jobs"""
     cron_instance = CronScheduler(connection=connection)
 
-    # Register all previously registered jobs with the CronScheduler instance
-    for data in _job_data_registry:
+    # Snapshot and consume the registry so a second call doesn't re-register the same jobs
+    job_definitions = _job_data_registry[:]
+    _job_data_registry.clear()
+    for data in job_definitions:
         logging.debug(f'Registering job: {data["func"].__name__}')
         cron_instance.register(**data)
 

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -330,6 +330,17 @@ class TestCronScheduler(RQTestCase):
         finally:
             os.remove(invalid_file_path)  # Clean up temp file
 
+    def test_create_cron_consumes_registry(self):
+        """create_cron consumes the global registry, so a second call registers nothing new"""
+        cron.register(say_hello, queue_name=self.queue_name, interval=60)
+
+        first_scheduler = cron.create_cron(self.connection)
+        self.assertEqual(len(first_scheduler.get_jobs()), 1)
+        self.assertEqual(len(_job_data_registry), 0, 'Registry not consumed by create_cron')
+
+        second_scheduler = cron.create_cron(self.connection)
+        self.assertEqual(len(second_scheduler.get_jobs()), 0)
+
     @patch('rq.cron.time.sleep')
     @patch('rq.cron.CronScheduler.calculate_sleep_interval')
     @patch('rq.cron.CronScheduler.enqueue_jobs')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cron jobs from being registered more than once when the cron scheduler is created repeatedly.
  * Ensured each registered job is consumed after its initial scheduler setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->