### PR TITLE
Preserve internal ImportError in import_attribute

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -190,7 +190,9 @@ def import_attribute(name: str) -> Callable[..., Any]:
             module_name = '.'.join(module_name_bits)
             module = importlib.import_module(module_name)
             break
-        except ImportError:
+        except ImportError as e:
+            if not e.name or not (module_name == e.name or module_name.startswith(e.name + '.')):
+                raise
             attribute_bits.insert(0, module_name_bits.pop())
 
     if module is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,7 @@ from rq.utils import (
     utcparse,
     validate_absolute_path,
 )
-from rq.worker import SimpleWorker
+from rq.worker import SimpleWorker, Worker
 from tests import RQTestCase, fixtures
 
 
@@ -168,8 +168,33 @@ class TestUtils(RQTestCase):
         """Ensure get_version works properly"""
         self.assertEqual(import_attribute('rq.utils.get_version'), get_version)
         self.assertEqual(import_attribute('rq.worker.SimpleWorker'), SimpleWorker)
+        self.assertEqual(import_attribute('rq.worker.Worker.all'), Worker.all)
         self.assertRaises(ValueError, import_attribute, 'non.existent.module')
         self.assertRaises(ValueError, import_attribute, 'rq.worker.WrongWorker')
+
+    def test_import_attribute_preserves_internal_import_error(self):
+        """Ensure import_attribute does not mask ImportError raised inside an existing module."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pkg_dir = os.path.join(tmpdir, 'my_temp_pkg')
+            os.makedirs(pkg_dir)
+            with open(os.path.join(pkg_dir, '__init__.py'), 'w') as f:
+                f.write('')
+            with open(os.path.join(pkg_dir, 'broken_module.py'), 'w') as f:
+                f.write('import non_existent_dependency_xyz_12345\n')
+
+            sys.path.insert(0, tmpdir)
+            try:
+                with self.assertRaises(ImportError) as ctx:
+                    import_attribute('my_temp_pkg.broken_module.some_function')
+                self.assertIn('non_existent_dependency_xyz_12345', str(ctx.exception))
+            finally:
+                if tmpdir in sys.path:
+                    sys.path.remove(tmpdir)
+                sys.modules.pop('my_temp_pkg.broken_module', None)
+                sys.modules.pop('my_temp_pkg', None)
+
+
 
     def test_ceildiv_even(self):
         """When a number is evenly divisible by another ceildiv returns the quotient"""


### PR DESCRIPTION
## Summary

Fixes #2264.

`import_attribute()` currently catches every `ImportError` while attempting to resolve a dotted path. This can mask `ImportError`s raised during execution of an existing module and instead result in an unrelated `ValueError`.

This change preserves the original `ImportError` when it originates from inside a successfully located module while keeping the existing attribute-peeling behavior for non-module path components.

## Changes

- Preserve internal `ImportError`s raised during module import.
- Keep existing attribute resolution behavior for classes, static methods, and nested attributes.
- Add a regression test covering modules that fail during import because of a missing dependency.
- Add an assertion verifying that importing a static method (`rq.worker.Worker.all`) continues to work.

## Testing

- Added a regression test for Issue #2264.
- Ran the full test suite successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved module attribute loading so genuine internal import errors are now reported instead of being mistaken for missing components.
  - Fixed handling of nested module attributes, providing more accurate results when resolving available functionality.
  - Added safeguards to preserve meaningful error details and make failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->