### PR TITLE
Cron job registry

### DIFF
--- a/rq/cron.py
+++ b/rq/cron.py
@@ -17,7 +17,7 @@ from croniter import croniter
 from redis import Redis
 from redis.client import Pipeline
 
-from . import cron_scheduler_registry
+from . import cron_job_registry, cron_scheduler_registry
 from .defaults import (
     DEFAULT_CRON_JOB_HISTORY_LIMIT,
     DEFAULT_CRON_JOB_HISTORY_TTL,
@@ -43,6 +43,21 @@ from .utils import (
     validate_absolute_path,
 )
 from .webhook import Webhook
+
+
+def get_cron_job_history_key(name: str) -> str:
+    """Redis key of the sorted set holding IDs of jobs spawned by the named cron job"""
+    return f'rq:cron_job:{name}:jobs'
+
+
+def get_cron_job_ids(name: str, connection: Redis, start: int = 0, end: int = -1) -> list[str]:
+    """Return IDs of jobs spawned by the named cron job, newest first.
+
+    `start` and `end` are zero-based inclusive indexes into the newest-first
+    ordering, following `zrange` semantics (`end=-1` means the oldest entry).
+    Ordering among jobs enqueued at the same timestamp is unspecified.
+    """
+    return [as_text(job_id) for job_id in connection.zrange(get_cron_job_history_key(name), start, end, desc=True)]
 
 
 class CronJob:
@@ -117,7 +132,7 @@ class CronJob:
     @property
     def job_history_key(self) -> str:
         """Redis key of the sorted set holding IDs of jobs spawned by this cron job"""
-        return f'rq:cron_job:{self.name}:jobs'
+        return get_cron_job_history_key(self.name)
 
     def enqueue(self, connection: Redis) -> Job:
         """Enqueue this job to its queue, record it in the job history and update the next run time"""
@@ -132,6 +147,7 @@ class CronJob:
             pipeline.zadd(self.job_history_key, {job.id: job.enqueued_at.timestamp()})
             pipeline.zremrangebyrank(self.job_history_key, 0, -(DEFAULT_CRON_JOB_HISTORY_LIMIT + 1))
             pipeline.expire(self.job_history_key, DEFAULT_CRON_JOB_HISTORY_TTL)
+            cron_job_registry.add(self.name, pipeline, enqueue_timestamp=job.enqueued_at.timestamp())
             pipeline.execute()
         logging.getLogger(__name__).info(f'Enqueued job {self.func.__name__} to queue {self.queue_name}')
 
@@ -144,7 +160,7 @@ class CronJob:
         ordering, following `zrange` semantics (`end=-1` means the oldest entry).
         Ordering among jobs enqueued at the same timestamp is unspecified.
         """
-        return [as_text(job_id) for job_id in connection.zrange(self.job_history_key, start, end, desc=True)]
+        return get_cron_job_ids(self.name, connection, start, end)
 
     def get_next_enqueue_time(self) -> datetime:
         """Calculate the next run time based on interval or cron expression"""

--- a/rq/cron_job_registry.py
+++ b/rq/cron_job_registry.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import time
+
+from redis import Redis
+from redis.client import Pipeline
+
+from .defaults import DEFAULT_CRON_JOB_HISTORY_TTL
+
+
+def get_registry_key() -> str:
+    """Get the Redis key for the cron job name registry"""
+    return 'rq:cron_jobs'
+
+
+def add(name: str, connection: Redis | Pipeline, enqueue_timestamp: float | None = None) -> None:
+    """Record a cron job name in the registry
+
+    Adding a name that's already registered refreshes its timestamp. Multiple
+    cron jobs may share a name, so duplicates are not an error.
+
+    Args:
+        name: Name of the cron job to record
+        connection: Redis connection or pipeline to use
+        enqueue_timestamp: When the cron job last enqueued. Defaults to the current time
+    """
+    connection.zadd(get_registry_key(), {name: enqueue_timestamp or time.time()})
+
+
+def get_names(connection: Redis, cleanup: bool = True) -> list[str]:
+    """Get all cron job names from the registry
+
+    Args:
+        connection: Redis connection to use
+        cleanup: If True, removes stale entries from the registry before reading
+
+    Returns:
+        List of cron job names (strings) sorted by last enqueue time (oldest first)
+    """
+    if cleanup:
+        remove_stale_entries(connection)
+
+    names = connection.zrange(get_registry_key(), 0, -1)
+    return [name.decode('utf-8') if isinstance(name, bytes) else name for name in names]
+
+
+def remove_stale_entries(connection: Redis, threshold: int = DEFAULT_CRON_JOB_HISTORY_TTL) -> int:
+    """Remove stale cron job names from the registry
+
+    Removes names whose last enqueue is more than `threshold` seconds ago. The
+    default threshold matches the job history TTL, so names age out of the
+    registry on the same clock as the job history keys they point to.
+
+    Args:
+        connection: Redis connection to use
+        threshold: Number of seconds after which an entry is considered stale
+
+    Returns:
+        Number of stale entries removed
+    """
+    cutoff_time = time.time() - threshold
+    return connection.zremrangebyscore(get_registry_key(), 0, cutoff_time)

--- a/tests/test_cron_job.py
+++ b/tests/test_cron_job.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
-from rq import Queue, utils
-from rq.cron import CronJob, CronScheduler
+from rq import Queue, cron_job_registry, utils
+from rq.cron import CronJob, CronScheduler, get_cron_job_history_key, get_cron_job_ids
 from rq.defaults import DEFAULT_CRON_JOB_HISTORY_TTL
 from rq.utils import NOT_JSON_SERIALIZABLE
 from rq.webhook import Webhook
@@ -205,6 +205,25 @@ class TestCronJob(RQTestCase):
 
         ttl = self.connection.ttl(cron_job.job_history_key)
         self.assertTrue(0 < ttl <= DEFAULT_CRON_JOB_HISTORY_TTL)
+
+    def test_enqueue_records_name_in_registry(self):
+        """enqueue() records the cron job's name in the cron job registry"""
+        cron_job = CronJob(func=say_hello, queue_name=self.queue.name, interval=60, name='greeter')
+        job = cron_job.enqueue(self.connection)
+
+        self.assertEqual(cron_job_registry.get_names(self.connection), ['greeter'])
+        score = self.connection.zscore(cron_job_registry.get_registry_key(), 'greeter')
+        self.assertEqual(score, job.enqueued_at.timestamp())
+
+    def test_get_cron_job_ids_by_name(self):
+        """Module-level get_cron_job_ids() reads a history from just the cron job name"""
+        self.assertEqual(get_cron_job_history_key('greeter'), 'rq:cron_job:greeter:jobs')
+
+        cron_job = CronJob(func=say_hello, queue_name=self.queue.name, interval=60, name='greeter')
+        first_job = cron_job.enqueue(self.connection)
+        second_job = cron_job.enqueue(self.connection)
+
+        self.assertEqual(get_cron_job_ids('greeter', self.connection), [second_job.id, first_job.id])
 
     def test_enqueue_with_webhooks(self):
         """Webhooks are attached to the job produced by enqueue"""

--- a/tests/test_cron_job_registry.py
+++ b/tests/test_cron_job_registry.py
@@ -1,0 +1,70 @@
+import time
+
+from rq import cron_job_registry
+from rq.defaults import DEFAULT_CRON_JOB_HISTORY_TTL
+from tests import RQTestCase
+
+
+class TestCronJobRegistry(RQTestCase):
+    """Tests for the cron job registry functions"""
+
+    def test_add(self):
+        """add() records a cron job name, directly or through a pipeline"""
+        cron_job_registry.add('job-a', self.connection)
+        self.assertEqual(cron_job_registry.get_names(self.connection), ['job-a'])
+
+        with self.connection.pipeline() as pipeline:
+            cron_job_registry.add('job-b', pipeline)
+            pipeline.execute()
+
+        names = cron_job_registry.get_names(self.connection)
+        self.assertEqual(len(names), 2)
+        self.assertIn('job-b', names)
+
+        # An explicit enqueue timestamp is stored as-is
+        explicit_timestamp = time.time() - 30
+        cron_job_registry.add('job-c', self.connection, enqueue_timestamp=explicit_timestamp)
+        self.assertEqual(self.connection.zscore(cron_job_registry.get_registry_key(), 'job-c'), explicit_timestamp)
+
+    def test_add_same_name_updates_timestamp(self):
+        """Adding an existing name refreshes its timestamp instead of raising"""
+        cron_job_registry.add('job-a', self.connection, enqueue_timestamp=100.0)
+        cron_job_registry.add('job-a', self.connection, enqueue_timestamp=200.0)
+
+        self.assertEqual(self.connection.zcard(cron_job_registry.get_registry_key()), 1)
+        self.assertEqual(self.connection.zscore(cron_job_registry.get_registry_key(), 'job-a'), 200.0)
+
+    def test_get_names_orders_by_enqueue_time(self):
+        """get_names() returns decoded names ordered oldest enqueue time first"""
+        current_time = time.time()
+        cron_job_registry.add('newer-job', self.connection, enqueue_timestamp=current_time)
+        cron_job_registry.add('older-job', self.connection, enqueue_timestamp=current_time - 60)
+
+        self.assertEqual(cron_job_registry.get_names(self.connection), ['older-job', 'newer-job'])
+
+    def test_get_names_removes_stale_entries(self):
+        """get_names() prunes stale entries unless cleanup=False"""
+        current_time = time.time()
+        stale_timestamp = current_time - DEFAULT_CRON_JOB_HISTORY_TTL - 100
+        cron_job_registry.add('stale-job', self.connection, enqueue_timestamp=stale_timestamp)
+        cron_job_registry.add('recent-job', self.connection, enqueue_timestamp=current_time)
+
+        self.assertEqual(cron_job_registry.get_names(self.connection), ['recent-job'])
+        self.assertIsNone(self.connection.zscore(cron_job_registry.get_registry_key(), 'stale-job'))
+
+        cron_job_registry.add('stale-job', self.connection, enqueue_timestamp=stale_timestamp)
+        names = cron_job_registry.get_names(self.connection, cleanup=False)
+        self.assertEqual(names, ['stale-job', 'recent-job'])
+
+    def test_remove_stale_entries(self):
+        """remove_stale_entries() removes entries older than the threshold and returns the count"""
+        current_time = time.time()
+        stale_timestamp = current_time - DEFAULT_CRON_JOB_HISTORY_TTL - 100
+        cron_job_registry.add('stale-job', self.connection, enqueue_timestamp=stale_timestamp)
+        cron_job_registry.add('recent-job', self.connection, enqueue_timestamp=current_time - 60)
+
+        self.assertEqual(cron_job_registry.remove_stale_entries(self.connection), 1)
+        self.assertEqual(cron_job_registry.get_names(self.connection), ['recent-job'])
+
+        self.assertEqual(cron_job_registry.remove_stale_entries(self.connection, threshold=30), 1)
+        self.assertEqual(cron_job_registry.get_names(self.connection), [])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cron jobs can now have configurable logical names.
  - Added access to enqueue history and recorded job IDs, with ordering, pagination, retention, and expiration support.
  - Added a registry for discovering cron jobs and tracking their latest enqueue activity.
  - Prevented duplicate registration when cron definitions are loaded globally.

- **Bug Fixes**
  - Maintained compatibility with previously serialized cron jobs that do not include names.
  - Scheduler logs now propagate correctly for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->