### PR TITLE
Add built-in cloudpickle serializer alias

### DIFF
--- a/rq/serializers.py
+++ b/rq/serializers.py
@@ -24,6 +24,30 @@ class DefaultSerializer:
 PickleSerializer = DefaultSerializer
 
 
+class CloudpickleSerializer:
+    """Serializer backed by the optional cloudpickle dependency."""
+
+    @staticmethod
+    def dumps(obj: Any, /) -> bytes:
+        try:
+            import cloudpickle
+        except ImportError as exc:
+            raise ImportError(
+                "The 'cloudpickle' serializer requires the 'cloudpickle' package."
+            ) from exc
+        return cloudpickle.dumps(obj)
+
+    @staticmethod
+    def loads(data: bytes, /) -> Any:
+        try:
+            import cloudpickle
+        except ImportError as exc:
+            raise ImportError(
+                "The 'cloudpickle' serializer requires the 'cloudpickle' package."
+            ) from exc
+        return cloudpickle.loads(data)
+
+
 class JSONSerializer:
     @staticmethod
     def dumps(*args, **kwargs):
@@ -37,6 +61,7 @@ class JSONSerializer:
 SERIALIZER_ALIASES: dict[str, Serializer] = {
     'json': JSONSerializer,
     'pickle': PickleSerializer,
+    'cloudpickle': CloudpickleSerializer,
 }
 
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -4,7 +4,13 @@ import pickletools
 import queue
 import unittest
 
-from rq.serializers import DefaultSerializer, JSONSerializer, PickleSerializer, resolve_serializer
+from rq.serializers import (
+    CloudpickleSerializer,
+    DefaultSerializer,
+    JSONSerializer,
+    PickleSerializer,
+    resolve_serializer,
+)
 
 
 class TestSerializers(unittest.TestCase):
@@ -43,5 +49,6 @@ class TestSerializers(unittest.TestCase):
         # Shorthand aliases
         self.assertIs(resolve_serializer('json'), JSONSerializer)
         self.assertIs(resolve_serializer('pickle'), PickleSerializer)
+        self.assertIs(resolve_serializer('cloudpickle'), CloudpickleSerializer)
         self.assertIs(resolve_serializer('rq.serializers.PickleSerializer'), PickleSerializer)
         self.assertIs(resolve_serializer('rq.serializers.DefaultSerializer'), PickleSerializer)


### PR DESCRIPTION
Fixes #2429

## Summary
- add a built-in cloudpickle serializer alias
- import cloudpickle lazily so it remains optional
- raise a clear import error when the optional package is unavailable
- add serializer alias regression coverage

## Testing
Validated with git apply --check against current master; full test suite not run locally. Draft PR for CI validation.

<!-- pr-relay-job relay-88-e049d89333af7a33150c -->