### PR TITLE
Added registry.purge() so rq empty can clear failed and finished jobs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ### RQ 3.0 (unreleased)
+* Added `registry.purge()` and `queue.purge_registries()` to bulk delete every job in a registry. `rq empty` can now clear the failed, finished and canceled job registries via `--failed`, `--finished`, `--canceled` and `--registries`.
 * `Job.perform()` no longer removes the job key's TTL. Job key TTL changes are now handled by workers. Thanks @selwin!
 * Refactored how job dependencies are handled. Introduced `READY_TO_ENQUEUE` job status and ReadyJobRegistry. Thanks @selwin!
 * `get_current_job()` now uses `contextvars` instead of thread-locals; gevent-based custom workers need `greenlet` >= 0.4.17. Thanks @selwin!

--- a/docs/docs/job_registries.md
+++ b/docs/docs/job_registries.md
@@ -90,3 +90,62 @@ for job_id in registry.get_job_ids():
 for job_id in registry.get_job_ids():
     registry.remove(job_id, delete_job=True)
 ```
+
+## Purging a Registry
+
+To clear out a whole registry at once, use `registry.purge()`. It removes every entry and
+deletes the jobs themselves, working in chunks so that a large registry doesn't have to be
+loaded into memory. It returns the number of registry entries it removed.
+
+```python
+from redis import Redis
+from rq import Queue
+
+redis = Redis()
+queue = Queue(connection=redis)
+
+# Delete every failed job of this queue
+queue.failed_job_registry.purge()
+
+# Clear the registry but leave the job data to expire through its own TTL.
+# Much faster on a very large registry, since the jobs are never fetched.
+queue.failed_job_registry.purge(delete_jobs=False)
+```
+
+`Queue.purge_registries()` does the same for several registries in one call, returning the
+number of entries removed from each:
+
+```python
+queue.purge_registries(failed=True, finished=True)
+# {'failed': 373, 'finished': 12}
+```
+
+Only the registries holding jobs that will never run again can be purged this way: `failed`,
+`finished` and `canceled`. Deferred and scheduled jobs are still waiting to run, and started
+jobs may be executing right now, so those registries are left out on purpose.
+
+### Purging Registries via CLI
+
+The same thing from the command line, through `rq empty`:
+
+```console
+# Delete every failed job of the myqueue queue
+rq empty --failed myqueue
+
+# Clear the failed, finished and canceled registries of two queues
+rq empty --registries myqueue myotherqueue
+
+# ...of every queue
+rq empty --registries --all
+
+# Clear the registry entries but leave the job data to expire through its own TTL
+rq empty --failed --keep-jobs myqueue
+```
+
+Without any of these options `rq empty` behaves as it always has and empties the queue itself,
+leaving the registries alone. The two can be combined:
+
+```console
+# Empty the queue AND its failed, finished and canceled registries
+rq empty --queued --registries myqueue
+```

--- a/docs/docs/monitoring.md
+++ b/docs/docs/monitoring.md
@@ -39,6 +39,10 @@ Bricktop.18349 idle: default
 3 workers, 3 queues
 ```
 
