### PR TITLE
Fix SpawnWorker connection serialization with redis-py 8.1.0

### DIFF
--- a/rq/connections.py
+++ b/rq/connections.py
@@ -6,13 +6,14 @@ class NoRedisConnectionException(Exception):
     pass
 
 
-# redis-py >= 8 may add RESP3 maintenance-notification handlers and derived
+# redis-py >= 8 may add maintenance-notification handlers and other derived
 # connection metadata to connection_kwargs. Those values describe the current
 # pool's internal state, and some contain locks, so RQ drops them before
 # rebuilding a Redis connection in another process.
 REDIS_RUNTIME_CONNECTION_KWARGS = (
     'maint_notifications_config',
     'maint_notifications_pool_handler',
+    'himport_registry',
     'event_dispatcher',
     'orig_host_address',
     'orig_socket_timeout',

--- a/tests/test_spawn_worker.py
+++ b/tests/test_spawn_worker.py
@@ -41,17 +41,19 @@ class TestWorker(RQTestCase):
     def test_filters_non_serializable_connection_kwargs(self):
         """SpawnWorker strips connection-local runtime objects before rebuilding Redis in the child.
 
-        redis-py 8 adds an unpicklable maintenance-notification handler to connection_kwargs;
-        get_connection_kwargs (used by fork_work_horse) must drop it so the
-        kwargs can be rebuilt in the spawned process.
+        redis-py 8 adds an unpicklable maintenance-notification handler to connection_kwargs,
+        while redis-py 8.1 adds an HImportRegistry; get_connection_kwargs (used by fork_work_horse)
+        must drop both so the kwargs can be rebuilt in the spawned process.
         """
         connection = Redis()
         conn_kwargs = connection.connection_pool.connection_kwargs
         conn_kwargs['maint_notifications_pool_handler'] = object()
+        conn_kwargs['himport_registry'] = 'runtime state'
 
         redis_kwargs = get_connection_kwargs(connection)
 
         self.assertNotIn('maint_notifications_pool_handler', redis_kwargs)
+        self.assertNotIn('himport_registry', redis_kwargs)
         self.assertIn('maint_notifications_pool_handler', conn_kwargs)
 
     def test_worker_normalizes_serializer_arg_for_spawn(self):


### PR DESCRIPTION
## Summary

- Exclude redis-py 8.1's internal `himport_registry` from `get_connection_kwargs()`.
- Let redis-py create a fresh registry when SpawnWorker reconstructs the child connection pool.
- Keep the fix at the existing connection-serialization boundary without pinning or downgrading redis-py.

## Root cause

SpawnWorker embeds the repr of Redis connection kwargs into generated `python -c` source. redis-py 8.1 adds `HImportRegistry()` to those kwargs, but the generated child does not import that runtime-only type and fails with `NameError` before the job callable starts.

## Tests

- Extended the existing SpawnWorker connection-kwargs regression test to prove `himport_registry` is excluded.
- Verified the complete SpawnWorker test module against Python 3.13.15 and redis-py 8.1.0.
- Ran Ruff lint/format checks, mypy, and `git diff --check`.

Fixes #2456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis connection handling when workers run across processes.
  * Prevented runtime-only metadata from being incorrectly reused during connection rebuilding.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->