### PR TITLE
docs: clarify SimpleWorker code reload behavior

### DIFF
--- a/docs/docs/workers.md
+++ b/docs/docs/workers.md
@@ -352,6 +352,11 @@ A worker implementation that executes jobs in the same process, without using `f
 
 `SimpleWorker` does not provide periodic heartbeats during job execution.
 This means long-running jobs may appear to be "stuck" from monitoring tools' perspective.
+
+Because jobs run in the worker process, imported Python modules stay loaded between jobs. Source code
+changes made while a `SimpleWorker` is running are therefore not reloaded automatically; restart the
+worker to make subsequent jobs use the updated code.
+
 `SimpleWorker` is not recommended for production use unless you fully understand these limitations.
 
 Usage:


### PR DESCRIPTION
## Summary

Document a `SimpleWorker` behavior that is easy to miss when using it for local development or debugging: because jobs execute in the worker process, imported Python modules remain loaded between jobs, so editing a job's source while the worker is running does not automatically reload that module.

The documentation now tells users to restart `SimpleWorker` before expecting subsequent jobs to use changed source code.

Closes #1434.

## Validation

- reproduced on current `master` with `SimpleWorker` + `fakeredis`: first job returned `v1`; after rewriting the job module to return `v2`, a second job on the same worker still returned `v1`, with the module present in `sys.modules`
- `git diff --check` — pass
- docs-only change: 1 file, 5 lines added

AI assistance was used to help investigate the issue, reproduce the behavior, and prepare the documentation patch. The final diff and reproduction were reviewed directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that worker processes retain imported Python modules between jobs.
  * Documented that workers must be restarted for subsequent jobs to use source code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->