### PR TITLE
Move callback related logic from job.py to callbacks.py

### DIFF
--- a/rq/__init__.py
+++ b/rq/__init__.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F401
-from .job import Callback, Retry, cancel_job, get_current_job, requeue_job
+from .callbacks import Callback
+from .job import Retry, cancel_job, get_current_job, requeue_job
 from .queue import Queue
 from .rate_limit import RateLimit
 from .repeat import Repeat

--- a/rq/callbacks.py
+++ b/rq/callbacks.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from .defaults import CALLBACK_TIMEOUT
+from .timeouts import JobTimeoutException
+from .utils import parse_timeout, resolve_function_reference
+
+if TYPE_CHECKING:
+    from .job import Job
+    from .timeouts import BaseDeathPenalty
+
+
+class Callback:
+    def __init__(self, func: str | Callable[..., Any], timeout: Any | None = None):
+        if not isinstance(func, str) and not inspect.isfunction(func) and not inspect.isbuiltin(func):
+            raise ValueError('Callback `func` must be a string or function')
+
+        self.func = func
+        self.timeout = parse_timeout(timeout) if timeout else CALLBACK_TIMEOUT
+
+    @property
+    def name(self) -> str:
+        if isinstance(self.func, str):
+            return self.func
+        _, func_name = resolve_function_reference(self.func)
+        return func_name
+
+
+def execute_success_callback(job: Job, death_penalty_class: type[BaseDeathPenalty], result: Any) -> None:
+    """Run the job's success callback under its timeout."""
+    callback = job.success_callback
+    if callback is None:
+        return
+    if inspect.iscoroutinefunction(callback):
+        raise TypeError('Coroutine success callbacks are not supported')
+
+    job.log.debug('Job %s: running success callback...', job.id)
+    with death_penalty_class(job.success_callback_timeout, JobTimeoutException, job_id=job.id):
+        callback(job, job.connection, result)
+
+
+def execute_failure_callback(job: Job, death_penalty_class: type[BaseDeathPenalty], *exc_info) -> None:
+    """Run the job's failure callback under its timeout."""
+    callback = job.failure_callback
+    if callback is None:
+        return
+    if inspect.iscoroutinefunction(callback):
+        raise TypeError('Coroutine failure callbacks are not supported')
+
+    job.log.debug('Job %s: running failure callback...', job.id)
+    try:
+        with death_penalty_class(job.failure_callback_timeout, JobTimeoutException, job_id=job.id):
+            callback(job, job.connection, *exc_info)
+    except Exception:
+        job.log.exception('Job %s: error while executing failure callback', job.id)
+        raise
+
+
+def execute_stopped_callback(job: Job, death_penalty_class: type[BaseDeathPenalty]) -> None:
+    """Run the job's stopped callback under its timeout."""
+    callback = job.stopped_callback
+    if callback is None:
+        return
+    if inspect.iscoroutinefunction(callback):
+        raise TypeError('Coroutine stopped callbacks are not supported')
+
+    job.log.debug('Job %s: running stopped callback...', job.id)
+    try:
+        with death_penalty_class(job.stopped_callback_timeout, JobTimeoutException, job_id=job.id):
+            callback(job, job.connection)
+    except Exception:
+        job.log.exception('Job %s: error while executing stopped callback', job.id)
+        raise

--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -9,8 +9,8 @@ if TYPE_CHECKING:
 
     from .job import Retry
 
+from .callbacks import Callback
 from .defaults import DEFAULT_RESULT_TTL
-from .job import Callback
 from .queue import Queue
 from .webhook import Webhook
 

--- a/rq/job.py
+++ b/rq/job.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import json
 import logging
 import re
@@ -17,7 +16,6 @@ from uuid import uuid4
 from redis import WatchError
 
 from .defaults import CALLBACK_TIMEOUT, UNSERIALIZABLE_RETURN_VALUE_PAYLOAD
