### PR TITLE
fix: defer result_ttl for jobs with unfinished dependents

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -1665,6 +1665,7 @@ class Job:
         execution_id: str | None = None,
         execution_started_at: datetime | None = None,
         execution_ended_at: datetime | None = None,
+        defer_finished_registry: bool = False,
     ):
         """Saves and cleanup job after successful execution"""
         self.log.debug('Job %s: handling success...', self.id)
@@ -1686,7 +1687,7 @@ class Job:
             execution_ended_at=execution_ended_at,
         )
 
-        if result_ttl != 0:
+        if result_ttl != 0 and not defer_finished_registry:
             finished_job_registry = self.finished_job_registry
             finished_job_registry.add(self, result_ttl, pipeline)
 

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -44,6 +44,7 @@ from ..exceptions import DequeueTimeout, DeserializationError, StopRequested
 from ..executions import WORKER_EXECUTIONS_KEY_TEMPLATE, Execution, cleanup_execution, prepare_execution
 from ..group import Group
 from ..job import Job, JobStatus, Retry
+from ..utils import as_text
 from ..job_lifecycle import call_exception_handlers, format_exc_info
 from ..logutils import blue, green, setup_loghandlers, yellow
 from ..queue import Queue
@@ -785,6 +786,26 @@ class BaseWorker:
                     job.send_webhooks(JobStatus.FAILED, exc_string=exc_string)
                 if should_enqueue_dependents:
                     queue.enqueue_dependents(job)
+                    # Same logic as handle_job_success: when a failed job's
+                    # dependencies no longer have unfinished dependents, start
+                    # their result_ttl countdown (#2452).
+                    dep_ids = list(self.connection.smembers(job.dependencies_key))
+                    for dep_id in dep_ids:
+                        dep_id_str = as_text(dep_id)
+                        dep = self.job_class.fetch(dep_id_str, connection=self.connection, serializer=self.serializer)
+                        if dep is None or dep.get_status(refresh=False) != JobStatus.FINISHED:
+                            continue
+                        remaining_dependents = self.connection.smembers(dep.dependents_key)
+                        if not remaining_dependents:
+                            dep_result_ttl = dep.get_result_ttl(self.default_result_ttl)
+                            if dep_result_ttl != 0:
+                                dep.finished_job_registry.add(dep, dep_result_ttl)
+                                dep.cleanup(dep_result_ttl, remove_from_queue=False)
+                                self.log.debug(
+                                    'Worker %s: added dependency %s to finished registry'
+                                    ' (all dependents done, after failure)',
+                                    self.name, dep.id,
+                                )
                     if job.has_rate_limit:
                         job.rate_limit_registry.release_and_enqueue(job.id)
                 elif retry and retry_interval and job.has_rate_limit:
@@ -1522,6 +1543,11 @@ class BaseWorker:
                     self.increment_total_working_time(job.ended_at - job.started_at, pipeline)  # type: ignore
 
                     result_ttl = job.get_result_ttl(self.default_result_ttl)
+                    # Check if this job still has unfinished dependents.  If so,
+                    # defer adding it to the finished_job_registry so that its
+                    # result is not garbage-collected while dependents still
+                    # need it (see #2452).
+                    has_pending_dependents = bool(job.dependent_ids)
                     if result_ttl != 0:
                         self.log.debug("Worker %s: saving job %s's successful execution result", self.name, job.id)
                         job._handle_success(
@@ -1531,6 +1557,7 @@ class BaseWorker:
                             execution_id=execution.id,
                             execution_started_at=execution.created_at,
                             execution_ended_at=job.ended_at,
+                            defer_finished_registry=has_pending_dependents,
                         )
 
                     if job.repeats_left is not None and job.repeats_left > 0:
@@ -1540,13 +1567,35 @@ class BaseWorker:
                             'Worker %s: job %s scheduled to repeat (%s left)', self.name, job.id, job.repeats_left
                         )
                         Repeat.schedule(job, queue, pipeline=pipeline)
