### PR TITLE
Schedule job repeats against UTC, not the local wall clock

### DIFF
--- a/rq/repeat.py
+++ b/rq/repeat.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import TYPE_CHECKING
+
+from .utils import now
 
 if TYPE_CHECKING:
     from redis.client import Pipeline
@@ -109,8 +111,11 @@ class Repeat:
             # Enqueue the job immediately
             queue._enqueue_job(job, pipeline=pipe)
         else:
-            # Schedule the job to run after the interval
-            scheduled_time = datetime.now() + timedelta(seconds=interval)
+            # Schedule the job to run after the interval. Use an aware UTC
+            # datetime: a naive one makes ScheduledJobRegistry.schedule() guess
+            # the server's offset from time.altzone whenever time.daylight is
+            # set, which is an hour off outside DST.
+            scheduled_time = now() + timedelta(seconds=interval)
             queue.schedule_job(job, scheduled_time, pipeline=pipe)
 
         # Execute the pipeline if we created it

--- a/tests/test_repeat.py
+++ b/tests/test_repeat.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from unittest import mock
 
 from rq import Queue, Worker
 from rq.job import Job
@@ -194,6 +195,37 @@ class TestRepeatEnqueue(RQTestCase):
         # Check repeats_left was decremented
         job.refresh()
         self.assertEqual(job.repeats_left, 2)
+
+    def test_repeat_schedule_is_not_shifted_by_local_timezone(self):
+        """Repeat.schedule() schedules against UTC, not the server's wall clock"""
+        queue = self.queue
+        registry = ScheduledJobRegistry(queue=queue)
+
+        job = queue.enqueue(say_hello, repeat=Repeat(times=3, interval=30))
+        queue.empty()
+
+        # Simulate a server whose timezone observes DST but is currently on
+        # standard time. For a naive datetime, ScheduledJobRegistry.schedule()
+        # falls back to time.altzone whenever time.daylight is set, so it
+        # guesses an offset an hour away from the real one. An aware datetime
+        # never reaches that fallback.
+        standard_offset = int(-datetime.now().astimezone().utcoffset().total_seconds())
+        daylight = mock.patch('time.daylight', 1)
+        timezone = mock.patch('time.timezone', standard_offset)
+        altzone = mock.patch('time.altzone', standard_offset - 3600)
+
+        with daylight, timezone, altzone:
+            before_schedule = now()
+            Repeat.schedule(job, queue)
+            after_schedule = now()
+
+        scheduled_time = registry.get_scheduled_time(job.id)
+        expected_min = before_schedule + timedelta(seconds=25)
+        expected_max = after_schedule + timedelta(seconds=35)
+        self.assertTrue(
+            expected_min <= scheduled_time <= expected_max,
+            f'Job not scheduled in expected window: {expected_min} <= {scheduled_time} <= {expected_max}',
+        )
 
 
 class TestWorkerRepeat(RQTestCase):


### PR DESCRIPTION
`Repeat.schedule()` builds the next run time from a naive `datetime.now()` (`rq/repeat.py:113`). `ScheduledJobRegistry.schedule()` then has to guess the server's offset, and its fallback is

```python
tz = timezone(timedelta(seconds=-(time.timezone if time.daylight == 0 else time.altzone)))
```

`time.daylight` means "this zone observes DST at all", not "DST is in effect right now" (that is `time.localtime().tm_isdst`), so `altzone` is applied year round. On a DST-observing server that is currently on standard time, the repeat is scheduled an hour early — and for an interval under an hour, immediately.

Measured just now against a local Redis, same machine, same clock, `Repeat(times=3, interval=3600)`:

```
TZ                    daylight  scheduled minus intended   job fires in
Australia/Sydney         1            -3600 s                  0 s
Pacific/Auckland         1            -3600 s                  0 s
America/Santiago         1            -3600 s                  0 s
Europe/London            1                0 s               3600 s     (currently in DST)
UTC                      0                0 s               3600 s
```

The first three are southern-hemisphere zones on standard time today; the northern ones show the same thing in their winter. Every other scheduling site in rq already uses the aware `rq.utils.now()` — `Job.get_retry_interval`'s caller, `Queue.enqueue_in` (`rq/queue.py:1213`), `rq/cron.py:367`. `repeat.py` was the one that did not, so making it aware is a one-line change and the registry's fallback is never reached.

**Existing coverage and why it passes.** `test_repeat_schedule_interval_greater_than_zero` already asserts the scheduled window, but CI runs on `ubuntu-latest` with `TZ=UTC`, where `time.daylight == 0` and the fallback happens to guess right. The added test patches `time.daylight`/`time.timezone`/`time.altzone` to simulate a DST zone on standard time — the same idiom `tests/test_scheduler.py:102-104` already uses — so it fails in any CI timezone.

**Honest note on the fix:** any *aware* datetime fixes this, not just a UTC one. I ran a mutant that used `datetime.now().astimezone()` instead and it passes the new test and the whole suite. I chose `rq.utils.now()` because it matches every other call site; if you would rather keep local time and just make it aware, say so and I will switch.

**Not fixed here, deliberately:** the `time.daylight` expression in `ScheduledJobRegistry.schedule()` is itself wrong for any naive datetime a user passes to `enqueue_at`/`schedule`, and it is duplicated at `rq/scripts.py:188-191`. Correcting that changes behaviour for existing callers, so it wants its own change.

**What I ran:** full `pytest tests` against a local Redis, same venv, both legs in one session — **706 passed / 22 skipped before, 707 / 22 after** (+1 = the new test). On unmodified `master` the new test fails. `ruff check rq tests` and `ruff format --check` clean (ruff 0.16.5), `mypy rq/repeat.py` clean.

---

AI assistance: this change was drafted with Claude Opus 5 (`claude-opus-5`) via Claude Code. Every number above was measured on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeat-job scheduling to consistently use timezone-aware UTC timestamps.
  * Fixed scheduling discrepancies that could occur on servers observing daylight-saving time.

* **Tests**
  * Added regression coverage for repeat scheduling across local timezone configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->