-from .timeouts import BaseDeathPenalty, JobTimeoutException
 from .types import FailureCallbackType, SuccessCallbackType
 
 if TYPE_CHECKING:
@@ -34,6 +32,7 @@ if TYPE_CHECKING:
         pass
 
 
+from .callbacks import Callback
 from .exceptions import DeserializationError, InvalidJobOperation, NoSuchJobError
 from .serializers import resolve_serializer
 from .types import FunctionReferenceType, JobDependencyType
@@ -1607,47 +1606,6 @@ class Job:
         assert self.rate_limit_key
         return RateLimitRegistry(key=self.rate_limit_key, connection=self.connection)
 
-    def execute_success_callback(self, death_penalty_class: type[BaseDeathPenalty], result: Any):
-        """Executes success_callback for a job.
-        with timeout .
-
-        Args:
-            death_penalty_class (Type[BaseDeathPenalty]): The penalty class to use for timeout
-            result (Any): The job's result.
-        """
-        if not self.success_callback:
-            return
-
-        self.log.debug('Job %s: running success callback...', self.id)
-        with death_penalty_class(self.success_callback_timeout, JobTimeoutException, job_id=self.id):
-            self.success_callback(self, self.connection, result)
-
-    def execute_failure_callback(self, death_penalty_class: type[BaseDeathPenalty], *exc_info):
-        """Executes failure_callback with possible timeout"""
-        if not self.failure_callback:
-            return
-
-        self.log.debug('Job %s: running failure callback...', self.id)
-        try:
-            with death_penalty_class(self.failure_callback_timeout, JobTimeoutException, job_id=self.id):
-                self.failure_callback(self, self.connection, *exc_info)
-        except Exception:  # noqa
-            self.log.exception('Job %s: error while executing failure callback', self.id)
-            raise
-
-    def execute_stopped_callback(self, death_penalty_class: type[BaseDeathPenalty]):
-        """Executes stopped_callback with possible timeout"""
-        if self.stopped_callback is None:
-            return
-
-        self.log.debug('Job %s: running stopped callback...', self.id)
-        try:
-            with death_penalty_class(self.stopped_callback_timeout, JobTimeoutException, job_id=self.id):
-                self.stopped_callback(self, self.connection)
-        except Exception:  # noqa
-            self.log.exception('Job %s: error while executing stopped callback', self.id)
-            raise
-
     def send_webhooks(self, status: str | JobStatus, *, exc_string: str | None = None) -> None:
         """Sends every webhook registered for the given terminal job status.
         `exc_string` is included in the payload of `failed` webhooks.
@@ -2003,19 +1961,3 @@ class Retry:
         number_of_intervals = len(intervals)
         index = min(number_of_intervals - 1, count)
         return intervals[index]
-
-
-class Callback:
-    def __init__(self, func: str | Callable[..., Any], timeout: Any | None = None):
-        if not isinstance(func, str) and not inspect.isfunction(func) and not inspect.isbuiltin(func):
-            raise ValueError('Callback `func` must be a string or function')
-
-        self.func = func
-        self.timeout = parse_timeout(timeout) if timeout else CALLBACK_TIMEOUT
-
-    @property
-    def name(self) -> str:
-        if isinstance(self.func, str):
-            return self.func
-        _, func_name = resolve_function_reference(self.func)
-        return func_name

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -25,11 +25,12 @@ if TYPE_CHECKING:
 
     from .job import Retry
 
+from .callbacks import Callback, execute_failure_callback, execute_success_callback
 from .defaults import DEFAULT_RESULT_TTL
 from .dependency import Dependency
 from .exceptions import DequeueTimeout, NoSuchJobError
 from .intermediate_queue import IntermediateQueue
-from .job import Callback, Job, JobStatus
+from .job import Job, JobStatus
 from .job_lifecycle import format_exc_info, record_job_failure
 from .logutils import blue, green
 from .rate_limit import RateLimit
@@ -1443,10 +1444,10 @@ class Queue:
                 record_job_failure(job, exc_string, pipeline)
                 pipeline.execute()
 
-            job.execute_failure_callback(self.death_penalty_class, *sys.exc_info())
+            execute_failure_callback(job, self.death_penalty_class, *sys.exc_info())
             job.send_webhooks(JobStatus.FAILED, exc_string=exc_string)
         else:
-            job.execute_success_callback(self.death_penalty_class, job.return_value())
+            execute_success_callback(job, self.death_penalty_class, job.return_value())
             job.send_webhooks(JobStatus.FINISHED)
 
         return job

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -12,6 +12,7 @@ from redis.exceptions import WatchError
 
 from rq.serializers import resolve_serializer
 
+from .callbacks import execute_failure_callback
 from .connections import get_connection_kwargs
 from .defaults import DEFAULT_FAILURE_TTL
 from .exceptions import AbandonedJobError, InvalidJobOperation, NoSuchJobError
@@ -294,7 +295,9 @@ class StartedJobRegistry(BaseRegistry):
                 # A raising failure callback must not abort the batch or stop the job from
                 # being moved to the FailedJobRegistry, so log and swallow it here.
                 try:
-                    job.execute_failure_callback(self.death_penalty_class, AbandonedJobError, AbandonedJobError(), None)
+                    execute_failure_callback(
+                        job, self.death_penalty_class, AbandonedJobError, AbandonedJobError(), None
+                    )
                 except Exception:
                     logger.exception('%s cleanup: failure callback for job %s raised', self.__class__.__name__, job.id)
 

--- a/rq/worker/base.py
+++ b/rq/worker/base.py
@@ -31,6 +31,7 @@ from contextlib import suppress
 import redis.exceptions
 
 from .. import worker_registration
+from ..callbacks import execute_failure_callback, execute_success_callback
 from ..command import PUBSUB_CHANNEL_TEMPLATE, handle_command, parse_payload
 from ..defaults import (
     DEFAULT_JOB_MONITORING_INTERVAL,
@@ -1623,7 +1624,7 @@ class BaseWorker:
                 return True
             else:
                 job._status = JobStatus.FINISHED
-                job.execute_success_callback(self.death_penalty_class, return_value)
+                execute_success_callback(job, self.death_penalty_class, return_value)
                 self.handle_job_success(
                     job=job, queue=queue, started_job_registry=started_job_registry, execution=execution
                 )
@@ -1638,7 +1639,7 @@ class BaseWorker:
             exc_string = format_exc_info(exc_info)
 
             try:
-                job.execute_failure_callback(self.death_penalty_class, *exc_info)
+                execute_failure_callback(job, self.death_penalty_class, *exc_info)
             except:  # noqa
                 exc_info = sys.exc_info()
                 exc_string = format_exc_info(exc_info)

--- a/rq/worker/worker_classes.py
+++ b/rq/worker/worker_classes.py
@@ -9,6 +9,7 @@ import time
 from random import shuffle
 from typing import TYPE_CHECKING
 
+from ..callbacks import execute_stopped_callback
 from ..connections import get_connection_kwargs
 from ..defaults import DEFAULT_WORKER_TTL
 from ..exceptions import InvalidJobOperation, ShutDownImminentException
@@ -153,11 +154,10 @@ class Worker(BaseWorker):
         logged and swallowed here.
         """
         self.log.warning('Worker %s: job %s stopped by user, moving job to FailedJobRegistry', self.name, job.id)