-                    else:
+                    elif not has_pending_dependents:
                         job.cleanup(result_ttl, pipeline=pipeline, remove_from_queue=False)
 
                     self.log.debug('Cleaning up execution of job %s', job.id)
                     self.cleanup_execution(job, pipeline=pipeline, execution=execution)
 
                     pipeline.execute()
+
+                    # If this job was a dependent, check whether any of its
+                    # dependencies now have zero unfinished dependents.  If so,
+                    # add them to the finished_job_registry and start their
+                    # result_ttl countdown (#2452).
+                    dep_ids = list(self.connection.smembers(job.dependencies_key))
+                    for dep_id in dep_ids:
+                        dep_id_str = as_text(dep_id)
+                        dep = self.job_class.fetch(dep_id_str, connection=self.connection, serializer=self.serializer)
+                        if dep is None or dep.get_status(refresh=False) != JobStatus.FINISHED:
+                            continue
+                        remaining_dependents = self.connection.smembers(dep.dependents_key)
+                        if not remaining_dependents:
+                            dep_result_ttl = dep.get_result_ttl(self.default_result_ttl)
+                            if dep_result_ttl != 0:
+                                dep.finished_job_registry.add(dep, dep_result_ttl)
+                                dep.cleanup(dep_result_ttl, remove_from_queue=False)
+                                self.log.debug(
+                                    'Worker %s: added dependency %s to finished registry'
+                                    ' (all dependents done)',
+                                    self.name, dep.id,
+                                )
 
                     # Drain ready dependents onto their origin queues now that the
                     # deferred→ready transition has committed. Per-queue failures are

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -307,3 +307,35 @@ class TestDependencies(RQTestCase):
         # Verify enqueue_dependents does not enqueue the dependent
         q.enqueue_dependents(parent_job)
         self.assertEqual(dependent_job.get_status(), JobStatus.DEFERRED)
+
+    def test_result_ttl_deferred_when_dependents_pending(self):
+        """When a job finishes but has unfinished dependents, its result should
+        not be garbage-collected until all dependents complete (#2452).
+        """
+        q = Queue(connection=self.connection)
+
+        # Parent with short result_ttl
+        parent_job = q.enqueue(say_hello, result_ttl=1)
+        # Dependent job
+        dependent_job = q.enqueue(say_hello, depends_on=parent_job)
+
+        # Worker processes only the parent (max_jobs=1)
+        w = Worker([q], connection=self.connection)
+        w.work(burst=True, max_jobs=1)
+
+        # Parent should be finished
+        self.assertEqual(parent_job.get_status(), JobStatus.FINISHED)
+        # Dependent should still be deferred
+        self.assertEqual(dependent_job.get_status(), JobStatus.DEFERRED)
+        # Parent should NOT be in finished_job_registry yet (deferred)
+        finished_ids = parent_job.finished_job_registry.get_job_ids()
+        self.assertNotIn(parent_job.id, finished_ids)
+
+        # Now process the dependent
+        w.work(burst=True, max_jobs=1)
+
+        # After dependent finishes, parent should be added to finished_job_registry
+        finished_ids = parent_job.finished_job_registry.get_job_ids()
+        self.assertIn(parent_job.id, finished_ids)
+        # Parent result should still be accessible
+        self.assertEqual(parent_job.return_value(refresh=True), say_hello())


### PR DESCRIPTION
## Summary

Fixes #2452

When a job finishes but has dependents that haven't run yet, its result_ttl countdown now starts only after all dependents complete, not immediately upon the parent's completion.

## Problem

Previously, a parent job's result could be garbage-collected while dependents still needed it, causing NoSuchJobError on lookup. This happened because finished_job_registry.add() and job.cleanup() ran unconditionally in _handle_success, regardless of dependent state.

## Fix

- Adds a defer_finished_registry flag to _handle_success that skips adding to finished_job_registry when set
- In handle_job_success, checks job.dependent_ids before deciding whether to defer
- After pipeline execution, checks each dependency of the current job: if it is FINISHED and has no remaining dependents, adds it to finished_job_registry and starts its cleanup
- Same logic applied in handle_job_failure for consistency

## Testing

Added test_result_ttl_deferred_when_dependents_pending to tests/test_dependencies.py.

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>