### PR TITLE
Make CronScheduler.heartbeat() self heals, if it still runs after bri…

### DIFF
--- a/rq/cron.py
+++ b/rq/cron.py
@@ -21,6 +21,7 @@ from . import cron_job_registry, cron_scheduler_registry
 from .defaults import (
     DEFAULT_CRON_JOB_HISTORY_LIMIT,
     DEFAULT_CRON_JOB_HISTORY_TTL,
+    DEFAULT_CRON_SCHEDULER_TTL,
     DEFAULT_LOGGING_DATE_FORMAT,
     DEFAULT_LOGGING_FORMAT,
     DEFAULT_RESULT_TTL,
@@ -419,10 +420,10 @@ class CronScheduler:
 
         try:
             while True:
-                enqueued = self.enqueue_jobs()
-                if enqueued:
-                    # Save updated job timing data to Redis
-                    self.save_jobs_data()
+                enqueued_jobs = self.enqueue_jobs()
+                if enqueued_jobs:
+                    # Persist updated job timing data to Redis
+                    self.save()
                 self.heartbeat()
                 sleep_time = self.calculate_sleep_interval()
                 if sleep_time > 0:
@@ -541,24 +542,24 @@ class CronScheduler:
 
     def save(self, pipeline: Pipeline | None = None) -> None:
         """Save CronScheduler instance to Redis hash with TTL"""
-        connection = pipeline if pipeline is not None else self.connection
+        connection = pipeline if pipeline is not None else self.connection.pipeline()
         connection.hset(self.key, mapping=self.to_dict())
-        connection.expire(self.key, 60)
+        connection.expire(self.key, DEFAULT_CRON_SCHEDULER_TTL)
 
-    def save_jobs_data(self) -> None:
-        """Save cron jobs data to Redis."""
-        data = json.dumps([job.to_dict() for job in self._cron_jobs])
-        self.connection.hset(self.key, 'cron_jobs', data)
+        if pipeline is None:
+            connection.execute()
 
     def restore(self, raw_data: dict) -> None:
         """Restore CronScheduler instance from Redis hash data."""
         obj = decode_redis_hash(raw_data, decode_values=True)
 
-        self.hostname = obj['hostname']
+        self.hostname = obj.get('hostname', '')
         self.pid = int(obj.get('pid', 0))
-        self.name = obj['name']
-        self.created_at = str_to_date(obj['created_at'])
-        self.config_file = obj['config_file']
+        self.name = obj.get('name', self.name)
+        created_at = obj.get('created_at')
+        if created_at:
+            self.created_at = str_to_date(created_at)
+        self.config_file = obj.get('config_file', '')
 
         # Restore CronJob data if available
         if obj.get('cron_jobs'):
@@ -626,20 +627,24 @@ class CronScheduler:
         cron_scheduler_registry.unregister(self, pipeline)
 
     def heartbeat(self) -> None:
-        """Send a heartbeat to update this scheduler's last seen timestamp in the registry
-        and extend the scheduler's Redis hash TTL.
+        """Update this scheduler's last seen timestamp in the registry and refresh
+        its Redis hash TTL, re-creating both if they have expired or been pruned.
         """
-        with self.connection.pipeline() as pipe:
-            pipe.zadd(cron_scheduler_registry.get_registry_key(), {self.name: time.time()}, xx=True, ch=True)
-            pipe.expire(self.key, 120)
-            results = pipe.execute()
+        with self.connection.pipeline() as pipeline:
+            pipeline.zadd(cron_scheduler_registry.get_registry_key(), {self.name: time.time()})
+            pipeline.expire(self.key, DEFAULT_CRON_SCHEDULER_TTL)
+            zadd_result, expire_result = pipeline.execute()
 
-            # Check zadd result (first command in pipeline)
-            zadd_result = results[0]
-            if zadd_result:
-                self.log.debug(f'CronScheduler {self.name}: heartbeat sent successfully')
-            else:
-                self.log.warning(f'CronScheduler {self.name}: heartbeat failed - scheduler not found in registry')
+        if not expire_result:
+            # expire returns 0 when the key is missing: the hash expired
+            # (e.g. the host slept past the TTL), so re-create it
+            self.save()
+
+        # zadd returns 1 if the member was newly added
+        if zadd_result:
+            self.log.info('CronScheduler %s: re-registered in scheduler registry', self.name)
+        else:
+            self.log.debug('CronScheduler %s: heartbeat sent successfully', self.name)
 
     @property
     def last_heartbeat(self) -> datetime | None:

--- a/rq/cron_scheduler_registry.py
+++ b/rq/cron_scheduler_registry.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from redis import Redis
 from redis.client import Pipeline
 
+from .defaults import DEFAULT_CRON_SCHEDULER_TTL
 from .exceptions import DuplicateSchedulerError, SchedulerNotFound
 
 if TYPE_CHECKING:
@@ -78,7 +79,7 @@ def get_keys(connection: Redis) -> list[str]:
     return [key.decode('utf-8') if isinstance(key, bytes) else key for key in keys]
 
 
-def cleanup(connection: Redis, threshold: int = 120) -> int:
+def cleanup(connection: Redis, threshold: int = DEFAULT_CRON_SCHEDULER_TTL) -> int:
     """Remove stale CronScheduler entries from the registry
 
     Removes schedulers that haven't sent a heartbeat in more than `threshold` seconds.

--- a/rq/defaults.py
+++ b/rq/defaults.py
@@ -66,6 +66,13 @@ Refreshed on every write, so history expires if the cron job spawns no jobs for 
 """
 
 
+DEFAULT_CRON_SCHEDULER_TTL = 120
+""" The Time To Live (TTL) in seconds for a CronScheduler's Redis hash.
+Refreshed on every heartbeat. Also used as the staleness threshold when
+pruning dead schedulers from the scheduler registry.
+"""
+
+
 DEFAULT_SCHEDULER_FALLBACK_PERIOD = 120
 """ The amount in seconds it will take for a new scheduler
 to pickup tasks after a scheduler has died.

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -15,6 +15,7 @@ from rq import Queue, cron, utils
 from rq.connections import get_connection_kwargs
 from rq.cron import CronJob, CronScheduler, _job_data_registry
 from rq.cron_scheduler_registry import get_keys, get_registry_key
+from rq.defaults import DEFAULT_CRON_SCHEDULER_TTL
 from rq.exceptions import SchedulerNotFound
 from rq.webhook import Webhook
 from tests import RQTestCase
@@ -628,8 +629,8 @@ class TestCronScheduler(RQTestCase):
         with self.assertRaises(ValueError):
             job_1.enqueue(self.connection)
 
-    def test_save_jobs_data_updates_timing(self):
-        """Test that save_jobs_data() updates job timing information in Redis"""
+    def test_save_persists_job_timing(self):
+        """Test that save() persists updated job timing information in Redis"""
         scheduler = CronScheduler(connection=self.connection, name='test-scheduler')
 
         # Register a job with interval
@@ -653,8 +654,8 @@ class TestCronScheduler(RQTestCase):
         job.latest_enqueue_time = last_enqueue_time
         job.next_enqueue_time = next_time
 
-        # Save only jobs data (not full scheduler state)
-        scheduler.save_jobs_data()
+        # save() persists the full scheduler state, including job timing
+        scheduler.save()
 
         # Fetch again and verify timing was updated
         fetched_scheduler = CronScheduler.fetch('test-scheduler', self.connection)
@@ -670,7 +671,15 @@ class TestCronScheduler(RQTestCase):
         self.assertEqual(updated_jobs[0].next_enqueue_time.replace(microsecond=0), next_time.replace(microsecond=0))
 
     def test_cron_scheduler_restore_edge_cases(self):
-        """Test that restore() handles missing and malformed cron_jobs data gracefully"""
+        """Test that restore() handles missing fields and malformed cron_jobs data gracefully"""
+        # Test a partial hash missing scheduler metadata fields
+        scheduler = CronScheduler(connection=self.connection, name='partial-scheduler')
+        scheduler.restore({b'cron_jobs': b'[]'})
+        self.assertEqual(scheduler.name, 'partial-scheduler')
+        self.assertEqual(scheduler.hostname, '')
+        self.assertEqual(scheduler.pid, 0)
+        self.assertEqual(len(scheduler.get_jobs()), 0)
+
         # Test missing cron_jobs field (backwards compatibility)
         data = {
             b'hostname': b'test-host',
@@ -737,10 +746,10 @@ class TestCronScheduler(RQTestCase):
         # Verify Redis hash data was saved
         self.assertTrue(self.connection.exists(scheduler.key))
 
-        # Verify TTL is set (should be 60 seconds)
+        # Verify TTL is set
         ttl = self.connection.ttl(scheduler.key)
         self.assertGreater(ttl, 0)
-        self.assertLessEqual(ttl, 60)
+        self.assertLessEqual(ttl, DEFAULT_CRON_SCHEDULER_TTL)
 
         # Register death
         scheduler.register_death()
@@ -762,9 +771,9 @@ class TestCronScheduler(RQTestCase):
         initial_score = self.connection.zscore(registry_key, scheduler.name)
         self.assertIsNotNone(initial_score)
 
-        # Verify initial TTL (should be 60 seconds from register_birth)
+        # Verify initial TTL from register_birth
         initial_ttl = self.connection.ttl(scheduler.key)
-        self.assertTrue(0 < initial_ttl <= 60)
+        self.assertTrue(0 < initial_ttl <= DEFAULT_CRON_SCHEDULER_TTL)
 
         # Wait a brief moment to ensure timestamp difference
         time.sleep(0.01)
@@ -774,21 +783,50 @@ class TestCronScheduler(RQTestCase):
         self.assertIsNotNone(new_score)
         self.assertGreater(cast(float, new_score), cast(float, initial_score))
 
-        # Verify TTL was extended to 120 seconds
+        # Verify TTL was refreshed
         new_ttl = self.connection.ttl(scheduler.key)
-        self.assertTrue(60 < new_ttl <= 120)
+        self.assertTrue(0 < new_ttl <= DEFAULT_CRON_SCHEDULER_TTL)
 
         scheduler.register_death()
 
-        # Test heartbeat on unregistered scheduler
+        # Heartbeat on an unregistered scheduler registers it and saves its hash
         unregistered_scheduler = CronScheduler(connection=self.connection, name='unregistered-scheduler')
-
-        # This should not raise an exception, but should log a warning
         unregistered_scheduler.heartbeat()
 
-        # Verify unregistered scheduler is still not in registry
         score = self.connection.zscore(registry_key, 'unregistered-scheduler')
-        self.assertIsNone(score)
+        self.assertIsNotNone(score)
+        self.assertTrue(self.connection.exists(unregistered_scheduler.key))
+
+        unregistered_scheduler.register_death()
+        self.connection.delete(unregistered_scheduler.key)
+
+    def test_heartbeat_resurrects_scheduler_after_expiry(self):
+        """Test that heartbeat() re-creates the scheduler hash and registry entry after expiry"""
+        scheduler = CronScheduler(connection=self.connection, name='resurrected-scheduler')
+        scheduler.register(say_hello, 'default', interval=60)
+        scheduler.register_birth()
+
+        # Simulate the hash expiring and the registry entry being pruned,
+        # e.g. after the host slept longer than the heartbeat TTL
+        self.connection.delete(scheduler.key)
+        self.connection.zrem(get_registry_key(), scheduler.name)
+
+        scheduler.heartbeat()
+
+        # Scheduler is visible to monitoring again, with its full state restored
+        schedulers = CronScheduler.all(self.connection)
+        scheduler_names = [found_scheduler.name for found_scheduler in schedulers]
+        self.assertIn('resurrected-scheduler', scheduler_names)
+
+        fetched_scheduler = CronScheduler.fetch('resurrected-scheduler', self.connection)
+        self.assertEqual(fetched_scheduler.hostname, scheduler.hostname)
+        self.assertEqual(fetched_scheduler.pid, scheduler.pid)
+        restored_jobs = fetched_scheduler.get_jobs()
+        self.assertEqual(len(restored_jobs), 1)
+        self.assertEqual(restored_jobs[0].interval, 60)
+
+        scheduler.register_death()
+        self.connection.delete(scheduler.key)
 
     @patch('rq.cron.CronScheduler.register_death')
     @patch('rq.cron.CronScheduler._install_signal_handlers')


### PR DESCRIPTION
…ef connection timeouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler heartbeat reliability by automatically restoring expired or missing scheduler registrations.
  * Prevented scheduler data loss when metadata is incomplete or partially unavailable.
  * Standardized scheduler expiration and cleanup timing for more consistent behavior.

* **Maintenance**
  * Simplified scheduler data persistence and timing management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->