-        if job.stopped_callback:
-            try:
-                job.execute_stopped_callback(self.death_penalty_class)
-            except Exception:
-                self.log.exception('Worker %s: stopped callback for job %s raised', self.name, job.id)
+        try:
+            execute_stopped_callback(job, self.death_penalty_class)
+        except Exception:
+            self.log.exception('Worker %s: stopped callback for job %s raised', self.name, job.id)
         self.handle_job_failure(
             job, queue=queue, exc_string='Job stopped by user, work-horse terminated.', execution=execution
         )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -373,3 +373,15 @@ def _send_kill_horse_command(worker_name, connection_kwargs, delay=0.25):
 
 class CustomJob(Job):
     """A custom job class just to test it"""
+
+
+async def async_success_callback(job, connection, result):
+    connection.set(f'async_success_callback:{job.id}', result, ex=60)
+
+
+async def async_failure_callback(job, connection, type, value, traceback):
+    connection.set(f'async_failure_callback:{job.id}', str(value), ex=60)
+
+
+async def async_stopped_callback(job, connection):
+    connection.set(f'async_stopped_callback:{job.id}', 'stopped', ex=60)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -2,11 +2,15 @@ from datetime import timedelta
 from unittest import mock
 
 from rq import Queue, Worker
+from rq.callbacks import execute_failure_callback, execute_stopped_callback, execute_success_callback
 from rq.job import UNEVALUATED, Callback, Job, JobStatus
 from rq.serializers import JSONSerializer
 from rq.worker import SimpleWorker
 from tests import RQTestCase
 from tests.fixtures import (
+    async_failure_callback,
+    async_stopped_callback,
+    async_success_callback,
     div_by_zero,
     erroneous_callback,
     long_process,
@@ -163,26 +167,42 @@ class SyncJobCallback(RQTestCase):
         self.assertEqual(job.get_status(), JobStatus.FAILED)
         self.assertFalse(self.connection.exists(f'failure_callback:{job.id}'))
 
-    def test_sync_routes_callbacks_through_execute_methods(self):
+    def test_sync_routes_callbacks_through_execution_helpers(self):
         """Sync execution dispatches callbacks via execute_*_callback (gaining timeout
         wrapping), not by calling the raw callbacks directly."""
         queue = Queue(is_async=False, connection=self.connection)
 
-        with mock.patch.object(Job, 'execute_success_callback') as mocked:
+        with mock.patch('rq.queue.execute_success_callback') as mocked:
             queue.enqueue(say_hello, on_success=save_result)
         mocked.assert_called_once()
-        self.assertIs(mocked.call_args.args[0], queue.death_penalty_class)
+        self.assertIs(mocked.call_args.args[1], queue.death_penalty_class)
 
-        with mock.patch.object(Job, 'execute_failure_callback') as mocked:
+        with mock.patch('rq.queue.execute_failure_callback') as mocked:
             queue.enqueue(div_by_zero, on_failure=save_exception)
         mocked.assert_called_once()
-        self.assertIs(mocked.call_args.args[0], queue.death_penalty_class)
+        self.assertIs(mocked.call_args.args[1], queue.death_penalty_class)
 
     def test_sync_failure_callback_exception_propagates(self):
         """A raising sync failure callback propagates out, as before the refactor."""
         queue = Queue(is_async=False, connection=self.connection)
         with self.assertRaises(Exception):
             queue.enqueue(div_by_zero, on_failure=erroneous_callback)
+
+    def test_coroutine_callbacks_rejected(self):
+        """Coroutine callbacks raise TypeError instead of being called without await."""
+        queue = Queue(connection=self.connection)
+
+        job = queue.enqueue(say_hello, on_success=Callback(async_success_callback))
+        with self.assertRaises(TypeError):
+            execute_success_callback(job, SimpleWorker.death_penalty_class, None)
+
+        job = queue.enqueue(say_hello, on_failure=Callback(async_failure_callback))
+        with self.assertRaises(TypeError):
+            execute_failure_callback(job, SimpleWorker.death_penalty_class, ValueError, ValueError('x'), None)
+
+        job = queue.enqueue(long_process, on_stopped=Callback(async_stopped_callback))
+        with self.assertRaises(TypeError):
+            execute_stopped_callback(job, SimpleWorker.death_penalty_class)
 
     def test_stopped_callback(self):
         """queue.enqueue* methods with on_stopped is persisted correctly"""
@@ -191,16 +211,12 @@ class SyncJobCallback(RQTestCase):
         worker = SimpleWorker('foo', connection=connection, serializer=JSONSerializer)
 
         job = queue.enqueue(long_process, on_stopped=save_result_if_not_stopped)
-        job.execute_stopped_callback(
-            worker.death_penalty_class
-        )  # Calling execute_stopped_callback directly for coverage
+        execute_stopped_callback(job, worker.death_penalty_class)  # Calling directly for coverage
         self.assertTrue(self.connection.exists(f'stopped_callback:{job.id}'))
 
         # test string callbacks
         job = queue.enqueue(long_process, on_stopped=Callback('tests.fixtures.save_result_if_not_stopped'))
-        job.execute_stopped_callback(
-            worker.death_penalty_class
-        )  # Calling execute_stopped_callback directly for coverage
+        execute_stopped_callback(job, worker.death_penalty_class)  # Calling directly for coverage
         self.assertTrue(self.connection.exists(f'stopped_callback:{job.id}'))
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -873,13 +873,13 @@ class TestStartedJobRegistry(RQTestCase):
         self.assertNotIn(job, failed_job_registry)
         self.assertIn(job, self.registry)
 
-        with mock.patch.object(Job, 'execute_failure_callback') as mocked:
+        with mock.patch('rq.registry.execute_failure_callback') as mocked:
             mock_handler = mock.MagicMock()
             mock_handler.return_value = False
             mock_handler_no_return = mock.MagicMock()
             mock_handler_no_return.return_value = None
             self.registry.cleanup(exception_handlers=[mock_handler_no_return, mock_handler])
-            mocked.assert_called_once_with(self.queue.death_penalty_class, AbandonedJobError, ANY, None)
+            mocked.assert_called_once_with(job, self.queue.death_penalty_class, AbandonedJobError, ANY, None)
             mock_handler.assert_called_once_with(job, AbandonedJobError, ANY, None)
             mock_handler_no_return.assert_called_once_with(job, AbandonedJobError, ANY, None)
         self.assertIn(job.id, failed_job_registry)
@@ -897,7 +897,7 @@ class TestStartedJobRegistry(RQTestCase):
         job = self.queue.enqueue(say_hello)
         self.connection.zadd(self.registry.key, {f'{job.id}:execution_id': 1})
 
-        with mock.patch.object(Job, 'execute_failure_callback', side_effect=Exception()):
+        with mock.patch('rq.registry.execute_failure_callback', side_effect=Exception()):
             self.registry.cleanup()
 
         self.assertIn(job.id, failed_job_registry)
@@ -922,9 +922,9 @@ class TestStartedJobRegistry(RQTestCase):
         self.connection.zadd(self.registry.key, {f'{parent_job.id}:execution': 2})
         queue.remove(parent_job.id)
 
-        with mock.patch.object(Job, 'execute_failure_callback') as mocked:
+        with mock.patch('rq.registry.execute_failure_callback') as mocked:
             self.registry.cleanup()
-            mocked.assert_called_once_with(queue.death_penalty_class, AbandonedJobError, ANY, ANY)
+            mocked.assert_called_once_with(parent_job, queue.death_penalty_class, AbandonedJobError, ANY, ANY)
 
         # check that parent job was moved to FailedJobRegistry and has correct status
         self.assertIn(parent_job, failed_job_registry)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized execution support for success, failure, and stopped-job callbacks.
  * Callbacks can be referenced by callable or string name and run with configurable timeouts.
* **Bug Fixes**
  * Callback failures are logged and handled consistently across synchronous jobs, workers, and abandoned jobs.
  * Stopped-job callbacks are now reliably processed.
  * Coroutine-based callbacks are rejected with a clear `TypeError` instead of being executed unexpectedly.
* **Tests**
  * Added coverage for callback routing, timeout handling, stopped jobs, and unsupported asynchronous callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->