### PR TITLE
Stop asserting TypeError wording in failure-callback tests

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -148,7 +148,7 @@ class SyncJobCallback(RQTestCase):
 
         job = queue.enqueue(div_by_zero, on_failure=save_exception)
         self.assertEqual(job.get_status(), JobStatus.FAILED)
-        self.assertIn('div_by_zero', self.connection.get(f'failure_callback:{job.id}').decode())
+        self.assertTrue(self.connection.exists(f'failure_callback:{job.id}'))
 
         job = queue.enqueue(div_by_zero, on_success=save_result)
         self.assertEqual(job.get_status(), JobStatus.FAILED)
@@ -157,7 +157,7 @@ class SyncJobCallback(RQTestCase):
         # test string callbacks
         job = queue.enqueue(div_by_zero, on_failure=Callback('tests.fixtures.save_exception'))
         self.assertEqual(job.get_status(), JobStatus.FAILED)
-        self.assertIn('div_by_zero', self.connection.get(f'failure_callback:{job.id}').decode())
+        self.assertTrue(self.connection.exists(f'failure_callback:{job.id}'))
 
         job = queue.enqueue(div_by_zero, on_success=Callback('tests.fixtures.save_result'))
         self.assertEqual(job.get_status(), JobStatus.FAILED)
@@ -258,7 +258,7 @@ class WorkerCallbackTestCase(RQTestCase):
         self.assertEqual(job.get_status(), JobStatus.FAILED)
         job.refresh()
         print(job.exc_info)
-        self.assertIn('div_by_zero', self.connection.get(f'failure_callback:{job.id}').decode())
+        self.assertTrue(self.connection.exists(f'failure_callback:{job.id}'))
 
         job = queue.enqueue(div_by_zero, on_success=save_result)
         worker.work(burst=True)
@@ -271,7 +271,7 @@ class WorkerCallbackTestCase(RQTestCase):
         self.assertEqual(job.get_status(), JobStatus.FAILED)
         job.refresh()
         print(job.exc_info)
-        self.assertIn('div_by_zero', self.connection.get(f'failure_callback:{job.id}').decode())
+        self.assertTrue(self.connection.exists(f'failure_callback:{job.id}'))
 
         job = queue.enqueue(div_by_zero, on_success=Callback('tests.fixtures.save_result'))
         worker.work(burst=True)


### PR DESCRIPTION
Fixes #2357.

`div_by_zero` is enqueued without its required argument, so the job fails with `TypeError` rather than `ZeroDivisionError`. The tests then asserted that the exception text contains `div_by_zero`.

That string is not stable: Debian's Python 3.14.2 omits the function name from the message, so the suite fails even though the failure callback ran.

Per @selwin, the tests only need to prove the callback ran. They now check that the Redis key exists instead of matching exception wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated failure-callback tests to verify that callback results are stored in Redis for synchronous and worker execution.
  * Added coverage for string-based callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->