+The finished and failed counts `rq info` reports come from each queue's job registries, which
+are separate from the queue itself. To clear them out, see
+[purging a registry](/docs/job_registries/#purging-a-registry).
+
 
 ## Querying by queue names
 

--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -39,10 +39,26 @@ def main():
 
 @main.command()
 @click.option('--all', '-a', is_flag=True, help='Empty all queues')
+@click.option('--queued', is_flag=True, help='Empty the queue itself. Implied when no registry option is given')
+@click.option('--failed', is_flag=True, help="Empty the queue's failed job registry")
+@click.option('--finished', is_flag=True, help="Empty the queue's finished job registry")
+@click.option('--canceled', is_flag=True, help="Empty the queue's canceled job registry")
+@click.option('--registries', is_flag=True, help='Empty the failed, finished and canceled job registries')
+@click.option('--keep-jobs', is_flag=True, help='Only clear registry entries, letting job data expire via its TTL')
 @click.argument('queues', nargs=-1)
 @pass_cli_config
-def empty(cli_config, all, queues, serializer, **options):
+def empty(cli_config, all, queued, failed, finished, canceled, registries, keep_jobs, queues, serializer, **options):
     """Empty given queues."""
+
+    if registries:
+        failed = finished = canceled = True
+
+    empty_registries = failed or finished or canceled
+    # Without a registry option `rq empty` keeps its original meaning: drain the queue itself.
+    empty_queue = queued or not empty_registries
+
+    if keep_jobs and not empty_registries:
+        raise click.UsageError('--keep-jobs requires one of --failed, --finished, --canceled or --registries')
 
     if all:
         queues = cli_config.queue_class.all(
@@ -64,8 +80,15 @@ def empty(cli_config, all, queues, serializer, **options):
         sys.exit(0)
 
     for queue in queues:
-        num_jobs = queue.empty()
-        click.echo(f'{num_jobs} jobs removed from {queue.name} queue')
+        if empty_queue:
+            num_jobs = queue.empty()
+            click.echo(f'{num_jobs} jobs removed from {queue.name} queue')
+        if empty_registries:
+            counts = queue.purge_registries(
+                failed=failed, finished=finished, canceled=canceled, delete_jobs=not keep_jobs
+            )
+            for registry_name, num_jobs in counts.items():
+                click.echo(f'{num_jobs} {registry_name} jobs removed from {queue.name} queue')
 
 
 @main.command()

--- a/rq/job.py
+++ b/rq/job.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 from .callbacks import Callback
-from .exceptions import DeserializationError, InvalidJobOperation, NoSuchJobError
+from .exceptions import DeserializationError, InvalidJobOperation, NoSuchGroupError, NoSuchJobError
 from .serializers import resolve_serializer
 from .types import FunctionReferenceType, JobDependencyType
 from .utils import (
@@ -1410,8 +1410,14 @@ class Job:
         if self.group_id:
             from .group import Group
 
-            group = Group.fetch(self.group_id, self.connection)
-            group.delete_job(self.id, pipeline=pipeline)
+            try:
+                group = Group.fetch(self.group_id, self.connection)
+            except NoSuchGroupError:
+                # The group set is gone once its last member is removed, so a job outliving
+                # its group is normal and must not abort the rest of this delete.
+                pass
+            else:
+                group.delete_job(self.id, pipeline=pipeline)
 
         connection.delete(self.key, self.dependents_key, self.dependencies_key)
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -498,6 +498,38 @@ class Queue:
 
         return CanceledJobRegistry(queue=self, job_class=self.job_class, serializer=self.serializer)
 
+    def purge_registries(
+        self,
+        failed: bool = False,
+        finished: bool = False,
+        canceled: bool = False,
+        delete_jobs: bool = True,
+    ) -> dict[str, int]:
+        """Removes all entries from the selected job registries of this queue.
+
+        Only registries holding jobs that will never run again are offered here. The
+        deferred, scheduled and started registries hold jobs that are still pending or
+        in flight, so they are purged through their own APIs instead.
+
+        Args:
+            failed (bool, optional): Purge the FailedJobRegistry. Defaults to False.
+            finished (bool, optional): Purge the FinishedJobRegistry. Defaults to False.
+            canceled (bool, optional): Purge the CanceledJobRegistry. Defaults to False.
+            delete_jobs (bool, optional): Whether to delete the jobs too. Defaults to True.
+
+        Returns:
+            dict[str, int]: Number of entries removed, keyed by registry name. Only the
+                selected registries are present, so selecting none returns an empty dict.
+        """
+        results: dict[str, int] = {}
+        if failed:
+            results['failed'] = self.failed_job_registry.purge(delete_jobs=delete_jobs)
+        if finished:
+            results['finished'] = self.finished_job_registry.purge(delete_jobs=delete_jobs)
+        if canceled:
+            results['canceled'] = self.canceled_job_registry.purge(delete_jobs=delete_jobs)
+        return results
+
     def remove(self, job_or_id: Job | str, pipeline: Pipeline | None = None):
         """Removes Job from queue, accepts either a Job instance or ID.
 

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -154,6 +154,88 @@ class BaseRegistry:
             job_instance.delete()
         return result
 
+    def purge(self, delete_jobs: bool = True, chunk_size: int = 1000) -> int:
+        """Removes every entry from this registry, optionally deleting the jobs themselves.
+
+        Entries are drained in chunks: each pass reads the first `chunk_size` members and
+        removes exactly those members, so every pass makes progress and the loop terminates
+        even while entries are being added concurrently.
+
+        Registry entries routinely outlive their job hash, so a missing job is not an error:
+        the entry is removed and counted either way. This is why the return value counts
+        registry entries removed rather than jobs deleted.
+
+        Unlike `count` and `get_job_ids()`, this deliberately does not run `cleanup()`.
+        Expired entries have to be purged and counted like any other, not silently dropped
+        with their job hash left behind.
+
+        Args:
+            delete_jobs (bool, optional): Whether to delete the jobs too. Defaults to True.
+            chunk_size (int, optional): How many entries to remove per round trip. Defaults to 1000.
+
+        Returns:
+            int: The number of registry entries removed.
+        """
+        if chunk_size < 1:
+            raise ValueError('chunk_size must be a positive integer')
+
+        total = 0
+        while True:
+            members = self.connection.zrange(self.key, 0, chunk_size - 1)
+            if not members:
+                break
+
+            if delete_jobs:
+                removed = self._purge_chunk(members)
+            else:
+                removed = self.connection.zrem(self.key, *members)
+
+            if not removed:
+                # Redis removed none of the members we just read, so another client is
+                # draining this registry too. Stop rather than spin on it.
+                logger.debug('%s.purge removed nothing from %s, stopping', type(self).__name__, self.key)
+                break
+
+            total += removed
+
+        return total
+
+    def _purge_chunk(self, members: Sequence[Any]) -> int:
+        """Removes `members` from the registry and deletes their jobs in one transaction.
+
+        Args:
+            members (Sequence[Any]): Raw sorted set members, as returned by `ZRANGE`.
+
+        Returns:
+            int: The number of registry entries removed.
+        """
+        # parse_job_id() decodes the member and, for StartedJobRegistry, splits the composite
+        # key. The raw members are what ZREM needs; the parsed ids are what fetch_many needs.
+        job_ids = [self.parse_job_id(member) for member in members]
+        jobs = self.job_class.fetch_many(job_ids, connection=self.connection, serializer=self.serializer)
+
+        with self.connection.pipeline() as pipeline:
+            # ZREM goes first so its reply is the authoritative count. Job.delete() below
+            # buffers a ZREM of the same member via _remove_from_registries(), which would
+            # leave a trailing ZREM reporting 0.
+            pipeline.zrem(self.key, *members)
+
+            for job in jobs:
+                if job is None:
+                    # The job hash is already gone; dropping the stale entry is the point.
+                    continue
+                try:
+                    # Jobs held by a registry are never on the queue list, and the LREM that
+                    # Job.delete() would otherwise do is O(len(queue)) per job.
+                    job.delete(pipeline=pipeline, remove_from_queue=False)
+                except Exception:
+                    # A partial Job.delete() would leave the hash behind, so delete its keys
+                    # directly instead of letting one bad job abort the whole chunk.
+                    logger.exception('%s.purge could not delete job %s', type(self).__name__, job.id)
+                    pipeline.delete(job.key, job.dependents_key, job.dependencies_key)
+
+            return pipeline.execute()[0]
+
     def get_expired_job_ids(self, timestamp: float | None = None):
         """Returns job ids whose score are less than current timestamp.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,6 +141,96 @@ class TestRQCli(CLITestCase):
         self.assert_normal_execution(result)
         self.assertEqual(result.output.strip(), 'Nothing to do')
 
+    def test_empty_failed_registry(self):
+        """rq empty -u <url> --failed <queue>"""
+        connection = Redis.from_url(self.redis_url)
+        queue = Queue('empty-failed', connection=connection)
+        queue.enqueue(div_by_zero)
+        Worker([queue], connection=connection).work(burst=True)
+        queued_job = queue.enqueue(say_hello)
+        self.assertEqual(queue.failed_job_registry.count, 1)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ['empty', '-u', self.redis_url, '--failed', 'empty-failed'])
+        self.assert_normal_execution(result)
+
+        self.assertIn('1 failed jobs removed from empty-failed queue', result.output)
+        self.assertEqual(queue.failed_job_registry.count, 0)
+        # A registry option must never drain the queue itself.
+        self.assertEqual(queue.get_job_ids(), [queued_job.id])
+
+    def test_empty_leaves_registries_alone_by_default(self):
+        """rq empty -u <url> <queue>"""
+        connection = Redis.from_url(self.redis_url)
+        queue = Queue('empty-default', connection=connection)
+        queue.enqueue(div_by_zero)
+        Worker([queue], connection=connection).work(burst=True)
+        queue.enqueue(say_hello)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ['empty', '-u', self.redis_url, 'empty-default'])
+        self.assert_normal_execution(result)
+
+        self.assertIn('1 jobs removed from empty-default queue', result.output)
+        self.assertEqual(queue.count, 0)
+        self.assertEqual(queue.failed_job_registry.count, 1)
+
+    def test_empty_queued_and_registries(self):
+        """rq empty -u <url> --queued --registries <queue>"""
+        connection = Redis.from_url(self.redis_url)
+        queue = Queue('empty-both', connection=connection)
+        queue.enqueue(div_by_zero)
+        Worker([queue], connection=connection).work(burst=True)
+        queue.enqueue(say_hello)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ['empty', '-u', self.redis_url, '--queued', '--registries', 'empty-both'])
+        self.assert_normal_execution(result)
+
+        self.assertIn('1 jobs removed from empty-both queue', result.output)
+        self.assertIn('1 failed jobs removed from empty-both queue', result.output)
+        self.assertIn('0 finished jobs removed from empty-both queue', result.output)
+        self.assertIn('0 canceled jobs removed from empty-both queue', result.output)
+        self.assertEqual(queue.count, 0)
+        self.assertEqual(queue.failed_job_registry.count, 0)
+
+    def test_empty_registries_all_queues(self):
+        """rq empty -u <url> --registries --all"""
+        connection = Redis.from_url(self.redis_url)
+        queues = [Queue(name, connection=connection) for name in ('empty-all-1', 'empty-all-2')]
+        for queue in queues:
+            queue.enqueue(div_by_zero)
+        Worker(queues, connection=connection).work(burst=True)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ['empty', '-u', self.redis_url, '--registries', '--all'])
+        self.assert_normal_execution(result)
+
+        for queue in queues:
+            self.assertEqual(queue.failed_job_registry.count, 0)
+
+    def test_empty_failed_keep_jobs(self):
+        """rq empty -u <url> --failed --keep-jobs <queue>"""
+        connection = Redis.from_url(self.redis_url)
+        queue = Queue('empty-keep', connection=connection)
+        job = queue.enqueue(div_by_zero)
+        Worker([queue], connection=connection).work(burst=True)
+
+        runner = CliRunner()
+        result = runner.invoke(main, ['empty', '-u', self.redis_url, '--failed', '--keep-jobs', 'empty-keep'])
+        self.assert_normal_execution(result)
+
+        self.assertEqual(queue.failed_job_registry.count, 0)
+        self.assertTrue(Job.exists(job.id, connection=connection))
+
+    def test_empty_keep_jobs_without_a_registry_is_a_usage_error(self):
+        """rq empty -u <url> --keep-jobs <queue>"""
+        runner = CliRunner()
+        result = runner.invoke(main, ['empty', '-u', self.redis_url, '--keep-jobs', 'empty-keep'])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn('--keep-jobs requires one of', result.output)
+
     def test_requeue(self):
         """rq requeue -u <url> --all"""
         connection = Redis.from_url(self.redis_url)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -16,7 +16,7 @@ from rq.registry import (
 from rq.serializers import JSONSerializer
 from rq.worker import Worker
 from tests import RQTestCase, min_redis_version
-from tests.fixtures import echo, say_hello
+from tests.fixtures import div_by_zero, echo, say_hello
 
 
 class MultipleDependencyJob(Job):
@@ -850,6 +850,56 @@ class TestQueue(RQTestCase):
         job = Job.fetch(job.id, connection=self.connection)
         self.assertEqual(job.retries_left, 3)
         self.assertEqual(job.retry_intervals, [5])
+
+
+class TestPurgeRegistries(RQTestCase):
+    def setUp(self):
+        super().setUp()
+        self.queue = Queue(connection=self.connection)
+
+    def populate(self):
+        """Puts one job in each of the failed, finished and canceled registries."""
+        failed = self.queue.enqueue(div_by_zero)
+        finished = self.queue.enqueue(say_hello)
+        worker = Worker([self.queue], connection=self.connection)
+        worker.work(burst=True)
+
+        canceled = self.queue.enqueue(say_hello)
+        canceled.cancel()
+        return failed, finished, canceled
+
+    def test_purge_registries_selects_only_what_it_is_asked_for(self):
+        """Unselected registries are left untouched."""
+        _, finished, _ = self.populate()
+
+        counts = self.queue.purge_registries(failed=True, canceled=True)
+
+        self.assertEqual(counts, {'failed': 1, 'canceled': 1})
+        self.assertEqual(self.queue.finished_job_registry.get_job_ids(), [finished.id])
+        self.assertTrue(self.connection.exists(finished.key))
+
+    def test_purge_registries_without_arguments_does_nothing(self):
+        """Selecting no registry is a no-op returning an empty mapping."""
+        self.populate()
+
+        self.assertEqual(self.queue.purge_registries(), {})
+        self.assertEqual(self.queue.failed_job_registry.count, 1)
+
+    def test_purge_registries_keeps_jobs_when_asked(self):
+        """delete_jobs=False clears the indexes but leaves the jobs in place."""
+        failed, _, _ = self.populate()
+
+        self.assertEqual(self.queue.purge_registries(failed=True, delete_jobs=False), {'failed': 1})
+        self.assertTrue(self.connection.exists(failed.key))
+
+    def test_purge_registries_leaves_queued_jobs_alone(self):
+        """Purging registries never touches jobs waiting on the queue."""
+        self.populate()
+        queued = self.queue.enqueue(say_hello)
+
+        self.queue.purge_registries(failed=True, finished=True, canceled=True)
+
+        self.assertEqual(self.queue.get_job_ids(), [queued.id])
 
 
 class TestUniqueJob(RQTestCase):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2,6 +2,7 @@ import math
 from datetime import timedelta
 from unittest import mock
 from unittest.mock import ANY
+from uuid import uuid4
 
 import pytest
 
@@ -969,3 +970,138 @@ class TestStartedJobRegistry(RQTestCase):
 
         with pytest.raises(NotImplementedError):
             self.registry.remove('job_id')
+
+
+class TestPurge(RQTestCase):
+    def setUp(self):
+        super().setUp()
+        self.queue = Queue(connection=self.connection)
+        self.registry = FailedJobRegistry(queue=self.queue)
+
+    def enqueue_failed_jobs(self, count: int) -> list[Job]:
+        """Runs `count` failing jobs through a worker so they land in FailedJobRegistry."""
+        jobs = [self.queue.enqueue(div_by_zero) for _ in range(count)]
+        Worker([self.queue], connection=self.connection).work(burst=True)
+        return jobs
+
+    def test_purge_empty_registry(self):
+        """Purging an empty registry removes nothing."""
+        self.assertEqual(self.registry.purge(), 0)
+
+    def test_purge_rejects_non_positive_chunk_size(self):
+        """purge() requires a positive chunk size."""
+        for chunk_size in (0, -1):
+            with self.assertRaises(ValueError):
+                self.registry.purge(chunk_size=chunk_size)
+
+    def test_purge_deletes_jobs(self):
+        """Purging a registry removes its entries and deletes the jobs."""
+        jobs = self.enqueue_failed_jobs(3)
+
+        self.assertEqual(self.registry.purge(), 3)
+
+        self.assertEqual(self.registry.get_job_ids(), [])
+        for job in jobs:
+            self.assertFalse(self.connection.exists(job.key))
+
+    def test_purge_keeps_jobs_when_delete_jobs_is_false(self):
+        """purge(delete_jobs=False) clears the index but leaves the jobs alone."""
+        jobs = self.enqueue_failed_jobs(3)
+
+        self.assertEqual(self.registry.purge(delete_jobs=False), 3)
+
+        self.assertEqual(self.registry.get_job_ids(), [])
+        for job in jobs:
+            self.assertTrue(self.connection.exists(job.key))
+
+    def test_purge_counts_entries_not_jobs(self):
+        """Entries whose job is already gone are still removed and counted."""
+        job = self.enqueue_failed_jobs(1)[0]
+        self.connection.delete(job.key)
+        self.connection.zadd(self.registry.key, {'nonexistent': 1})
+
+        self.assertEqual(self.registry.purge(), 2)
+        self.assertEqual(self.connection.zcard(self.registry.key), 0)
+
+    def test_purge_does_not_run_cleanup(self):
+        """Expired entries are purged and counted, not silently dropped by cleanup()."""
+        job = self.enqueue_failed_jobs(1)[0]
+        # A score in the past is what cleanup() would ZREMRANGEBYSCORE away, leaving the
+        # job hash behind and uncounted.
+        self.connection.zadd(self.registry.key, {job.id: 1})
+
+        self.assertEqual(self.registry.purge(), 1)
+        self.assertFalse(self.connection.exists(job.key))
+
+    def test_purge_in_chunks(self):
+        """A registry larger than chunk_size is drained over several passes."""
+        self.connection.zadd(self.registry.key, {f'job-{i}': i for i in range(25)})
+
+        self.assertEqual(self.registry.purge(delete_jobs=False, chunk_size=10), 25)
+        self.assertEqual(self.connection.zcard(self.registry.key), 0)
+
+    def test_purge_does_not_touch_the_queue(self):
+        """Purging skips the O(len(queue)) LREM, since these jobs aren't on the queue."""
+        self.enqueue_failed_jobs(1)
+        queued_job = self.queue.enqueue(say_hello)
+
+        with mock.patch.object(Queue, 'remove') as remove:
+            self.registry.purge()
+
+        remove.assert_not_called()
+        self.assertEqual(self.queue.get_job_ids(), [queued_job.id])
+
+    def test_purge_continues_when_a_job_cannot_be_deleted(self):
+        """One job failing to delete doesn't abort the chunk or orphan its hash."""
+        jobs = self.enqueue_failed_jobs(3)
+
+        with mock.patch.object(Job, 'delete', side_effect=Exception('boom')):
+            self.assertEqual(self.registry.purge(), 3)
+
+        self.assertEqual(self.connection.zcard(self.registry.key), 0)
+        for job in jobs:
+            self.assertFalse(self.connection.exists(job.key))
+
+    def test_purge_started_registry_parses_composite_keys(self):
+        """StartedJobRegistry members are {job_id}:{execution_id} and still resolve."""
+        registry = StartedJobRegistry(queue=self.queue)
+        job = self.queue.enqueue(say_hello)
+        self.connection.zadd(registry.key, {f'{job.id}:{uuid4().hex}': 1})
+
+        self.assertEqual(registry.purge(), 1)
+        self.assertEqual(self.connection.zcard(registry.key), 0)
+        self.assertFalse(self.connection.exists(job.key))
+
+    def test_purge_with_serializer(self):
+        """purge() threads the registry's serializer through to the bulk job fetch."""
+        queue = Queue(connection=self.connection, serializer=JSONSerializer)
+        queue.enqueue(div_by_zero)
+        Worker([queue], connection=self.connection, serializer=JSONSerializer).work(burst=True)
+        registry = FailedJobRegistry(queue=queue)
+
+        self.assertEqual(registry.purge(), 1)
+        self.assertEqual(registry.get_job_ids(), [])
+
+    def test_purge_finished_registry(self):
+        """FinishedJobRegistry can be purged."""
+        job = self.queue.enqueue(say_hello)
+        worker = Worker([self.queue], connection=self.connection)
+        worker.perform_job(job, self.queue, worker.prepare_execution(job))
+        registry = FinishedJobRegistry(queue=self.queue)
+        self.assertEqual(registry.get_job_ids(), [job.id])
+
+        self.assertEqual(registry.purge(), 1)
+        self.assertEqual(registry.get_job_ids(), [])
+        self.assertFalse(self.connection.exists(job.key))
+
+    def test_purge_canceled_registry(self):
+        """CanceledJobRegistry can be purged despite having no expiry semantics."""
+        jobs = [self.queue.enqueue(say_hello) for _ in range(3)]
+        for job in jobs:
+            job.cancel()
+        registry = CanceledJobRegistry(queue=self.queue)
+
+        self.assertEqual(registry.purge(), 3)
+        self.assertEqual(self.connection.zcard(registry.key), 0)
+        for job in jobs:
+            self.assertFalse(self.connection.exists(job.key))


### PR DESCRIPTION
* Added BaseRegistry.purge() and Queue.purge_registries()
* rq empty accepts --failed, --finished, --canceled, --registries, --queued and --keep-jobs
* Job.delete() no longer raises NoSuchGroupError when a job outlives its group

Fixes #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added APIs to purge individual job registries or multiple registries at once.
  - Extended `rq empty` with options to clear queued, failed, finished, canceled, or all supported registries.
  - Added an option to remove registry entries while retaining job data.

- **Bug Fixes**
  - Job deletion now succeeds when its associated group has already been removed.

- **Documentation**
  - Added guidance for purging registries and clarified how registry counts reported by `rq info` can be cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->