### PR TITLE
Add worker name and job ID for logging

### DIFF
--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -1175,9 +1175,11 @@ class BaseWorker:
                     self.log.debug('Worker %s: dequeued job %s from %s', self.name, blue(job.id), green(queue.name))
                     job.redis_server_version = self.get_redis_server_version()
                     if self.log_job_description:
-                        self.log.info('%s: %s (%s)', green(queue.name), blue(job.description), job.id)
+                        self.log.info(
+                            'Worker %s: %s: %s (%s)', self.name, green(queue.name), blue(job.description), job.id
+                        )
                     else:
-                        self.log.info('%s: %s', green(queue.name), job.id)
+                        self.log.info('Worker %s: %s: %s', self.name, green(queue.name), job.id)
 
                 break
             except DequeueTimeout:
@@ -1654,18 +1656,20 @@ class BaseWorker:
 
             return False
 
-        self.log.info('%s: %s (%s)', green(job.origin), blue('Job OK'), job.id)
+        self.log.info('Worker %s: %s: %s (%s)', self.name, green(job.origin), blue('Job OK'), job.id)
         if return_value is not None:
             self.log.debug('Worker %s: result: %r', self.name, yellow(str(return_value)))
 
         if self.log_result_lifespan:
             result_ttl = job.get_result_ttl(self.default_result_ttl)
             if result_ttl == 0:
-                self.log.info('Result discarded immediately')
+                self.log.info('Worker %s: job %s result discarded immediately', self.name, job.id)
             elif result_ttl > 0:
-                self.log.info('Result is kept for %s seconds', result_ttl)
+                self.log.info('Worker %s: job %s result is kept for %s seconds', self.name, job.id, result_ttl)
             else:
-                self.log.info('Result will never expire, clean up result key manually')
+                self.log.info(
+                    'Worker %s: job %s result will never expire, clean up result key manually', self.name, job.id
+                )
 
         return True
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1326,8 +1326,10 @@ class TestWorker(RQTestCase):
         w = Worker([q], connection=self.connection)
         job = q.enqueue(say_hello, args=('Frank',), result_ttl=10)
         w.perform_job(job, q, w.prepare_execution(job))
-        mock_logger_info.assert_called_with('Result is kept for %s seconds', 10)
-        self.assertIn('Result is kept for %s seconds', [c[0][0] for c in mock_logger_info.call_args_list])
+        mock_logger_info.assert_called_with('Worker %s: job %s result is kept for %s seconds', w.name, job.id, 10)
+        self.assertIn(
+            'Worker %s: job %s result is kept for %s seconds', [c[0][0] for c in mock_logger_info.call_args_list]
+        )
 
     @mock.patch('rq.worker.logger.info')
     def test_log_result_lifespan_false(self, mock_logger_info):
@@ -1340,7 +1342,9 @@ class TestWorker(RQTestCase):
         w = TestWorker([q], connection=self.connection)
         job = q.enqueue(say_hello, args=('Frank',), result_ttl=10)
         w.perform_job(job, q, w.prepare_execution(job))
-        self.assertNotIn('Result is kept for 10 seconds', [c[0][0] for c in mock_logger_info.call_args_list])
+        self.assertNotIn(
+            'Worker %s: job %s result is kept for %s seconds', [c[0][0] for c in mock_logger_info.call_args_list]
+        )
 
     @mock.patch('rq.worker.logger.info')
     def test_log_job_description_on_dequeue_true(self, mock_logger_info):
@@ -1349,7 +1353,7 @@ class TestWorker(RQTestCase):
         w = Worker([q], connection=self.connection)
         q.enqueue(say_hello, args=('Frank',), result_ttl=10)
         w.dequeue_job_and_maintain_ttl(10)
-        self.assertIn('Frank', mock_logger_info.call_args[0][2])
+        self.assertIn('Frank', mock_logger_info.call_args[0][3])
 
     @mock.patch('rq.worker.logger.info')
     def test_log_job_description_on_dequeue_false(self, mock_logger_info):
@@ -1358,7 +1362,7 @@ class TestWorker(RQTestCase):
         w = Worker([q], log_job_description=False, connection=self.connection)
         q.enqueue(say_hello, args=('Frank',), result_ttl=10)
         w.dequeue_job_and_maintain_ttl(10)
-        self.assertNotIn('Frank', mock_logger_info.call_args[0][2])
+        self.assertNotIn('Frank', mock_logger_info.call_args[0][3])
 
     @mock.patch('rq.worker.logger.info')
     def test_log_job_description_on_success_true(self, mock_logger_info):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker log messages by including the worker name for dequeued jobs and completed results.
  * Added worker name and job ID details to result-lifespan messages, including discarded and non-expiring results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->