### PR TITLE
Support methods and callable objects as job callbacks

### DIFF
--- a/rq/callbacks.py
+++ b/rq/callbacks.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 
 class Callback:
     def __init__(self, func: str | Callable[..., Any], timeout: Any | None = None):
-        if not isinstance(func, str) and not inspect.isfunction(func) and not inspect.isbuiltin(func):
-            raise ValueError('Callback `func` must be a string or function')
+        if not isinstance(func, str) and (inspect.isclass(func) or not callable(func)):
+            raise ValueError('Callback `func` must be a string or callable')
 
         self.func = func
         self.timeout = parse_timeout(timeout) if timeout else CALLBACK_TIMEOUT
@@ -34,7 +34,7 @@ def execute_success_callback(job: Job, death_penalty_class: type[BaseDeathPenalt
     callback = job.success_callback
     if callback is None:
         return
-    if inspect.iscoroutinefunction(callback):
+    if inspect.iscoroutinefunction(callback) or inspect.iscoroutinefunction(getattr(callback, '__call__', None)):
         raise TypeError('Coroutine success callbacks are not supported')
 
     job.log.debug('Job %s: running success callback...', job.id)
@@ -47,7 +47,7 @@ def execute_failure_callback(job: Job, death_penalty_class: type[BaseDeathPenalt
     callback = job.failure_callback
     if callback is None:
         return
-    if inspect.iscoroutinefunction(callback):
+    if inspect.iscoroutinefunction(callback) or inspect.iscoroutinefunction(getattr(callback, '__call__', None)):
         raise TypeError('Coroutine failure callbacks are not supported')
 
     job.log.debug('Job %s: running failure callback...', job.id)
@@ -64,7 +64,7 @@ def execute_stopped_callback(job: Job, death_penalty_class: type[BaseDeathPenalt
     callback = job.stopped_callback
     if callback is None:
         return
-    if inspect.iscoroutinefunction(callback):
+    if inspect.iscoroutinefunction(callback) or inspect.iscoroutinefunction(getattr(callback, '__call__', None)):
         raise TypeError('Coroutine stopped callbacks are not supported')
 
     job.log.debug('Job %s: running stopped callback...', job.id)

--- a/rq/callbacks.py
+++ b/rq/callbacks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
+from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from .defaults import CALLBACK_TIMEOUT
@@ -29,12 +30,18 @@ class Callback:
         return func_name
 
 
+def _is_async_callback(callback: Callable[..., Any]) -> bool:
+    while isinstance(callback, partial):
+        callback = callback.func
+    return inspect.iscoroutinefunction(callback) or inspect.iscoroutinefunction(getattr(callback, '__call__', None))
+
+
 def execute_success_callback(job: Job, death_penalty_class: type[BaseDeathPenalty], result: Any) -> None:
     """Run the job's success callback under its timeout."""
     callback = job.success_callback
     if callback is None:
         return
-    if inspect.iscoroutinefunction(callback) or inspect.iscoroutinefunction(getattr(callback, '__call__', None)):
+    if _is_async_callback(callback):
         raise TypeError('Coroutine success callbacks are not supported')
 
     job.log.debug('Job %s: running success callback...', job.id)
@@ -47,7 +54,7 @@ def execute_failure_callback(job: Job, death_penalty_class: type[BaseDeathPenalt
     callback = job.failure_callback
     if callback is None:
         return
-    if inspect.iscoroutinefunction(callback) or inspect.iscoroutinefunction(getattr(callback, '__call__', None)):
+    if _is_async_callback(callback):
         raise TypeError('Coroutine failure callbacks are not supported')
 
     job.log.debug('Job %s: running failure callback...', job.id)
@@ -64,7 +71,7 @@ def execute_stopped_callback(job: Job, death_penalty_class: type[BaseDeathPenalt
     callback = job.stopped_callback
     if callback is None:
         return
-    if inspect.iscoroutinefunction(callback) or inspect.iscoroutinefunction(getattr(callback, '__call__', None)):
+    if _is_async_callback(callback):
         raise TypeError('Coroutine stopped callbacks are not supported')
 
     job.log.debug('Job %s: running stopped callback...', job.id)

--- a/rq/job.py
+++ b/rq/job.py
@@ -339,7 +339,7 @@ class Job:
         job._args = args
         job._kwargs = kwargs
 
-        if on_success:
+        if on_success is not None:
             if not isinstance(on_success, Callback):
                 warnings.warn(
                     'Passing a string or function for `on_success` is deprecated, pass `Callback` instead',
@@ -352,7 +352,7 @@ class Job:
             if instance is not None:
                 job._callback_instances['success'] = instance
 
-        if on_failure:
+        if on_failure is not None:
             if not isinstance(on_failure, Callback):
                 warnings.warn(
                     'Passing a string or function for `on_failure` is deprecated, pass `Callback` instead',
@@ -365,7 +365,7 @@ class Job:
             if instance is not None:
                 job._callback_instances['failure'] = instance
 
-        if on_stopped:
+        if on_stopped is not None:
             if not isinstance(on_stopped, Callback):
                 warnings.warn(
                     'Passing a string or function for `on_stopped` is deprecated, pass `Callback` instead',

--- a/rq/job.py
+++ b/rq/job.py
@@ -191,6 +191,8 @@ class Job:
         self._instance: object | UnevaluatedType | None = UNEVALUATED
         self._args: tuple | list | UnevaluatedType = UNEVALUATED
         self._kwargs: dict[str, Any] | UnevaluatedType = UNEVALUATED
+        self._callback_instances: dict[str, Any] = {}
+        self._callback_instances_data: bytes | None = None
         self._success_callback_name: str | None = None
         self._success_callback: Callable[[Job, Redis, Any], Any] | UnevaluatedType = UNEVALUATED
         self._failure_callback_name: str | None = None
@@ -346,6 +348,9 @@ class Job:
                 on_success = Callback(on_success)  # backward compatibility
             job._success_callback_name = on_success.name
             job._success_callback_timeout = on_success.timeout
+            instance, _ = resolve_function_reference(on_success.func)
+            if instance is not None:
+                job._callback_instances['success'] = instance
 
         if on_failure:
             if not isinstance(on_failure, Callback):
@@ -356,6 +361,9 @@ class Job:
                 on_failure = Callback(on_failure)  # backward compatibility
             job._failure_callback_name = on_failure.name
             job._failure_callback_timeout = on_failure.timeout
+            instance, _ = resolve_function_reference(on_failure.func)
+            if instance is not None:
+                job._callback_instances['failure'] = instance
 
         if on_stopped:
             if not isinstance(on_stopped, Callback):
@@ -366,6 +374,9 @@ class Job:
                 on_stopped = Callback(on_stopped)  # backward compatibility
             job._stopped_callback_name = on_stopped.name
             job._stopped_callback_timeout = on_stopped.timeout
+            instance, _ = resolve_function_reference(on_stopped.func)
+            if instance is not None:
+                job._callback_instances['stopped'] = instance
 
         if webhooks:
             if not isinstance(webhooks, Sequence) or not all(isinstance(webhook, Webhook) for webhook in webhooks):
@@ -530,11 +541,26 @@ class Job:
 
         return import_attribute(func_name)
 
+    def _get_callback(self, name: str, callback_type: str) -> Callable[..., Any]:
+        if self._callback_instances_data is not None:
+            try:
+                self._callback_instances = self.serializer.loads(self._callback_instances_data)
+            except Exception as e:
+                raise DeserializationError() from e
+            self._callback_instances_data = None
+
+        instance = self._callback_instances.get(callback_type)
+        if instance is not None:
+            if name == '__call__' and not isinstance(instance, type):
+                return instance
+            return getattr(instance, name)
+        return import_attribute(name)
+
     @property
     def success_callback(self) -> SuccessCallbackType | None:
         if self._success_callback is UNEVALUATED:
             if self._success_callback_name:
-                self._success_callback = import_attribute(self._success_callback_name)
+                self._success_callback = self._get_callback(self._success_callback_name, 'success')
             else:
                 return None
 
@@ -551,7 +577,7 @@ class Job:
     def failure_callback(self) -> FailureCallbackType | None:
         if self._failure_callback is UNEVALUATED:
             if self._failure_callback_name:
-                self._failure_callback = import_attribute(self._failure_callback_name)
+                self._failure_callback = self._get_callback(self._failure_callback_name, 'failure')
             else:
                 return None
 
@@ -568,7 +594,7 @@ class Job:
     def stopped_callback(self) -> Callable[[Job, Redis], Any] | None:
         if self._stopped_callback is UNEVALUATED:
             if self._stopped_callback_name:
-                self._stopped_callback = import_attribute(self._stopped_callback_name)
+                self._stopped_callback = self._get_callback(self._stopped_callback_name, 'stopped')
             else:
                 self._stopped_callback = None
 
@@ -1003,6 +1029,10 @@ class Job:
         # In future versions, if a job has no status, an error should be raised
         self._status = JobStatus(as_text(obj['status'])) if obj.get('status') else JobStatus.CREATED
 
+        self._callback_instances = {}
+        self._callback_instances_data = obj.get('callback_instances')
+        self._success_callback = self._failure_callback = self._stopped_callback = UNEVALUATED
+
         if obj.get('success_callback_name'):
             self._success_callback_name = obj['success_callback_name'].decode()
 
@@ -1101,6 +1131,12 @@ class Job:
             'worker_name': self.worker_name or '',
             'group_id': self.group_id or '',
         }
+
+        callback_instances_data = self._callback_instances_data
+        if callback_instances_data is None and self._callback_instances:
+            callback_instances_data = self.serializer.dumps(self._callback_instances)
+        if callback_instances_data is not None:
+            obj['callback_instances'] = callback_instances_data
 
         if self.number_of_retries is not None:
             obj['number_of_retries'] = self.number_of_retries

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -151,6 +151,16 @@ class CallbackInstanceTestCase(RQTestCase):
                 with self.assertRaises(TypeError):
                     execute(job, SimpleWorker.death_penalty_class, *args)
 
+                job = Job.create(
+                    say_hello,
+                    connection=self.connection,
+                    **{f'on_{kind}': Callback(partial(AsyncCallbackRecorder()))},
+                )
+                job.save()
+                job = Job.fetch(job.id, connection=self.connection)
+                with self.assertRaises(TypeError):
+                    execute(job, SimpleWorker.death_penalty_class, *args)
+
         job = Job.create(say_hello, connection=self.connection, on_success=Callback(partial(async_success_callback)))
         with self.assertRaises(TypeError):
             execute_success_callback(job, SimpleWorker.death_penalty_class, None)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
+from functools import partial
 from unittest import mock
 
 from rq import Queue, Worker
 from rq.callbacks import execute_failure_callback, execute_stopped_callback, execute_success_callback
+from rq.exceptions import DeserializationError
 from rq.job import UNEVALUATED, Callback, Job, JobStatus
 from rq.serializers import JSONSerializer
 from rq.worker import SimpleWorker
@@ -23,14 +25,142 @@ from tests.fixtures import (
 )
 
 
+class CallbackRecorder:
+    def __init__(self, value):
+        self.value = value
+
+    def __bool__(self):
+        return False
+
+    def record(self, job, connection, *args):
+        job.meta['callback'] = (self.value, args)
+        connection.set(f'callback:{job.id}', self.value)
+
+    def __call__(self, job, connection, *args):
+        self.record(job, connection, *args)
+
+    @classmethod
+    def record_class(cls, job, connection, *args):
+        job.meta['callback'] = (cls.__name__, args)
+
+
+class InheritedCallbackRecorder(CallbackRecorder):
+    pass
+
+
+class AsyncCallbackRecorder:
+    async def __call__(self, job, connection, *args):
+        raise AssertionError('Async callbacks must not be invoked')
+
+
+class CallbackInstanceTestCase(RQTestCase):
+    def _assert_callback_roundtrip(self, callback, expected):
+        cases = (
+            ('success', execute_success_callback, ('result',)),
+            ('failure', execute_failure_callback, (ValueError, ValueError('error'), None)),
+            ('stopped', execute_stopped_callback, ()),
+        )
+        for kind, execute, args in cases:
+            with self.subTest(kind=kind):
+                job = Job.create(
+                    say_hello, connection=self.connection, **{f'on_{kind}': Callback(callback, timeout=17)}
+                )
+                job.save()
+                job = Job.fetch(job.id, connection=self.connection)
+                execute(job, SimpleWorker.death_penalty_class, *args)
+                self.assertEqual(job.meta['callback'], (expected, args))
+                self.assertEqual(getattr(job, f'{kind}_callback_timeout'), 17)
+
+    def test_class_method_callbacks(self):
+        self._assert_callback_roundtrip(InheritedCallbackRecorder.record_class, 'InheritedCallbackRecorder')
+
+    def test_bound_method_callbacks(self):
+        self._assert_callback_roundtrip(CallbackRecorder('method').record, 'method')
+
+    def test_callable_instance_callbacks(self):
+        self._assert_callback_roundtrip(CallbackRecorder('instance'), 'instance')
+
+    def test_callback_state_is_saved_and_refreshed(self):
+        recorder = CallbackRecorder('initial')
+        job = Job.create(say_hello, connection=self.connection, on_success=Callback(recorder))
+        recorder.value = 'saved'
+        job.save()
+        restored = Job.fetch(job.id, connection=self.connection)
+        execute_success_callback(restored, SimpleWorker.death_penalty_class, 'result')
+        self.assertEqual(restored.meta['callback'], ('saved', ('result',)))
+
+        recorder.value = 'resaved'
+        job.save()
+        restored.refresh()
+        execute_success_callback(restored, SimpleWorker.death_penalty_class, 'result')
+        self.assertEqual(restored.meta['callback'], ('resaved', ('result',)))
+
+    def test_fetch_and_resave_do_not_deserialize_callbacks(self):
+        job = Job.create(say_hello, connection=self.connection, on_success=Callback(CallbackRecorder('pending')))
+        job.save()
+        with mock.patch.object(job.serializer, 'loads', side_effect=AssertionError('Eager deserialization')) as loads:
+            restored = Job.fetch(job.id, connection=self.connection)
+            restored.save()
+            loads.assert_not_called()
+
+        restored = Job.fetch(job.id, connection=self.connection)
+        execute_success_callback(restored, SimpleWorker.death_penalty_class, 'result')
+        self.assertEqual(restored.meta['callback'], ('pending', ('result',)))
+
+    def test_callback_uses_job_serializer(self):
+        job = Job.create(
+            say_hello,
+            connection=self.connection,
+            serializer=JSONSerializer,
+            on_success=Callback(CallbackRecorder('json')),
+        )
+        with self.assertRaises(TypeError):
+            job.to_dict()
+
+    def test_async_callable_callbacks_are_rejected(self):
+        cases = (
+            ('success', execute_success_callback, (None,)),
+            ('failure', execute_failure_callback, (ValueError, ValueError('error'), None)),
+            ('stopped', execute_stopped_callback, ()),
+        )
+        for kind, execute, args in cases:
+            with self.subTest(kind=kind):
+                job = Job.create(
+                    say_hello, connection=self.connection, **{f'on_{kind}': Callback(AsyncCallbackRecorder())}
+                )
+                job.save()
+                job = Job.fetch(job.id, connection=self.connection)
+                with self.assertRaises(TypeError):
+                    execute(job, SimpleWorker.death_penalty_class, *args)
+
+        job = Job.create(say_hello, connection=self.connection, on_success=Callback(partial(async_success_callback)))
+        with self.assertRaises(TypeError):
+            execute_success_callback(job, SimpleWorker.death_penalty_class, None)
+
+    def test_worker_executes_callable_callback(self):
+        queue = Queue(connection=self.connection)
+        job = queue.enqueue(say_hello, on_success=Callback(CallbackRecorder('worker')))
+        SimpleWorker([queue], connection=self.connection).work(burst=True)
+        self.assertEqual(job.get_status(), JobStatus.FINISHED)
+        self.assertEqual(self.connection.get(f'callback:{job.id}'), b'worker')
+
+    def test_callback_deserialization_error(self):
+        job = Job.create(say_hello, connection=self.connection, on_success=Callback(CallbackRecorder('broken')))
+        job.save()
+        job = Job.fetch(job.id, connection=self.connection)
+        with mock.patch.object(job.serializer, 'loads', side_effect=ValueError('Invalid callback data')):
+            with self.assertRaises(DeserializationError):
+                _ = job.success_callback
+
+
 class QueueCallbackTestCase(RQTestCase):
     def test_enqueue_with_success_callback(self):
         """Test enqueue* methods with on_success"""
         queue = Queue(connection=self.connection)
 
-        # Only functions and builtins are supported as callback
+        # Callback must be a callable or a string
         with self.assertRaises(ValueError):
-            queue.enqueue(say_hello, on_success=Job.fetch)
+            queue.enqueue(say_hello, on_success=42)
 
         job = queue.enqueue(say_hello, on_success=print)
 
@@ -57,9 +187,9 @@ class QueueCallbackTestCase(RQTestCase):
         """queue.enqueue* methods with on_failure is persisted correctly"""
         queue = Queue(connection=self.connection)
 
-        # Only functions and builtins are supported as callback
+        # Callback must be a callable or a string
         with self.assertRaises(ValueError):
-            queue.enqueue(say_hello, on_failure=Job.fetch)
+            queue.enqueue(say_hello, on_failure=42)
 
         job = queue.enqueue(say_hello, on_failure=print)
 
@@ -86,9 +216,9 @@ class QueueCallbackTestCase(RQTestCase):
         """queue.enqueue* methods with on_stopped is persisted correctly"""
         queue = Queue(connection=self.connection)
 
-        # Only functions and builtins are supported as callback
+        # Callback must be a callable or a string
         with self.assertRaises(ValueError):
-            queue.enqueue(say_hello, on_stopped=Job.fetch)
+            queue.enqueue(say_hello, on_stopped=42)
 
         job = queue.enqueue(long_process, on_stopped=print)
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -80,6 +80,24 @@ class CallbackInstanceTestCase(RQTestCase):
     def test_callable_instance_callbacks(self):
         self._assert_callback_roundtrip(CallbackRecorder('instance'), 'instance')
 
+    def test_falsey_callable_instance_callbacks(self):
+        cases = (
+            ('success', execute_success_callback, ('result',)),
+            ('failure', execute_failure_callback, (ValueError, ValueError('error'), None)),
+            ('stopped', execute_stopped_callback, ()),
+        )
+        for kind, execute, args in cases:
+            with self.subTest(kind=kind):
+                job = Job.create(
+                    say_hello,
+                    connection=self.connection,
+                    **{f'on_{kind}': CallbackRecorder(kind)},
+                )
+                job.save()
+                job = Job.fetch(job.id, connection=self.connection)
+                execute(job, SimpleWorker.death_penalty_class, *args)
+                self.assertEqual(job.meta['callback'], (kind, args))
+
     def test_callback_state_is_saved_and_refreshed(self):
         recorder = CallbackRecorder('initial')
         job = Job.create(say_hello, connection=self.connection, on_success=Callback(recorder))

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -157,13 +157,14 @@ class TestDecorator(RQTestCase):
         correct on_failure function on the job.
         """
 
-        # Only functions and builtins are supported as callback
+        # Class methods are supported as callbacks.
         @job('default', connection=self.connection, on_failure=Job.fetch)
         def foo():
             return 'Foo'
 
-        with self.assertRaises(ValueError):
-            result = foo.enqueue()
+        result = foo.enqueue()
+        result_job = Job.fetch(id=result.id, connection=self.connection)
+        self.assertEqual(result_job.failure_callback, Job.fetch)
 
         @job('default', connection=self.connection, on_failure=print)
         def hello():
@@ -178,13 +179,14 @@ class TestDecorator(RQTestCase):
         correct on_success function on the job.
         """
 
-        # Only functions and builtins are supported as callback
-        @job('default', connection=self.connection, on_failure=Job.fetch)
+        # Class methods are supported as callbacks.
+        @job('default', connection=self.connection, on_success=Job.fetch)
         def foo():
             return 'Foo'
 
-        with self.assertRaises(ValueError):
-            result = foo.enqueue()
+        result = foo.enqueue()
+        result_job = Job.fetch(id=result.id, connection=self.connection)
+        self.assertEqual(result_job.success_callback, Job.fetch)
 
         @job('default', connection=self.connection, on_success=print)
         def hello():


### PR DESCRIPTION
## Summary
- accept bound methods and callable instances as callbacks
- persist callback instances with the job serializer so state survives save and fetch
- preserve timeout handling and reject async callable instances

Closes #1500

## Tests
- callback and decorator tests (29 passed, 12 subtests passed)
- Ruff, formatting, and mypy
- full suite excluding the unrelated local Redis blocking timeout test (714 passed, 22 skipped, 1 deselected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Callback handlers now support callable instances, bound methods, and class methods.
  - Callback instance state is preserved when jobs are stored and restored.
  - Persisted callback instances are loaded when needed, including after job restoration.

- **Bug Fixes**
  - Callback validation now consistently rejects non-callable values and classes.
  - Asynchronous callback handlers, including partially wrapped callbacks, are rejected with a clear error instead of being executed unsupported.
  - Callback deserialization failures now raise a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->