### PR TITLE
Prevent job code from swallowing timeout exceptions

### DIFF
--- a/rq/timeouts.py
+++ b/rq/timeouts.py
@@ -3,8 +3,12 @@ import signal
 import threading
 
 
-class BaseTimeoutException(Exception):
-    """Base exception for timeouts."""
+class BaseTimeoutException(BaseException):
+    """Base exception for RQ's control-flow timeouts.
+
+    Timeout signals must not be intercepted by application-level
+    ``except Exception`` handlers.
+    """
 
     pass
 

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,14 +1,28 @@
 import time
+import unittest
 from unittest.mock import patch
 
 from rq import Queue, SimpleWorker
 from rq.registry import FailedJobRegistry, FinishedJobRegistry
 from rq.timeouts import (
+    JobTimeoutException,
     TimerDeathPenalty,
     UnixSignalDeathPenalty,
     get_default_death_penalty_class,
 )
 from tests import RQTestCase
+
+
+class TestTimeoutExceptionHierarchy(unittest.TestCase):
+    def test_job_timeout_is_not_caught_by_application_exception_handlers(self):
+        def application_job():
+            try:
+                raise JobTimeoutException('timeout')
+            except Exception:
+                return 'timeout was swallowed'
+
+        with self.assertRaises(JobTimeoutException):
+            application_job()
 
 
 class TimerBasedWorker(SimpleWorker):


### PR DESCRIPTION
Fixes #2296.

## Problem

`JobTimeoutException` inherits from `Exception`, so a job that uses a broad application-level `except Exception` handler can accidentally catch RQ's timeout signal and continue running. That defeats the worker's execution deadline and can leave the job reported as successful.

## Change

Make RQ's timeout base class inherit from `BaseException`. RQ's control-flow handling remains explicit: job execution already catches the timeout at the worker boundary, horse monitoring catches `HorseMonitorTimeoutException`, and death-penalty cleanup catches `BaseTimeoutException` directly.

Add a regression that models an application handler and verifies that `JobTimeoutException` escapes it.

## Testing

- Regression failed on unmodified `master` because the application handler swallowed the timeout; passes after the change
- `pytest tests/test_timeouts.py` against a local Redis-compatible TCP test service (3 passed)
- Live `TimerDeathPenalty` propagation exercise on Windows
- `ruff check rq/timeouts.py tests/test_timeouts.py`
- `ruff format --check rq/timeouts.py tests/test_timeouts.py`
- `mypy rq/timeouts.py`
- `python -m compileall -q rq/timeouts.py tests/test_timeouts.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job timeout exceptions now reliably propagate instead of being inadvertently caught by broad application error handlers.
  * Timeout behavior is clarified and more consistent for applications handling exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->