### PR TITLE
Fix import_attribute swallowing internal ImportError

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -190,7 +190,11 @@ def import_attribute(name: str) -> Callable[..., Any]:
             module_name = '.'.join(module_name_bits)
             module = importlib.import_module(module_name)
             break
-        except ImportError:
+        except ModuleNotFoundError as exc:
+            if exc.name is None or not (
+                module_name == exc.name or module_name.startswith(f'{exc.name}.')
+            ):
+                raise
             attribute_bits.insert(0, module_name_bits.pop())
 
     if module is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -171,6 +171,14 @@ class TestUtils(RQTestCase):
         self.assertRaises(ValueError, import_attribute, 'non.existent.module')
         self.assertRaises(ValueError, import_attribute, 'rq.worker.WrongWorker')
 
+    def test_import_attribute_preserves_internal_import_error(self):
+        with patch(
+            'rq.utils.importlib.import_module',
+            side_effect=ImportError('dependency import failed'),
+        ):
+            with self.assertRaisesRegex(ImportError, 'dependency import failed'):
+                import_attribute('rq.worker.SimpleWorker')
+
     def test_ceildiv_even(self):
         """When a number is evenly divisible by another ceildiv returns the quotient"""
         dividend = 12


### PR DESCRIPTION
## Summary

Stop `import_attribute()` from converting dependency/import failures raised inside a valid job module into the misleading `Invalid attribute name` error.

## Changes

- only shorten the candidate dotted module path when `ModuleNotFoundError.name` is the candidate itself or one of its missing parent prefixes
- allow ordinary `ImportError` and nested dependency `ModuleNotFoundError` exceptions to propagate unchanged
- retain the existing fallback behavior for genuinely nonexistent dotted paths
- add regression coverage for an internal import failure

## Validation

Focused test:
`pytest -q tests/test_utils.py -k import_attribute`

Fixes #2089

<!-- pr-relay-job relay-58-9ca0021e348c4707c222 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when loading components from dotted module paths.
  - Internal dependency errors are now surfaced accurately instead of being reported as invalid attribute paths.
- **Tests**
  - Added regression coverage to ensure import errors from valid modules are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->