### PR TITLE
Fix test not calling `tearDown()`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,7 @@ class CLITestCase(RQTestCase):
         self.connection: Redis = Redis.from_url(self.redis_url)
 
     def tearDown(self):
+        super().tearDown()
         self.connection.close()
 
     def assert_normal_execution(self, result):
@@ -906,10 +907,9 @@ class WorkerPoolCLITestCase(CLITestCase):
 
         runner = CliRunner()
         # With exception handler, job should be in failed registry with meta updated
-        result = runner.invoke(main, ['worker-pool',
-                                      '-u', self.redis_url,
-                                      '-b', '--exception-handler',
-                                      'tests.fixtures.add_meta'])
+        result = runner.invoke(
+            main, ['worker-pool', '-u', self.redis_url, '-b', '--exception-handler', 'tests.fixtures.add_meta']
+        )
         self.assert_normal_execution(result)
 
         # Job should be failed (exception handled by custom handler)
@@ -928,11 +928,19 @@ class WorkerPoolCLITestCase(CLITestCase):
         job = q.enqueue(div_by_zero)
 
         runner = CliRunner()
-        result = runner.invoke(main, [
-            'worker-pool', '-u', self.redis_url, '-b',
-            '--exception-handler', 'tests.fixtures.add_meta',
-            '--exception-handler', 'tests.fixtures.black_hole'
-        ])
+        result = runner.invoke(
+            main,
+            [
+                'worker-pool',
+                '-u',
+                self.redis_url,
+                '-b',
+                '--exception-handler',
+                'tests.fixtures.add_meta',
+                '--exception-handler',
+                'tests.fixtures.black_hole',
+            ],
+        )
         self.assert_normal_execution(result)
 
         # Job should be failed (exception handled)
@@ -953,10 +961,10 @@ class WorkerPoolCLITestCase(CLITestCase):
     def test_worker_pool_invalid_exception_handler(self):
         """rq worker-pool -u <url> -b --exception-handler <invalid>"""
         runner = CliRunner()
-        result = runner.invoke(main, [
-            'worker-pool', '-u', self.redis_url, '-b',
-            '--exception-handler', 'tests.fixtures.nonexistent_handler'
-        ])
+        result = runner.invoke(
+            main,
+            ['worker-pool', '-u', self.redis_url, '-b', '--exception-handler', 'tests.fixtures.nonexistent_handler'],
+        )
         # Should fail because handler doesn't exist
         self.assertNotEqual(result.exit_code, 0)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup by ensuring standard teardown processing runs before closing the Redis connection.
  * Reformatted worker-pool exception-handler test cases without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->